### PR TITLE
Feature/ansible api test fixes

### DIFF
--- a/keywords/Logging.py
+++ b/keywords/Logging.py
@@ -20,7 +20,7 @@ def fetch_sync_gateway_logs(prefix, is_perf_run=False):
 
     print("Pulling logs")
     # fetch logs from sync_gateway instances
-    status = ansible_runner.run_ansible_playbook("fetch-sync-gateway-logs.yml", stop_on_fail=False)
+    status = ansible_runner.run_ansible_playbook("fetch-sync-gateway-logs.yml")
     if status != 0:
         log.error("Error pulling logs")
 

--- a/keywords/SyncGateway.py
+++ b/keywords/SyncGateway.py
@@ -62,13 +62,12 @@ class SyncGateway:
         logging.info("Starting sync_gateway on {} ...".format(target))
         ansible_runner = AnsibleRunner()
         config_path =  os.path.abspath(config)
-        status = ansible_runner.run_targeted_ansible_playbook(
+        status = ansible_runner.run_ansible_playbook(
             "start-sync-gateway.yml",
             extra_vars={
                 "sync_gateway_config_filepath": config_path
             },
-            target_name=target,
-            stop_on_fail=False
+            subset=target
         )
         assert status == 0, "Could not start sync_gateway"
 
@@ -76,8 +75,8 @@ class SyncGateway:
         target = hostname_for_url(url)
         logging.info("Shutting down sync_gateway on {} ...".format(target))
         ansible_runner = AnsibleRunner()
-        status = ansible_runner.run_targeted_ansible_playbook(
+        status = ansible_runner.run_ansible_playbook(
             "stop-sync-gateway.yml",
-            target_name=target,
-            stop_on_fail=False)
+            subset=target
+        )
         assert status == 0, "Could not stop sync_gateway"

--- a/libraries/NetworkUtils.py
+++ b/libraries/NetworkUtils.py
@@ -13,26 +13,17 @@ class NetworkUtils:
 
     def start_packet_capture(self):
         ansible_runner = AnsibleRunner()
-        status = ansible_runner.run_ansible_playbook(
-            "start-ngrep.yml",
-            stop_on_fail=False
-        )
+        status = ansible_runner.run_ansible_playbook("start-ngrep.yml")
         assert status == 0, "Failed to start packet capture"
 
     def stop_packet_capture(self):
         ansible_runner = AnsibleRunner()
-        status = ansible_runner.run_ansible_playbook(
-            "stop-ngrep.yml",
-            stop_on_fail=False
-        )
+        status = ansible_runner.run_ansible_playbook("stop-ngrep.yml")
         assert status == 0, "Failed to stop packet capture"
 
     def collect_packet_capture(self, test_name):
         ansible_runner = AnsibleRunner()
-        status = ansible_runner.run_ansible_playbook(
-            "collect-ngrep.yml",
-            stop_on_fail=False
-        )
+        status = ansible_runner.run_ansible_playbook("collect-ngrep.yml")
         assert status == 0, "Failed to collect packet capture"
 
         # zip logs and timestamp

--- a/libraries/provision/ansible/callbacks/robot_tee.py
+++ b/libraries/provision/ansible/callbacks/robot_tee.py
@@ -1,5 +1,5 @@
 from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
-from robot.api.logger import info
+from robot.api.logger import console
 
 class CallbackModule(CallbackModule_default):
 
@@ -15,29 +15,29 @@ class CallbackModule(CallbackModule_default):
 
     def v2_playbook_on_task_start(self, task, is_conditional):
         if len(task.name) > 0:
-            info("TASK [{}] ---------------------------------------------- ".format(task.name), also_console=True)
+            console("TASK [{}] ---------------------------------------------- ".format(task.name))
         super(CallbackModule, self).v2_playbook_on_task_start(task, is_conditional)
 
     def v2_playbook_on_include(self, included_file):
-        info("TASK [include] ---------------------------------------------- ", also_console=True)
-        info("included: {}".format(included_file), also_console=True)
+        console("TASK [include] ---------------------------------------------- ")
+        console("included: {}".format(included_file))
         super(CallbackModule, self).v2_playbook_on_include(included_file)
 
     def v2_runner_on_ok(self, result):
-        info("ok: [{}]".format(result._host), also_console=True)
+        console("ok: [{}]".format(result._host))
         super(CallbackModule, self).v2_runner_on_ok(result)
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
         if ignore_errors:
-            info("ignoring errors: [{}]".format(result._host), also_console=True)
+            console("ignoring errors: [{}]".format(result._host))
         else:
-            info("failed: [{}]".format(result._host), also_console=True)
+            console("failed: [{}]".format(result._host))
         super(CallbackModule, self).v2_runner_on_failed(result, ignore_errors)
 
     def v2_runner_on_skipped(self, result):
-        info("skipping: [{}]".format(result._host), also_console=True)
+        console("skipping: [{}]".format(result._host))
         super(CallbackModule, self).v2_runner_on_skipped(result)
 
     def v2_runner_on_unreachable(self, result):
-        info("unreachable: [{}]".format(result._host), also_console=True)
+        console("unreachable: [{}]".format(result._host))
         super(CallbackModule, self).v2_runner_on_unreachable(result)

--- a/libraries/provision/ansible_runner.py
+++ b/libraries/provision/ansible_runner.py
@@ -8,7 +8,7 @@ class AnsibleRunner:
     def __init__(self):
         self.provisiong_config = os.environ["CLUSTER_CONFIG"]
 
-    def run_ansible_playbook(self, script_name, extra_vars={}, stop_on_fail=True, subset=constants.DEFAULT_SUBSET):
+    def run_ansible_playbook(self, script_name, extra_vars={}, subset=constants.DEFAULT_SUBSET):
 
         inventory_filename = self.provisiong_config
 
@@ -27,12 +27,11 @@ class AnsibleRunner:
 
         return len(stats.failures)
 
-    def run_targeted_ansible_playbook(self, script_name, target_name, extra_vars={}, stop_on_fail=True):
+    def run_targeted_ansible_playbook(self, script_name, target_name, extra_vars={}):
 
         return self.run_ansible_playbook(
             script_name=script_name,
             extra_vars=extra_vars,
-            stop_on_fail=stop_on_fail,
             subset = target_name
         )
 

--- a/libraries/provision/ansible_runner.py
+++ b/libraries/provision/ansible_runner.py
@@ -26,15 +26,3 @@ class AnsibleRunner:
         logging.info(stats)
 
         return len(stats.failures)
-
-    def run_targeted_ansible_playbook(self, script_name, target_name, extra_vars={}):
-
-        return self.run_ansible_playbook(
-            script_name=script_name,
-            extra_vars=extra_vars,
-            subset = target_name
-        )
-
-
-
-

--- a/libraries/provision/clean_cluster.py
+++ b/libraries/provision/clean_cluster.py
@@ -13,8 +13,8 @@ def clean_cluster():
     print("Cleaning cluster: {}".format(cluster_config))
 
     ansible_runner = AnsibleRunner()
-    status = ansible_runner.run_ansible_playbook("remove-previous-installs.yml", stop_on_fail=False)
-    assert(status == 0)
+    status = ansible_runner.run_ansible_playbook("remove-previous-installs.yml")
+    assert(status == 0), "Failed to removed previous installs"
 
 
 if __name__ == "__main__":

--- a/libraries/provision/install_couchbase_server.py
+++ b/libraries/provision/install_couchbase_server.py
@@ -69,10 +69,9 @@ def install_couchbase_server(couchbase_server_config):
         extra_vars={
             "couchbase_server_package_base_url": server_baseurl,
             "couchbase_server_package_name": server_package_name
-        },
-        stop_on_fail=False
+        }
     )
-    assert(status == 0), "Failed to install Couchbase Server"
+    assert status == 0, "Failed to install Couchbase Server"
 
     print(">>> Creating server buckets")
     # Create default buckets
@@ -80,7 +79,7 @@ def install_couchbase_server(couchbase_server_config):
         "create-server-buckets.yml",
         extra_vars={"bucket_names": ["data-bucket", "index-bucket"]}
     )
-    assert (status == 0), "Failed to create Couchbase Server buckets"
+    assert status == 0, "Failed to create Couchbase Server buckets"
 
     # Wait for server to be in 'healthy state'
     print(">>> Waiting for server to be in 'healthy' state")

--- a/libraries/provision/install_sync_gateway.py
+++ b/libraries/provision/install_sync_gateway.py
@@ -97,10 +97,9 @@ def install_sync_gateway(sync_gateway_config):
                 "commit": sync_gateway_config.commit,
                 "build_flags": sync_gateway_config.build_flags,
                 "skip_bucketflush": sync_gateway_config.skip_bucketflush
-            },
-            stop_on_fail=False
+            }
         )
-        assert(status == 0)
+        assert status == 0, "Failed to install sync_gateway source"
 
     else:
         # Install build
@@ -113,10 +112,9 @@ def install_sync_gateway(sync_gateway_config):
                 "couchbase_sg_accel_package": sg_accel_package_name,
                 "sync_gateway_config_filepath": config_path,
                 "skip_bucketflush": sync_gateway_config.skip_bucketflush
-            },
-            stop_on_fail=False
+            }
         )
-        assert(status == 0)
+        assert(status == 0), "Failed to install sync_gateway package"
 
 if __name__ == "__main__":
     usage = """usage: python install_sync_gateway.py

--- a/libraries/provision/provision_cluster.py
+++ b/libraries/provision/provision_cluster.py
@@ -37,21 +37,21 @@ def provision_cluster(couchbase_server_config, sync_gateway_config, install_deps
     ansible_runner = AnsibleRunner()
 
     # Reset previous installs
-    status = ansible_runner.run_ansible_playbook("remove-previous-installs.yml", stop_on_fail=False)
-    assert(status == 0)
+    status = ansible_runner.run_ansible_playbook("remove-previous-installs.yml")
+    assert status == 0, "Failed to remove previous installs"
 
     if install_deps:
         # OS-level modifications
-        status = ansible_runner.run_ansible_playbook("os-level-modifications.yml", stop_on_fail=False)
-        assert(status == 0)
+        status = ansible_runner.run_ansible_playbook("os-level-modifications.yml")
+        assert status == 0, "OS level modifications failed"
 
         # Install dependencies
-        status = ansible_runner.run_ansible_playbook("install-common-tools.yml", stop_on_fail=False)
-        assert(status == 0)
+        status = ansible_runner.run_ansible_playbook("install-common-tools.yml")
+        assert status == 0, "Failed to install common tools"
 
     # Clear firewall rules
-    status = ansible_runner.run_ansible_playbook("flush-firewall.yml", stop_on_fail=False)
-    assert(status == 0)
+    status = ansible_runner.run_ansible_playbook("flush-firewall.yml")
+    assert status == 0, "Failed to flush firewall"
 
     # Install server package
     install_couchbase_server.install_couchbase_server(couchbase_server_config)

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -68,25 +68,25 @@ class Cluster:
         
         # Stop sync_gateways
         log.info(">>> Stopping sync_gateway")
-        status = ansible_runner.run_ansible_playbook("stop-sync-gateway.yml", stop_on_fail=False)
+        status = ansible_runner.run_ansible_playbook("stop-sync-gateway.yml")
         if status != 0:
             log.error("Error in provisioning!! Verify your ssh user is correct in 'libraries/provision/playbooks/ansible.cfg'")
             raise Exception("Failed to run provisioning")
 
         # Stop sync_gateways
         log.info(">>> Stopping sg_accel")
-        status = ansible_runner.run_ansible_playbook("stop-sg-accel.yml", stop_on_fail=False)
-        assert(status == 0)
+        status = ansible_runner.run_ansible_playbook("stop-sg-accel.yml")
+        assert status == 0, "Failed to stop sg_accel"
 
         # Deleting sync_gateway artifacts
         log.info(">>> Deleting sync_gateway artifacts")
-        status = ansible_runner.run_ansible_playbook("delete-sync-gateway-artifacts.yml", stop_on_fail=False)
-        assert(status == 0)
+        status = ansible_runner.run_ansible_playbook("delete-sync-gateway-artifacts.yml")
+        assert status == 0, "Failed to delete sync_gateway artifacts"
 
         # Deleting sg_accel artifacts
         log.info(">>> Deleting sg_accel artifacts")
-        status = ansible_runner.run_ansible_playbook("delete-sg-accel-artifacts.yml", stop_on_fail=False)
-        assert(status == 0)
+        status = ansible_runner.run_ansible_playbook("delete-sg-accel-artifacts.yml")
+        assert status == 0, "Failed to delete sg_accel artifacts"
 
         bucket_delete_create_max_retries = 3
         bucket_delete_create_attempt_num = 0
@@ -135,8 +135,7 @@ class Cluster:
             "start-sync-gateway.yml",
             extra_vars={
                 "sync_gateway_config_filepath": config_path_full
-            },
-            stop_on_fail=False
+            }
         )
         assert status == 0, "Failed to start to Sync Gateway"
 
@@ -148,10 +147,9 @@ class Cluster:
                 "start-sg-accel.yml",
                 extra_vars={
                     "sync_gateway_config_filepath": config_path_full
-                },
-                stop_on_fail=False
+                }
             )
-            assert(status == 0)
+            assert status == 0, "Failed to start sg_accel"
 
         # Validate CBGT
         if mode == "distributed_index":

--- a/libraries/testkit/server.py
+++ b/libraries/testkit/server.py
@@ -87,8 +87,7 @@ class Server:
             "create-server-buckets.yml",
             extra_vars={
                 "bucket_names": names
-            },
-            stop_on_fail=False
+            }
         )
         return status
 

--- a/libraries/testkit/sgaccel.py
+++ b/libraries/testkit/sgaccel.py
@@ -21,10 +21,9 @@ class SgAccel:
         return r.text
 
     def stop(self):
-        status = self.ansible_runner.run_targeted_ansible_playbook(
+        status = self.ansible_runner.run_ansible_playbook(
             "stop-sg-accel.yml",
-            target_name=self.hostname,
-            stop_on_fail=False,
+            subset=self.hostname
         )
         return status
 
@@ -33,13 +32,12 @@ class SgAccel:
 
         log.info(">>> Starting sg_accel with configuration: {}".format(conf_path))
 
-        status = self.ansible_runner.run_targeted_ansible_playbook(
+        status = self.ansible_runner.run_ansible_playbook(
             "start-sg-accel.yml",
             extra_vars={
                 "sync_gateway_config_filepath": conf_path
             },
-            target_name=self.hostname,
-            stop_on_fail=False
+            subset=self.hostname
         )
         return status
 

--- a/libraries/testkit/syncgateway.py
+++ b/libraries/testkit/syncgateway.py
@@ -29,10 +29,9 @@ class SyncGateway:
         return r.text
 
     def stop(self):
-        status = self.ansible_runner.run_targeted_ansible_playbook(
+        status = self.ansible_runner.run_ansible_playbook(
             "stop-sync-gateway.yml",
-            target_name=self.hostname,
-            stop_on_fail=False,
+            subset=self.hostname
         )
         return status
 
@@ -42,13 +41,12 @@ class SyncGateway:
 
         log.info(">>> Starting sync_gateway with configuration: {}".format(conf_path))
 
-        status = self.ansible_runner.run_targeted_ansible_playbook(
+        status = self.ansible_runner.run_ansible_playbook(
             "start-sync-gateway.yml",
             extra_vars={
                 "sync_gateway_config_filepath": conf_path
             },
-            target_name=self.hostname,
-            stop_on_fail=False
+            subset=self.hostname
         )
         return status
 
@@ -57,13 +55,12 @@ class SyncGateway:
 
         log.info(">>> Restarting sync_gateway with configuration: {}".format(conf_path))
 
-        status = self.ansible_runner.run_targeted_ansible_playbook(
+        status = self.ansible_runner.run_ansible_playbook(
             "reset-sync-gateway.yml",
             extra_vars={
                 "sync_gateway_config_filepath": conf_path,
             },
-            target_name=self.hostname,
-            stop_on_fail=False
+            subset=self.hostname
         )
         return status
 

--- a/libraries/utilities/fetch_machine_stats.py
+++ b/libraries/utilities/fetch_machine_stats.py
@@ -14,7 +14,8 @@ def fetch_machine_stats(folder_name):
 
     print("Pulling logs")
     # fetch logs from sync_gateway instances
-    ansible_runner.run_ansible_playbook("fetch-machine-stats.yml")
+    status = ansible_runner.run_ansible_playbook("fetch-machine-stats.yml")
+    assert status == 0, "Failed to fetch machine stats"
 
     # zip logs and timestamp
     if os.path.isdir("/tmp/perf_logs"):

--- a/libraries/utilities/fetch_sync_gateway_profile.py
+++ b/libraries/utilities/fetch_sync_gateway_profile.py
@@ -11,7 +11,8 @@ def fetch_sync_gateway_profile(folder_name):
 
     print("Pulling sync_gateway profile ...")
     # fetch logs from sync_gateway instances
-    ansible_runner.run_ansible_playbook("fetch-sync-gateway-profile.yml")
+    status = ansible_runner.run_ansible_playbook("fetch-sync-gateway-profile.yml")
+    assert status == 0, "Failed to fetch sync_gateway profile"
 
     # zip logs and timestamp
     if os.path.isdir("/tmp/sync_gateway_profile"):

--- a/libraries/utilities/push_cbcollect_info_supportal.py
+++ b/libraries/utilities/push_cbcollect_info_supportal.py
@@ -8,7 +8,8 @@ def push_cbcollect_info_supportal():
     2. Pushes to supportal.couchbase.com
     """
     ansible_runner = AnsibleRunner()
-    ansible_runner.run_ansible_playbook("push-cbcollect-info-supportal.yml")
+    status = ansible_runner.run_ansible_playbook("push-cbcollect-info-supportal.yml")
+    assert status == 0, "Failed to push cbcollect info"
     
 
 if __name__ == "__main__":

--- a/testsuites/syncgateway/performance/run_perf_test.py
+++ b/testsuites/syncgateway/performance/run_perf_test.py
@@ -84,8 +84,11 @@ def run_perf_test(number_pullers, number_pushers, use_gateload, gen_gateload_con
     # Killing sync_gateway and sg_accel will trigger collection of
     #    1) machine_stats
     #    2) sync_gateway profile data
-    ansible_runner.run_ansible_playbook("stop-sync-gateway.yml")
-    ansible_runner.run_ansible_playbook("stop-sg-accel.yml")
+    stop_sync_gateway_status = ansible_runner.run_ansible_playbook("stop-sync-gateway.yml")
+    assert stop_sync_gateway_status == 0, "Failed to stop sync_gateway"
+
+    stop_sg_accel_status = ansible_runner.run_ansible_playbook("stop-sg-accel.yml")
+    assert stop_sg_accel_status == 0, "Failed to stop sg_accel"
 
     # HACK: refresh interval for resource stat collection is 10 seconds.
     #  Make sure enough time has passed before collecting json


### PR DESCRIPTION
- remove all `stop_on_fail=False`
- use console in ansible callback to avoid double logging in robot
- remove run_targeted_ansible_playbook, now use run_ansible_playbook(..., subset=hostname)
- remove ansible-playbook calls executing on background thread (not supported anymore), please review the changes in test_dcp_reshard.py carefully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbaselabs/mobile-testkit/493)
<!-- Reviewable:end -->
