### PR TITLE
Call bootstrap.sh with correct number of args

### DIFF
--- a/libraries/provision/ansible/playbooks/install-sync-gateway-source.yml
+++ b/libraries/provision/ansible/playbooks/install-sync-gateway-source.yml
@@ -65,7 +65,7 @@
   - name: download bootstrap script
     get_url: url=https://raw.githubusercontent.com/couchbase/sync_gateway/master/bootstrap.sh dest=/home/centos mode=0751
   - name: run bootstrap script (bootstrap.sh takes a branch and a commit as params, this will be fixed to only take a commit at some point)
-    shell: ./bootstrap.sh {{ branch }} {{ branch }}  
+    shell: ./bootstrap.sh {{ branch }}
   - name: build
     shell: ./build.sh {{ build_flags }}
 


### PR DESCRIPTION
The bootstrap.sh script recently changed to only take a single argument (a commit) rather than two arguments (a branch and a commit)

This fix calls bootstrap.sh correctly, since before it wasn't working