### PR TITLE
Feature/test cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,11 @@ Run a single test
 
 Although it is not necessary, the `-b debug.txt` will provide more output and stacktraces for deeper investigation
 
+Skipping the cluster provisioning (i.e. You are writing tests and know your cluster is the topology you are expecting)
+
+`robot -b debug.txt -v SERVER_VERSION:4.1.0 -v SYNC_GATEWAY_VERSION:1.2.0-79 -v RESET_CLUSTER:False testsuites/syncgateway/functional/1sg_1ac_1cbs.robot`
+`robot -b debug.txt -v SERVER_VERSION:4.1.0 -v SYNC_GATEWAY_VERSION:1.2.0-79 -v RESET_CLUSTER:False -t "test sync sanity" testsuites/syncgateway/functional/1sg_1ac_1cbs.robot`
+
 **Running Performance Tests**
 
 - [Spin up a AWS CloudFormation stack](#Spin=Up-Machines-on-AWS)

--- a/libraries/NetworkUtils.py
+++ b/libraries/NetworkUtils.py
@@ -1,0 +1,9 @@
+import subprocess
+
+
+class NetworkUtils:
+
+    def list_connections(self):
+        output = subprocess.check_output("netstat -ant | awk '{print $6}' | sort | uniq -c | sort -n", shell=True)
+        print(output)
+

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -37,7 +37,8 @@ class Cluster:
         # Load resources/cluster_configs/<cluster_config>.json
         with open("{}.json".format(host_file)) as f:
             cluster = json.loads(f.read())
-            print("Using Cluster: {}.json".format(cluster))
+
+        log.info("Cluster: {}".format(cluster))
 
         cbs = [{"name": cbs["name"], "ip": cbs["ip"]} for cbs in cluster["couchbase_servers"]]
 

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -95,11 +95,12 @@ class Cluster:
         bucket_delete_create_attempt_num = 0
         while bucket_delete_create_attempt_num < bucket_delete_create_max_retries:
             try:
-                log.info("Deleting / Creating server buckets: Attempt {}".format(bucket_delete_create_attempt_num))
+                log.info(">>> Deleting / Creating server buckets: Attempt {}".format(bucket_delete_create_attempt_num))
                 # Delete buckets
                 log.info(">>> Deleting buckets on: {}".format(self.servers[0].ip))
                 status = self.servers[0].delete_buckets()
                 assert (status == 0)
+                log.info(">>> Bucket deletion status: {}".format(status))
 
                 # Parse config and grab bucket names
                 config_path_full = os.path.abspath(config_path)
@@ -112,9 +113,12 @@ class Cluster:
                 log.info(">>> Creating buckets {}".format(bucket_name_set))
                 status = self.servers[0].create_buckets(bucket_name_set)
                 assert (status == 0)
+                log.info(">>> Bucket creation status: {}".format(status))
 
+                # Both steps are successful, break out of retry loop
+                break
             except AssertionError as e:
-                log.info("Failed to delete / create buckets. Trying again ...")
+                log.error("Failed to delete / create buckets. Trying again ...")
                 bucket_delete_create_attempt_num += 1
 
         # Max tries to delete / create buckets

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -91,23 +91,37 @@ class Cluster:
         status = ansible_runner.run_ansible_playbook("delete-sg-accel-artifacts.yml", stop_on_fail=False)
         assert(status == 0)
 
-        # Delete buckets
-        log.info(">>> Deleting buckets on: {}".format(self.servers[0].ip))
-        self.servers[0].delete_buckets()
-        
-        # Parse config and grab bucket names
-        config_path_full = os.path.abspath(config_path)
-        config = Config(config_path_full)
-        mode = config.get_mode()
-        bucket_name_set = config.get_bucket_name_set()
-        self.sync_gateway_config = config
-        
-        log.info(">>> Creating buckets on: {}".format(self.servers[0].ip))
-        log.info(">>> Creating buckets {}".format(bucket_name_set))
-        self.servers[0].create_buckets(bucket_name_set)
+        bucket_delete_create_max_retries = 3
+        bucket_delete_create_attempt_num = 0
+        while bucket_delete_create_attempt_num < bucket_delete_create_max_retries:
+            try:
+                log.info("Deleting / Creating server buckets: Attempt {}".format(bucket_delete_create_attempt_num))
+                # Delete buckets
+                log.info(">>> Deleting buckets on: {}".format(self.servers[0].ip))
+                status = self.servers[0].delete_buckets()
+                assert (status == 0)
+
+                # Parse config and grab bucket names
+                config_path_full = os.path.abspath(config_path)
+                config = Config(config_path_full)
+                mode = config.get_mode()
+                bucket_name_set = config.get_bucket_name_set()
+                self.sync_gateway_config = config
+
+                log.info(">>> Creating buckets on: {}".format(self.servers[0].ip))
+                log.info(">>> Creating buckets {}".format(bucket_name_set))
+                status = self.servers[0].create_buckets(bucket_name_set)
+                assert (status == 0)
+
+            except AssertionError as e:
+                log.info("Failed to delete / create buckets. Trying again ...")
+                bucket_delete_create_attempt_num += 1
+
+        # Max tries to delete / create buckets
+        if bucket_delete_create_attempt_num == bucket_delete_create_max_retries:
+            raise RuntimeError("Max tries exceeded to delete / create buckets")
 
         log.info(">>> Starting sync_gateway with configuration: {}".format(config_path_full))
-
         # Start sync-gateway
         status = ansible_runner.run_ansible_playbook(
             "start-sync-gateway.yml",

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -120,6 +120,8 @@ class Cluster:
             except AssertionError as e:
                 log.error("Failed to delete / create buckets. Trying again ...")
                 bucket_delete_create_attempt_num += 1
+                # Wait 3 sec before retry
+                time.sleep(3)
 
         # Max tries to delete / create buckets
         if bucket_delete_create_attempt_num == bucket_delete_create_max_retries:

--- a/libraries/testkit/server.py
+++ b/libraries/testkit/server.py
@@ -27,6 +27,7 @@ class Server:
 
     def delete_buckets(self):
         count = 0
+        status = 0
         while count < 3:
             resp = requests.get("{}/pools/default/buckets".format(self.url), headers=self._headers)
             resp.raise_for_status()
@@ -56,11 +57,14 @@ class Server:
 
         if count == 3:
             log.error("Could not delete bucket")
-            sys.exit(1)
+            status = 1
+
+        return status
 
     def delete_bucket(self, name):
         # HACK around Couchbase Server issue where issuing a bucket delete via REST occasionally returns 500 error
         count = 0
+        status = 0
         while count < 3:
             log.info(">>> Deleting buckets: {}".format(name))
             resp = requests.delete("{0}/pools/default/buckets/{1}".format(self.url, name), headers=self._headers)
@@ -73,7 +77,9 @@ class Server:
 
         if count == 3:
             log.error("Could not delete bucket")
-            sys.exit(1)
+            status = 1
+
+        return status
 
     def create_buckets(self, names):
         # Create buckets
@@ -83,7 +89,7 @@ class Server:
             extra_vars=json.dumps(extra_vars),
             stop_on_fail=False
         )
-        assert(status == 0)
+        return status
 
     def get_bucket(self, bucket_name):
         connection_str = "couchbase://{}/{}".format(self.ip, bucket_name)

--- a/libraries/testkit/settings.py
+++ b/libraries/testkit/settings.py
@@ -4,7 +4,7 @@ import logging
 # logging.basicConfig(level=logging.DEBUG)
 
 # the timeout for HTTP Requests, in seconds
-HTTP_REQ_TIMEOUT = 30
+HTTP_REQ_TIMEOUT = 60
 
 # Number of thread workers for requests
 MAX_REQUEST_WORKERS = 50

--- a/libraries/testkit/settings.py
+++ b/libraries/testkit/settings.py
@@ -4,7 +4,7 @@ import logging
 # logging.basicConfig(level=logging.DEBUG)
 
 # the timeout for HTTP Requests, in seconds
-HTTP_REQ_TIMEOUT = 60
+HTTP_REQ_TIMEOUT = 120
 
 # Number of thread workers for requests
 MAX_REQUEST_WORKERS = 50

--- a/libraries/testkit/user.py
+++ b/libraries/testkit/user.py
@@ -205,7 +205,7 @@ class User:
                     try:
                         doc_id = future.result()
                     except HTTPError as e:
-                        log.error("{0} {1} {2}".format(self.name, e.response.url, e.response.status_code))
+                        log.info("HTTPError: {0} {1} {2}".format(self.name, e.response.url, e.response.status_code))
                         errors.append((e.response.url, e.response.status_code))
         else:
             with concurrent.futures.ThreadPoolExecutor(max_workers=settings.MAX_REQUEST_WORKERS) as executor:
@@ -220,7 +220,7 @@ class User:
                         doc_list = f.result()
                         #print(doc_list)
                     except HTTPError as e:
-                        log.error("{0} {1} {2}".format(self.name, e.response.url, e.response.status_code))
+                        log.info("HTTPError: {0} {1} {2}".format(self.name, e.response.url, e.response.status_code))
                         errors.append((e.response.url, e.response.status_code))
 
         return errors

--- a/testsuites/syncgateway/functional/1sg_1ac_1cbs.robot
+++ b/testsuites/syncgateway/functional/1sg_1ac_1cbs.robot
@@ -26,6 +26,7 @@ Test Teardown   Test Teardown
 *** Variables ***
 ${CLUSTER_CONFIG}           ${CLUSTER_CONFIGS}/1sg_1ac_1cbs
 ${SYNC_GATEWAY_CONFIG}      ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_di.json
+${RESET_CLUSTER}            True
 
 *** Test Cases ***
 # Cluster has been setup
@@ -161,10 +162,10 @@ test single user single channel (distributed index)
 
 *** Keywords ***
 Suite Setup
-    Log To Console              Setting up ...
-    Set Environment Variable    CLUSTER_CONFIG    ${CLUSTER_CONFIG}
-    Log                         Using cluster ${CLUSTER_CONFIG}
-    Provision Cluster   ${SERVER_VERSION}   ${SYNC_GATEWAY_VERSION}    ${SYNC_GATEWAY_CONFIG}
+    Log To Console                    Setting up ...
+    Set Environment Variable          CLUSTER_CONFIG  ${CLUSTER_CONFIG}
+    Log                               Using cluster ${CLUSTER_CONFIG}
+    Run Keyword If  ${RESET_CLUSTER}  Provision Cluster  ${SERVER_VERSION}  ${SYNC_GATEWAY_VERSION}  ${SYNC_GATEWAY_CONFIG}
 
 Suite Teardown
     Log To Console      Tearing down ...

--- a/testsuites/syncgateway/functional/1sg_1ac_1cbs.robot
+++ b/testsuites/syncgateway/functional/1sg_1ac_1cbs.robot
@@ -40,8 +40,8 @@ test continuous changes parametrized 50 users 5000 docs 1 revision
 test continuous changes parametrized 50 users 5000 10 docs 10 revisions
     test continuous changes parametrized    ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_di.json  ${50}  ${10}  ${10}
 
-#test continuous changes parametrized 50 user 50 docs 1000 revisions
-#    test continuous changes parametrized    ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_di.json  ${50}  ${50}  ${1000}
+test continuous changes parametrized 50 user 50 docs 1000 revisions
+    test continuous changes parametrized    ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_di.json  ${50}  ${50}  ${1000}
 
 test continuous changes sanity
     test_continuous_changes_sanity          ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_di.json  ${10}  ${10}
@@ -86,10 +86,10 @@ test multiple dbs unique buckets lose tap
 
 
 # test_longpoll (distributed index mode)
-test longpoll changes parametrized
+test longpoll changes parametrized 5000 docs 1 rev
     test longpoll changes parametrized      ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_di.json   ${5000}  ${1}
 
-test longpoll changes parametrized
+test longpoll changes parametrized 50 docs 100 rev
     test longpoll changes parametrized      ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_di.json   ${50}   ${100}
 
 test longpoll changes sanity

--- a/testsuites/syncgateway/functional/1sg_1ac_1cbs.robot
+++ b/testsuites/syncgateway/functional/1sg_1ac_1cbs.robot
@@ -3,6 +3,7 @@ Resource    resources/common.robot
 
 Library     Process
 Library     OperatingSystem
+Library     ${Libraries}/NetworkUtils.py
 Library     ${Libraries}/ClusterKeywords.py
 Library     ${Libraries}/LoggingKeywords.py
 
@@ -169,4 +170,5 @@ Suite Teardown
     Log To Console      Tearing down ...
 
 Test Teardown
+    List Connections
     Run Keyword If Test Failed      Fetch And Analyze Logs

--- a/testsuites/syncgateway/functional/1sg_1ac_1cbs.robot
+++ b/testsuites/syncgateway/functional/1sg_1ac_1cbs.robot
@@ -39,8 +39,8 @@ test continuous changes parametrized 50 users 5000 docs 1 revision
 test continuous changes parametrized 50 users 5000 10 docs 10 revisions
     test continuous changes parametrized    ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_di.json  ${50}  ${10}  ${10}
 
-test continuous changes parametrized 50 user 50 docs 1000 revisions
-    test continuous changes parametrized    ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_di.json  ${50}  ${50}  ${1000}
+#test continuous changes parametrized 50 user 50 docs 1000 revisions
+#    test continuous changes parametrized    ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_di.json  ${50}  ${50}  ${1000}
 
 test continuous changes sanity
     test_continuous_changes_sanity          ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_di.json  ${10}  ${10}

--- a/testsuites/syncgateway/functional/1sg_1cbs.robot
+++ b/testsuites/syncgateway/functional/1sg_1cbs.robot
@@ -3,6 +3,7 @@ Resource    resources/common.robot
 
 Library     Process
 Library     OperatingSystem
+Library     ${Libraries}/NetworkUtils.py
 Library     ${Libraries}/ClusterKeywords.py
 Library     ${Libraries}/LoggingKeywords.py
 
@@ -251,4 +252,5 @@ Suite Teardown
     Log To Console      Tearing down ...
 
 Test Teardown
+    List Connections
     Run Keyword If Test Failed      Fetch And Analyze Logs

--- a/testsuites/syncgateway/functional/1sg_1cbs.robot
+++ b/testsuites/syncgateway/functional/1sg_1cbs.robot
@@ -84,8 +84,8 @@ test continuous changes parametrized 50 users 5000 docs 1 revision
 test continuous changes parametrized 50 users 5000 10 docs 10 revisions
     test continuous changes parametrized    ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_cc.json  ${50}  ${10}  ${10}
 
-#test continuous changes parametrized 50 user 50 docs 1000 revisions
-#    test continuous changes parametrized    ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_cc.json  ${50}  ${50}  ${1000}
+test continuous changes parametrized 50 user 50 docs 1000 revisions
+    test continuous changes parametrized    ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_cc.json  ${50}  ${50}  ${1000}
 
 test continuous changes sanity
     test_continuous_changes_sanity          ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_cc.json  ${10}  ${10}

--- a/testsuites/syncgateway/functional/1sg_1cbs.robot
+++ b/testsuites/syncgateway/functional/1sg_1cbs.robot
@@ -31,6 +31,7 @@ Test Teardown   Test Teardown
 *** Variables ***
 ${CLUSTER_CONFIG}           ${CLUSTER_CONFIGS}/1sg_1cbs
 ${SYNC_GATEWAY_CONFIG}      ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_cc.json
+${RESET_CLUSTER}            True
 
 *** Test Cases ***
 # Cluster has been setup
@@ -243,10 +244,10 @@ test single user single channel
 
 *** Keywords ***
 Suite Setup
-    Log To Console              Setting up ...
-    Set Environment Variable    CLUSTER_CONFIG    ${CLUSTER_CONFIG}
-    Log                         Using cluster ${CLUSTER_CONFIG}
-    Provision Cluster   ${SERVER_VERSION}   ${SYNC_GATEWAY_VERSION}    ${SYNC_GATEWAY_CONFIG}
+    Log To Console                    Setting up ...
+    Set Environment Variable          CLUSTER_CONFIG    ${CLUSTER_CONFIG}
+    Log                               Using cluster ${CLUSTER_CONFIG}
+    Run Keyword If  ${RESET_CLUSTER}  Provision Cluster   ${SERVER_VERSION}   ${SYNC_GATEWAY_VERSION}    ${SYNC_GATEWAY_CONFIG}
 
 Suite Teardown
     Log To Console      Tearing down ...

--- a/testsuites/syncgateway/functional/1sg_1cbs.robot
+++ b/testsuites/syncgateway/functional/1sg_1cbs.robot
@@ -82,8 +82,8 @@ test continuous changes parametrized 50 users 5000 docs 1 revision
 test continuous changes parametrized 50 users 5000 10 docs 10 revisions
     test continuous changes parametrized    ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_cc.json  ${50}  ${10}  ${10}
 
-test continuous changes parametrized 50 user 50 docs 1000 revisions
-    test continuous changes parametrized    ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_cc.json  ${50}  ${50}  ${1000}
+#test continuous changes parametrized 50 user 50 docs 1000 revisions
+#    test continuous changes parametrized    ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_cc.json  ${50}  ${50}  ${1000}
 
 test continuous changes sanity
     test_continuous_changes_sanity          ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_cc.json  ${10}  ${10}

--- a/testsuites/syncgateway/functional/1sg_2ac_1cbs.robot
+++ b/testsuites/syncgateway/functional/1sg_2ac_1cbs.robot
@@ -3,6 +3,7 @@ Resource    resources/common.robot
 
 Library     Process
 Library     OperatingSystem
+Library     ${Libraries}/NetworkUtils.py
 Library     ${Libraries}/ClusterKeywords.py
 Library     ${Libraries}/LoggingKeywords.py
 
@@ -46,4 +47,5 @@ Suite Teardown
     Log To Console      Tearing down ...
 
 Test Teardown
+    List Connections
     Run Keyword If Test Failed      Fetch And Analyze Logs

--- a/testsuites/syncgateway/functional/1sg_2ac_1cbs.robot
+++ b/testsuites/syncgateway/functional/1sg_2ac_1cbs.robot
@@ -18,6 +18,7 @@ Test Teardown   Test Teardown
 *** Variables ***
 ${CLUSTER_CONFIG}           ${CLUSTER_CONFIGS}/1sg_2ac_1cbs
 ${SYNC_GATEWAY_CONFIG}      ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_di.json
+${RESET_CLUSTER}            True
 
 *** Test Cases ***
 # Cluster has been setup
@@ -38,10 +39,10 @@ test dcp reshard single sg accel goes down and up
 
 *** Keywords ***
 Suite Setup
-    Log To Console              Setting up ...
-    Set Environment Variable    CLUSTER_CONFIG    ${CLUSTER_CONFIG}
-    Log                         Using cluster ${CLUSTER_CONFIG}
-    Provision Cluster   ${SERVER_VERSION}   ${SYNC_GATEWAY_VERSION}    ${SYNC_GATEWAY_CONFIG}
+    Log To Console                    Setting up ...
+    Set Environment Variable          CLUSTER_CONFIG    ${CLUSTER_CONFIG}
+    Log                               Using cluster ${CLUSTER_CONFIG}
+    Run Keyword If  ${RESET_CLUSTER}  Provision Cluster   ${SERVER_VERSION}   ${SYNC_GATEWAY_VERSION}    ${SYNC_GATEWAY_CONFIG}
 
 Suite Teardown
     Log To Console      Tearing down ...

--- a/testsuites/syncgateway/functional/2sg_1cbs.robot
+++ b/testsuites/syncgateway/functional/2sg_1cbs.robot
@@ -3,6 +3,7 @@ Resource    resources/common.robot
 
 Library     Process
 Library     OperatingSystem
+Library     ${Libraries}/NetworkUtils.py
 Library     ${Libraries}/ClusterKeywords.py
 Library     ${Libraries}/LoggingKeywords.py
 
@@ -42,4 +43,5 @@ Suite Teardown
     Log To Console      Tearing down ...
 
 Test Teardown
+    List Connections
     Run Keyword If Test Failed      Fetch And Analyze Logs

--- a/testsuites/syncgateway/functional/2sg_1cbs.robot
+++ b/testsuites/syncgateway/functional/2sg_1cbs.robot
@@ -17,6 +17,7 @@ Test Teardown   Test Teardown
 *** Variables ***
 ${CLUSTER_CONFIG}           ${CLUSTER_CONFIGS}/2sg_1cbs
 ${SYNC_GATEWAY_CONFIG}      ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_cc.json
+${RESET_CLUSTER}            True
 
 *** Test Cases ***
 # Cluster has been setup
@@ -34,10 +35,10 @@ test bucket shadow multiple sync gateways
 
 *** Keywords ***
 Suite Setup
-    Log To Console              Setting up ...
-    Set Environment Variable    CLUSTER_CONFIG    ${CLUSTER_CONFIG}
-    Log                         Using cluster ${CLUSTER_CONFIG}
-    Provision Cluster   ${SERVER_VERSION}   ${SYNC_GATEWAY_VERSION}    ${SYNC_GATEWAY_CONFIG}
+    Log To Console                    Setting up ...
+    Set Environment Variable          CLUSTER_CONFIG    ${CLUSTER_CONFIG}
+    Log                               Using cluster ${CLUSTER_CONFIG}
+    Run Keyword If  ${RESET_CLUSTER}  Provision Cluster   ${SERVER_VERSION}   ${SYNC_GATEWAY_VERSION}    ${SYNC_GATEWAY_CONFIG}
 
 Suite Teardown
     Log To Console      Tearing down ...

--- a/testsuites/syncgateway/functional/test_db_online_offline.py
+++ b/testsuites/syncgateway/functional/test_db_online_offline.py
@@ -627,7 +627,8 @@ def test_db_offline_tap_loss_sanity(conf, num_docs):
     assert(len(errors) == 0)
 
     # Delete bucket to sever TAP feed
-    cluster.servers[0].delete_bucket("data-bucket")
+    status = cluster.servers[0].delete_bucket("data-bucket")
+    assert (status == 0)
 
     # Check that bucket is in offline state
     errors = rest_scan(cluster.sync_gateways[0], db="db", online=False, num_docs=num_docs, user_name="seth", channels=["ABC"])
@@ -695,8 +696,10 @@ def test_multiple_dbs_unique_buckets_lose_tap(conf, num_docs):
         errors = rest_scan(cluster.sync_gateways[0], db=db, online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
         assert(len(errors) == 0)
 
-    cluster.servers[0].delete_bucket("data-bucket-1")
-    cluster.servers[0].delete_bucket("data-bucket-3")
+    status = cluster.servers[0].delete_bucket("data-bucket-1")
+    assert(status == 0)
+    status = cluster.servers[0].delete_bucket("data-bucket-3")
+    assert(status == 0)
 
     # Check that db2 and db4 are still Online
     for db in ["db2", "db4"]:

--- a/testsuites/syncgateway/functional/test_db_online_offline_webhooks.py
+++ b/testsuites/syncgateway/functional/test_db_online_offline_webhooks.py
@@ -154,7 +154,9 @@ def test_db_online_offline_webhooks_offline_two(num_users, num_channels, num_doc
     in_parallel(user_objects, 'update_docs', num_revisions)
     time.sleep(10)
 
-    cluster.servers[0].delete_bucket("data-bucket")
+    status = cluster.servers[0].delete_bucket("data-bucket")
+    assert(status == 0)
+
     log.info("Sleeping for 120 seconds...")
     time.sleep(120)
 

--- a/testsuites/syncgateway/functional/test_sync.py
+++ b/testsuites/syncgateway/functional/test_sync.py
@@ -259,7 +259,7 @@ def test_sync_sanity(conf):
     kdwb_caches = []
     for radio_station in radio_stations:
         doc_pusher = admin.register_user(target=cluster.sync_gateways[0], db="db", name="{}_doc_pusher".format(radio_station), password="password", channels=[radio_station])
-        doc_pusher.add_docs(number_of_docs_per_pusher, bulk=True,)
+        doc_pusher.add_docs(number_of_docs_per_pusher, bulk=True)
         if doc_pusher.name == "KDWB_doc_pusher":
             kdwb_caches.append(doc_pusher.cache)
 


### PR DESCRIPTION
- Fixes failing test single user single channel test by not using * channel
- Adds a dump of socket states at the end of each test
- Increases client read timeout to 120 secs
- Adds retry around delete / create buckets in cluster.reset()
- Allow skipping reset when developing tests