### PR TITLE
Fix ability to PROVISION_CLUSTER:False

### DIFF
--- a/keywords/ClusterKeywords.py
+++ b/keywords/ClusterKeywords.py
@@ -3,6 +3,9 @@ import json
 import requests
 import re
 
+from requests.exceptions import HTTPError
+from requests.exceptions import ConnectionError
+
 def log_r(request):
     logging.info("{0} {1} {2}".format(
             request.request.method,
@@ -27,6 +30,40 @@ class ClusterKeywords:
             return True
         else:
             return False
+
+    def verfiy_no_running_services(self, cluster_config):
+
+        with open("{}.json".format(cluster_config)) as f:
+            cluster_obj = json.loads(f.read())
+
+        running_services = []
+        for host in cluster_obj["hosts"]:
+
+            # Couchbase Server
+            try:
+                resp = requests.get("http://Administrator:password@{}:8091/pools".format(host["ip"]))
+                log_r(resp)
+                running_services.append(resp.url)
+            except ConnectionError as he:
+                logging.info(he)
+
+            # Sync Gateway
+            try:
+                resp = requests.get("http://{}:4984".format(host["ip"]))
+                log_r(resp)
+                running_services.append(resp.url)
+            except ConnectionError as he:
+                logging.info(he)
+
+            # Sg Accel
+            try:
+                resp = requests.get("http://{}:4985".format(host["ip"]))
+                log_r(resp)
+                running_services.append(resp.url)
+            except ConnectionError as he:
+                logging.info(he)
+
+        assert len(running_services) == 0, "Running Services Found: {}".format(running_services)
 
     def get_server_version(self, host):
         resp = requests.get("http://Administrator:password@{}:8091/pools".format(host))
@@ -128,7 +165,6 @@ class ClusterKeywords:
             # Since sync_gateway does not return the full commit, verify the prefix
             if running_ac_version != expected_sg_accel_version[:7]:
                 raise ValueError("Unexpected sync_gateway version!! Expected: {} Actual: {}".format(expected_sg_accel_version, running_ac_version))
-
 
     def verify_cluster_versions(self, cluster_config, expected_server_version, expected_sync_gateway_version):
 

--- a/keywords/ClusterKeywords.py
+++ b/keywords/ClusterKeywords.py
@@ -29,7 +29,7 @@ class ClusterKeywords:
             return False
 
     def get_server_version(self, host):
-        resp = requests.get("http://{}:8091/pools".format(host))
+        resp = requests.get("http://Administrator:password@{}:8091/pools".format(host))
         log_r(resp)
         resp.raise_for_status()
         resp_obj = resp.json()

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -126,7 +126,7 @@ class Cluster:
             extra_vars="sync_gateway_config_filepath={0}".format(config_path_full),
             stop_on_fail=False
         )
-        assert(status == 0)
+        assert status == 0, "Failed to start to Sync Gateway"
 
         # HACK - only enable sg_accel for distributed index tests
         # revise this with https://github.com/couchbaselabs/sync-gateway-testcluster/issues/222

--- a/libraries/utilities/generate_clusters_from_pool.py
+++ b/libraries/utilities/generate_clusters_from_pool.py
@@ -29,6 +29,7 @@ def write_config(config):
 
     with open(ansible_cluster_conf_file, "w") as f:
 
+        hosts = []
         couchbase_servers = []
         sync_gateways = []
         accels = []
@@ -37,6 +38,10 @@ def write_config(config):
         count = 1
         for ip in ips:
             f.write("ma{} ansible_host={}\n".format(count, ip))
+            hosts.append({
+                "name": "host{}".format(count),
+                "ip": ip
+            })
             count += 1
 
         f.write("\n")
@@ -109,6 +114,7 @@ def write_config(config):
 
         # Write json file consumable by testkit.cluster class
         cluster_dict = {
+            "hosts": hosts,
             "couchbase_servers": couchbase_servers,
             "sync_gateways": sync_gateways,
             "sg_accels": accels

--- a/resources/common.robot
+++ b/resources/common.robot
@@ -24,6 +24,9 @@ Provision Cluster
     ...  sync_gateway_config = the config to launch the Sync Gateways and Sg Accels with.
     ...  Cluster configs can be found in 'resources/cluster_configs'
 
+    Clean Cluster
+    Verfiy No Running Services  %{CLUSTER_CONFIG}
+
     ${is_binary} =  Sync Gateway Version Is Binary  version=${sync_gateway_version}
     Log  Is Sync Gateway Version Binary: ${is_binary}
 
@@ -46,6 +49,9 @@ Provision Cluster
 Clean Cluster
     Log                         Cluster Config: %{CLUSTER_CONFIG}
     ${result} =  Run Process  python  ${LIBRARIES}/provision/clean_cluster.py
+    Log  ${result.stderr}
+    Log  ${result.stdout}
+    Should Be Equal As Integers  ${result.rc}  0
 
 Install Server
     [Arguments]     ${server_version}

--- a/resources/common.robot
+++ b/resources/common.robot
@@ -17,14 +17,12 @@ ${SYNC_GATEWAY_SUITE_FUNCTIONAL}  testsuites/syncgateway/functional
 
 *** Keywords ***
 Provision Cluster
-    [Arguments]    ${cluster_config}  ${server_version}  ${sync_gateway_version}  ${sync_gateway_config}
-    [Documentation]    Installs a Sync Gateway (build) + Sg Accel cluster based on the ${cluster_config}
+    [Arguments]  ${server_version}  ${sync_gateway_version}  ${sync_gateway_config}
+    [Documentation]    Installs a Sync Gateway (build) + Sg Accel cluster based on the CLUSTER_CONFIG environment variable
     ...  server_version = the version of Couchbase Server to install (ex. 4.1.0 or 4.5.0-2151)
     ...  sync_gateway_version = the version of Sync Gateway and Sg Accel to install (ex. 1.2.1-4 or commit hash)
     ...  sync_gateway_config = the config to launch the Sync Gateways and Sg Accels with.
     ...  Cluster configs can be found in 'resources/cluster_configs'
-
-    Set Environment Variable  CLUSTER_CONFIG  ${cluster_config}
 
     ${is_binary} =  Sync Gateway Version Is Binary  version=${sync_gateway_version}
     Log  Is Sync Gateway Version Binary: ${is_binary}

--- a/resources/sync_gateway_configs/sync_gateway_sg_replicate_continuous_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_sg_replicate_continuous_cc.json
@@ -1,28 +1,30 @@
 {
-    "interface":":4984",
-    "adminInterface": "0.0.0.0:4985",
-    "maxIncomingConnections": 0,
-    "maxCouchbaseConnections": 16,
-    "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
-    "compressResponses": true,
-    "log": ["*"],
-    "replications": {
-        "continuous": {
-            "source":"http://{{ sync_gateway_node }}:4985/db1",
-            "target":"http://{{ sync_gateway_node }}:4985/db2",
-            "continuous":true
-        }
-    },
-    "databases":{
-        "db1":{
-            "server":"http://{{ couchbase_server_primary_node }}:8091",
-            "bucket":"data-bucket-1"
-        },
-        "db2":{
-            "server":"http://{{ couchbase_server_primary_node }}:8091",
-            "bucket":"data-bucket-2"
-        }
+  "interface": ":4984",
+  "adminInterface": "0.0.0.0:4985",
+  "maxIncomingConnections": 0,
+  "maxCouchbaseConnections": 16,
+  "maxFileDescriptors": 90000,
+  "slowServerCallWarningThreshold": 500,
+  "compressResponses": true,
+  "log": [
+    "*"
+  ],
+  "replications": [
+    {
+      "replication_id": "continuous",
+      "source": "http://{{ sync_gateway_node }}:4985/db1",
+      "target": "http://{{ sync_gateway_node }}:4985/db2",
+      "continuous": true
     }
+  ],
+  "databases": {
+    "db1": {
+      "server": "http://{{ couchbase_server_primary_node }}:8091",
+      "bucket": "data-bucket-1"
+    },
+    "db2": {
+      "server": "http://{{ couchbase_server_primary_node }}:8091",
+      "bucket": "data-bucket-2"
+    }
+  }
 }
-

--- a/testsuites/syncgateway/functional/1sg_1ac_1cbs.robot
+++ b/testsuites/syncgateway/functional/1sg_1ac_1cbs.robot
@@ -194,9 +194,10 @@ test single user single channel (distributed index)
 
 *** Keywords ***
 Suite Setup
+    Set Environment Variable  CLUSTER_CONFIG  ${CLUSTER_CONFIG}
+
     Run Keyword If  ${PROVISION_CLUSTER}
     ...  Provision Cluster
-    ...     cluster_config=${CLUSTER_CONFIG}
     ...     server_version=${SERVER_VERSION}
     ...     sync_gateway_version=${SYNC_GATEWAY_VERSION}
     ...     sync_gateway_config=${SYNC_GATEWAY_CONFIG}

--- a/testsuites/syncgateway/functional/1sg_1cbs.robot
+++ b/testsuites/syncgateway/functional/1sg_1cbs.robot
@@ -303,9 +303,10 @@ test single user single channel
 
 *** Keywords ***
 Suite Setup
+    Set Environment Variable  CLUSTER_CONFIG  ${CLUSTER_CONFIG}
+
     Run Keyword If  ${PROVISION_CLUSTER}
     ...  Provision Cluster
-    ...     cluster_config=${CLUSTER_CONFIG}
     ...     server_version=${SERVER_VERSION}
     ...     sync_gateway_version=${SYNC_GATEWAY_VERSION}
     ...     sync_gateway_config=${SYNC_GATEWAY_CONFIG}

--- a/testsuites/syncgateway/functional/1sg_1cbs.robot
+++ b/testsuites/syncgateway/functional/1sg_1cbs.robot
@@ -318,6 +318,8 @@ Suite Setup
 
 Suite Teardown
     Log To Console      Tearing down ...
+    Clean Cluster
+    Verify No Running Services  %{CLUSTER_CONFIG}
 
 Test Teardown
     List Connections

--- a/testsuites/syncgateway/functional/1sg_2ac_1cbs.robot
+++ b/testsuites/syncgateway/functional/1sg_2ac_1cbs.robot
@@ -42,9 +42,10 @@ test dcp reshard single sg accel goes down and up
 
 *** Keywords ***
 Suite Setup
+    Set Environment Variable  CLUSTER_CONFIG  ${CLUSTER_CONFIG}
+
     Run Keyword If  ${PROVISION_CLUSTER}
     ...  Provision Cluster
-    ...     cluster_config=${CLUSTER_CONFIG}
     ...     server_version=${SERVER_VERSION}
     ...     sync_gateway_version=${SYNC_GATEWAY_VERSION}
     ...     sync_gateway_config=${SYNC_GATEWAY_CONFIG}

--- a/testsuites/syncgateway/functional/2sg_1cbs.robot
+++ b/testsuites/syncgateway/functional/2sg_1cbs.robot
@@ -74,9 +74,10 @@ Test Replication Config
 
 *** Keywords ***
 Suite Setup
+    Set Environment Variable  CLUSTER_CONFIG  ${CLUSTER_CONFIG}
+
     Run Keyword If  ${PROVISION_CLUSTER}
     ...  Provision Cluster
-    ...     cluster_config=${CLUSTER_CONFIG}
     ...     server_version=${SERVER_VERSION}
     ...     sync_gateway_version=${SYNC_GATEWAY_VERSION}
     ...     sync_gateway_config=${SYNC_GATEWAY_CONFIG}

--- a/testsuites/syncgateway/functional/test_sg_replicate.py
+++ b/testsuites/syncgateway/functional/test_sg_replicate.py
@@ -10,6 +10,7 @@ from testkit.syncgateway import assert_has_doc
 from requests import HTTPError
 
 import time
+import logging 
 
 DB1 = "db1"
 DB2 = "db2"
@@ -41,6 +42,8 @@ def test_sg_replicate_basic_test():
     assert_does_not_have_doc(sg1_user, doc_id_sg2)
 
     # Start a push replication sg1 -> sg2
+    # Should block until replication
+    # Result should contain the stats of the completed replication
     replication_result = sg1.start_push_replication(
         sg2.admin.admin_url,
         DB1,
@@ -50,10 +53,12 @@ def test_sg_replicate_basic_test():
         use_admin_url=True
     )
 
-    assert replication_result["continuous"] is False
-    assert replication_result["docs_written"] == 2
-    assert replication_result["docs_read"] == 2
-    assert replication_result["doc_write_failures"] == 0
+    logging.debug("replication_result 1: {}".format(replication_result))
+    
+    assert replication_result["continuous"] is False, 'replication_result["continuous"] != False'
+    assert replication_result["docs_written"] == 1, 'replication_result["docs_written"] != 1' 
+    assert replication_result["docs_read"] == 1, 'replication_result["docs_read"] != 1' 
+    assert replication_result["doc_write_failures"] == 0, 'replication_result["doc_write_failures"] != 0'
 
     # Start a pull replication sg1 <- sg2
     replication_result = sg1.start_pull_replication(
@@ -65,10 +70,12 @@ def test_sg_replicate_basic_test():
         use_admin_url=True
     )
 
-    assert replication_result["continuous"] is False
-    assert replication_result["docs_written"] == 2
-    assert replication_result["docs_read"] == 2
-    assert replication_result["doc_write_failures"] == 0
+    logging.debug("replication_result 2: {}".format(replication_result))
+
+    assert replication_result["continuous"] is False, 'replication_result["continuous"] != False'
+    assert replication_result["docs_written"] == 1, 'replication_result["docs_written"] != 1'
+    assert replication_result["docs_read"] == 1, 'replication_result["docs_read"] != 1'
+    assert replication_result["doc_write_failures"] == 0, 'replication_result["doc_write_failures"] != 0'
 
     # Verify that the doc added to sg1 made it to sg2
     assert_has_doc(sg2_user, doc_id_sg1)

--- a/testsuites/syncgateway/functional/test_sg_replicate.py
+++ b/testsuites/syncgateway/functional/test_sg_replicate.py
@@ -214,6 +214,13 @@ def test_sg_replicate_non_existent_db():
 
     sg1, sg2 = create_sync_gateways(DEFAULT_CONFIG_PATH)
 
+    # delete databases if they exist
+    try:
+        sg1.admin.delete_db(DB1)
+        sg2.admin.delete_db(DB2)
+    except HTTPError:
+        logging.debug("Got HTTPError trying to delete a DB, which means it didn't already exist")
+
     # Start a push replication
     got_exception = False
     try:
@@ -228,7 +235,7 @@ def test_sg_replicate_non_existent_db():
     except HTTPError:
         got_exception = True
 
-    assert got_exception is True
+    assert got_exception is True, 'Expected an exception trying to create a replication against non-existent db'
 
 
 def test_sg_replicate_push_async(num_docs):


### PR DESCRIPTION
- Move setting the environment to the suite so that the Validate versions has knowledge of cluster even if you skip provisioning
- Include default user:pw for server rest API call

Running sanity check here - http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-functional-tests/. @tleyden Can you review but not merge? I will check the job and merge when done. 