### PR TITLE
Fixes #468 ngrep capture misses changes feed

### DIFF
--- a/libraries/provision/ansible/playbooks/collect-ngrep.yml
+++ b/libraries/provision/ansible/playbooks/collect-ngrep.yml
@@ -4,6 +4,12 @@
   become: yes
 
   tasks:
-  - name: fetch ngrep packet capture
-    fetch: src=/tmp/ngrep.txt dest=/tmp/sys-logs/ngrep_{{ inventory_hostname }}
 
+  - name: fetch ngrep packet capture from loopback device
+    fetch: src=/tmp/ngrep_lo.txt dest=/tmp/sys-logs/ngrep_lo_{{ inventory_hostname }}
+
+  - name: fetch ngrep packet capture from eth0 device
+    fetch: src=/tmp/ngrep_eth0.txt dest=/tmp/sys-logs/ngrep_eth0_{{ inventory_hostname }}
+
+  - name: fetch ngrep packet capture from eth1 device
+    fetch: src=/tmp/ngrep_eth1.txt dest=/tmp/sys-logs/ngrep_eth1_{{ inventory_hostname }}

--- a/libraries/provision/ansible/playbooks/files/run_ngrep.sh
+++ b/libraries/provision/ansible/playbooks/files/run_ngrep.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-ngrep -W byline port 4984 or port 4985 > /tmp/ngrep.txt
+ngrep -d $1 -W byline port 4984 or port 4985 > /tmp/ngrep_$1.txt

--- a/libraries/provision/ansible/playbooks/start-ngrep.yml
+++ b/libraries/provision/ansible/playbooks/start-ngrep.yml
@@ -7,5 +7,11 @@
   - name: copy the run ngrep script
     copy: src=files/run_ngrep.sh dest=/home/centos/ owner=centos group=centos mode=0755
 
-  - name: start ngrep in screen
-    shell: screen -d -m -S ngrep ./run_ngrep.sh chdir=/home/centos/
+  - name: start ngrep on loopback interface in screen
+    shell: screen -d -m -S ngrep_loopback ./run_ngrep.sh lo  chdir=/home/centos/
+
+  - name: start ngrep on eth0 in screen
+    shell: screen -d -m -S ngrep_eth0 ./run_ngrep.sh eth0  chdir=/home/centos/
+
+  - name: start ngrep on eth1 in screen
+    shell: screen -d -m -S ngrep_eth1 ./run_ngrep.sh eth1  chdir=/home/centos/


### PR DESCRIPTION
Tested.  Here is the zip that gets produced:

```
$ unzip "ngrep-Test Sg Replicate Continuous Replication-2016-05-18-11-57-31-output.zip"
Archive:  ngrep-Test Sg Replicate Continuous Replication-2016-05-18-11-57-31-output.zip
replace ngrep_eth0_sg1/sg1/tmp/ngrep_eth0.txt? [y]es, [n]o, [A]ll, [N]one, [r]ename: A
  inflating: ngrep_eth0_sg1/sg1/tmp/ngrep_eth0.txt
  inflating: ngrep_eth0_sg2/sg2/tmp/ngrep_eth0.txt
  inflating: ngrep_eth1_sg1/sg1/tmp/ngrep_eth1.txt
  inflating: ngrep_eth1_sg2/sg2/tmp/ngrep_eth1.txt
  inflating: ngrep_lo_sg1/sg1/tmp/ngrep_lo.txt
  inflating: ngrep_lo_sg2/sg2/tmp/ngrep_lo.txt
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbaselabs/mobile-testkit/470)
<!-- Reviewable:end -->
