### PR TITLE
Support CentOS 7.2 + CBS 4.1.0

### DIFF
--- a/libraries/provision/ansible/playbooks/install-couchbase-server-package.yml
+++ b/libraries/provision/ansible/playbooks/install-couchbase-server-package.yml
@@ -39,8 +39,16 @@
       get_url: url={{ couchbase_server_package_url }} dest=/tmp/{{ couchbase_server_package_name }}
     - name: Install Couchbase Server
       yum: name=/tmp/{{ couchbase_server_package_name }} state=present
+
+    # Start via init scipt if running CBS 4.1.0 on CentOS 7.2 due to https://issues.couchbase.com/browse/MB-17193
+    - name: Restart Couchbase Service (Hack around 7.2 and CBS 4.1.0 issue)
+      shell: /opt/couchbase/etc/couchbase_init.d start
+      when: ansible_distribution == 'CentOS' and ansible_distribution_version == '7.2.1511' and couchbase_server_package_name == 'couchbase-server-enterprise-4.1.0-centos7.x86_64.rpm'
+
     - name: Restart Couchbase Service
       service: name=couchbase-server state=restarted
+      when: not ansible_distribution == 'CentOS' and not ansible_distribution_version == '7.2.1511' and not couchbase_server_package_name == 'couchbase-server-enterprise-4.1.0-centos7.x86_64.rpm'
+
     - name: raise max file descriptors
       copy: src=files/security-nofiles-limit.conf dest=/etc/security/limits.d/20-nofiles.conf owner=root group=root mode=0644
 


### PR DESCRIPTION
Hack around the service install issues for CentOS 7.2 and Couchbase Server 4.1.0. 

Start via init scipt if running CBS 4.1.0 on CentOS 7.2 due to https://issues.couchbase.com/browse/MB-17193