### PR TITLE
Install mlocate tool

### DIFF
--- a/libraries/provision/ansible/playbooks/install-common-tools.yml
+++ b/libraries/provision/ansible/playbooks/install-common-tools.yml
@@ -22,6 +22,8 @@
     yum: pkg=graphviz state=latest
   - name: install sysstat
     yum: pkg=sysstat state=latest
+  - name: install mlocate
+    yum: pkg=mlocate state=latest
   - name: install the 'Development tools' package group
     yum: name="@Development tools" state=present
   - name: install pip


### PR DESCRIPTION
Allows you to run `locate <filename-pattern>` which makes it easier to find files across the system.

Apparently it will automatically run `updatedb` to update the index daily .. 

http://www.liquidweb.com/kb/how-to-install-mlocate-locate-and-updatedb-commands-on-centos-7/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbaselabs/mobile-testkit/451)
<!-- Reviewable:end -->
