### PR TITLE
Remove subprocess for installing sync_gateway for shared listener tests

### DIFF
--- a/keywords/ClusterKeywords.py
+++ b/keywords/ClusterKeywords.py
@@ -9,6 +9,8 @@ from requests.exceptions import ConnectionError
 from utils import *
 
 from CouchbaseServer import verify_server_version
+from SyncGateway import verify_sync_gateway_version
+from SyncGateway import verify_sg_accel_version
 from libraries.testkit.cluster import Cluster
 
 class ClusterKeywords:
@@ -46,13 +48,6 @@ class ClusterKeywords:
 
         return formatted_cluster
 
-    def sync_gateway_version_is_binary(self, version):
-        if len(version.split(".")) > 1:
-            # ex 1.2.1 or 1.2.1-4
-            return True
-        else:
-            return False
-
     def verfiy_no_running_services(self, cluster_config):
 
         with open("{}.json".format(cluster_config)) as f:
@@ -87,73 +82,9 @@ class ClusterKeywords:
 
         assert len(running_services) == 0, "Running Services Found: {}".format(running_services)
 
-    def get_sync_gateway_version(self, host):
-        resp = requests.get("http://{}:4984".format(host))
-        log_r(resp)
-        resp.raise_for_status()
-        resp_obj = resp.json()
+    def verify_cluster_versions(self, expected_server_version, expected_sync_gateway_version):
 
-        running_version = resp_obj["version"]
-        running_version_parts = re.split("[ /(;)]", running_version)
-
-        if running_version_parts[3] == "HEAD":
-            running_version_formatted = running_version_parts[6]
-        else:
-            running_version_formatted = "{}-{}".format(running_version_parts[3], running_version_parts[4])
-
-        # Returns the version as 338493 commit format or 1.2.1-4 version format
-        return running_version_formatted
-
-    def verify_sync_gateway_version(self, host, expected_sync_gateway_version):
-
-        running_sg_version = self.get_sync_gateway_version(host)
-
-        logging.info("Expected sync_gateway Version: {}".format(expected_sync_gateway_version))
-        logging.info("Running sync_gateway Version: {}".format(running_sg_version))
-
-        if self.sync_gateway_version_is_binary(expected_sync_gateway_version):
-            # Example, 1.2.1-4
-            if running_sg_version != expected_sync_gateway_version:
-                raise ValueError("Unexpected sync_gateway version!! Expected: {} Actual: {}".format(expected_sync_gateway_version, running_sg_version))
-        else:
-            # Since sync_gateway does not return the full commit, verify the prefix
-            if running_sg_version != expected_sync_gateway_version[:7]:
-                raise ValueError("Unexpected sync_gateway version!! Expected: {} Actual: {}".format(expected_sync_gateway_version, running_sg_version))
-
-    def get_sg_accel_version(self, host):
-        resp = requests.get("http://{}:4985".format(host))
-        log_r(resp)
-        resp.raise_for_status()
-        resp_obj = resp.json()
-
-        running_version = resp_obj["version"]
-        running_version_parts = re.split("[ /(;)]", running_version)
-
-        if running_version_parts[3] == "HEAD":
-            running_version_formatted = running_version_parts[6]
-        else:
-            running_version_formatted = "{}-{}".format(running_version_parts[3], running_version_parts[4])
-
-        # Returns the version as 338493 commit format or 1.2.1-4 version format
-        return running_version_formatted
-
-    def verify_sg_accel_version(self, host, expected_sg_accel_version):
-
-        running_ac_version = self.get_sg_accel_version(host)
-
-        logging.info("Expected sg_accel Version: {}".format(expected_sg_accel_version))
-        logging.info("Running sg_accel Version: {}".format(running_ac_version))
-
-        if self.sync_gateway_version_is_binary(expected_sg_accel_version):
-            # Example, 1.2.1-4
-            if running_ac_version != expected_sg_accel_version:
-                raise ValueError("Unexpected sync_gateway version!! Expected: {} Actual: {}".format(expected_sg_accel_version, running_ac_version))
-        else:
-            # Since sync_gateway does not return the full commit, verify the prefix
-            if running_ac_version != expected_sg_accel_version[:7]:
-                raise ValueError("Unexpected sync_gateway version!! Expected: {} Actual: {}".format(expected_sg_accel_version, running_ac_version))
-
-    def verify_cluster_versions(self, cluster_config, expected_server_version, expected_sync_gateway_version):
+        cluster_config = os.environ["CLUSTER_CONFIG"]
 
         logging.info("Verfying versions for cluster: {}".format(cluster_config))
 
@@ -166,11 +97,11 @@ class ClusterKeywords:
 
         # Verify sync_gateway versions
         for sg in cluster_obj["sync_gateways"]:
-            self.verify_sync_gateway_version(sg["ip"], expected_sync_gateway_version)
+            verify_sync_gateway_version(sg["ip"], expected_sync_gateway_version)
 
         # Verify sg_accel versions, use the same expected version for sync_gateway for now
         for ac in cluster_obj["sg_accels"]:
-            self.verify_sg_accel_version(ac["ip"], expected_sync_gateway_version)
+            verify_sg_accel_version(ac["ip"], expected_sync_gateway_version)
 
     def reset_cluster(self, sync_gateway_config):
         cluster = Cluster()
@@ -185,12 +116,15 @@ class ClusterKeywords:
 
         cbs_config = CouchbaseServerConfig(server_version)
 
-        if self.sync_gateway_version_is_binary(sync_gateway_version):
+        if version_is_binary(sync_gateway_version):
             version, build = version_and_build(sync_gateway_version)
             sg_config = SyncGatewayConfig(None, version, build, sync_gateway_config, "", False)
         else:
             sg_config = SyncGatewayConfig(sync_gateway_version, None, None, sync_gateway_config, "", False)
 
         provision_cluster(cbs_config, sg_config, install_deps=False)
+
+        # verify running services are the expected versions
+        self.verify_cluster_versions(server_version, sync_gateway_version)
 
 

--- a/keywords/SyncGateway.py
+++ b/keywords/SyncGateway.py
@@ -11,51 +11,111 @@ from requests import Session
 from requests import ConnectionError
 
 from constants import *
-from utils import version_and_build
-from utils import hostname_for_url
+from utils import *
+
 from libraries.provision.ansible_runner import AnsibleRunner
+
+def get_sync_gateway_version(host):
+    resp = requests.get("http://{}:4984".format(host))
+    log_r(resp)
+    resp.raise_for_status()
+    resp_obj = resp.json()
+
+    running_version = resp_obj["version"]
+    running_version_parts = re.split("[ /(;)]", running_version)
+
+    if running_version_parts[3] == "HEAD":
+        running_version_formatted = running_version_parts[6]
+    else:
+        running_version_formatted = "{}-{}".format(running_version_parts[3], running_version_parts[4])
+
+    # Returns the version as 338493 commit format or 1.2.1-4 version format
+    return running_version_formatted
+
+
+def verify_sync_gateway_version(host, expected_sync_gateway_version):
+    running_sg_version = get_sync_gateway_version(host)
+
+    logging.info("Expected sync_gateway Version: {}".format(expected_sync_gateway_version))
+    logging.info("Running sync_gateway Version: {}".format(running_sg_version))
+
+    if version_is_binary(expected_sync_gateway_version):
+        # Example, 1.2.1-4
+        if running_sg_version != expected_sync_gateway_version:
+            raise ValueError("Unexpected sync_gateway version!! Expected: {} Actual: {}".format(expected_sync_gateway_version, running_sg_version))
+    else:
+        # Since sync_gateway does not return the full commit, verify the prefix
+        if running_sg_version != expected_sync_gateway_version[:7]:
+            raise ValueError("Unexpected sync_gateway version!! Expected: {} Actual: {}".format(expected_sync_gateway_version, running_sg_version))
+
+
+def get_sg_accel_version(host):
+    resp = requests.get("http://{}:4985".format(host))
+    log_r(resp)
+    resp.raise_for_status()
+    resp_obj = resp.json()
+
+    running_version = resp_obj["version"]
+    running_version_parts = re.split("[ /(;)]", running_version)
+
+    if running_version_parts[3] == "HEAD":
+        running_version_formatted = running_version_parts[6]
+    else:
+        running_version_formatted = "{}-{}".format(running_version_parts[3], running_version_parts[4])
+
+    # Returns the version as 338493 commit format or 1.2.1-4 version format
+    return running_version_formatted
+
+
+def verify_sg_accel_version(host, expected_sg_accel_version):
+    running_ac_version = get_sg_accel_version(host)
+
+    logging.info("Expected sg_accel Version: {}".format(expected_sg_accel_version))
+    logging.info("Running sg_accel Version: {}".format(running_ac_version))
+
+    if version_is_binary(expected_sg_accel_version):
+        # Example, 1.2.1-4
+        if running_ac_version != expected_sg_accel_version:
+            raise ValueError("Unexpected sync_gateway version!! Expected: {} Actual: {}".format(expected_sg_accel_version, running_ac_version))
+    else:
+        # Since sync_gateway does not return the full commit, verify the prefix
+        if running_ac_version != expected_sg_accel_version[:7]:
+            raise ValueError("Unexpected sync_gateway version!! Expected: {} Actual: {}".format(expected_sg_accel_version, running_ac_version))
+
 
 class SyncGateway:
 
     def __init__(self):
         self._session = Session()
 
-    def verify_sync_gateway_launched(self, host, port, admin_port):
+    def install_sync_gateway(self, sync_gateway_version, sync_gateway_config):
 
-        url = "http://{}:{}".format(host, port)
-        admin_url = "http://{}:{}".format(host, admin_port)
+        # Dirty hack -- these have to be put here in order to avoid circular imports
+        from libraries.provision.install_sync_gateway import install_sync_gateway
+        from libraries.provision.install_sync_gateway import SyncGatewayConfig
 
-        count = 0
-        wait_time = 1
-        while count < MAX_RETRIES:
-            try:
-                resp = self._session.get(url)
-                # If request does not throw, exit retry loop
-                break
-            except ConnectionError as ce:
-                logging.info("Sync Gateway may not be launched (Retrying): {}".format(ce))
-                time.sleep(wait_time)
-                count += 1
-                wait_time *= 2
+        if version_is_binary(sync_gateway_version):
+            version, build = version_and_build(sync_gateway_version)
+            print("VERSION: {} BUILD: {}".format(version, build))
+            sg_config = SyncGatewayConfig(None, version, build, sync_gateway_config, "", False)
+        else:
+            sg_config = SyncGatewayConfig(sync_gateway_version, None, None, sync_gateway_config, "", False)
 
-        if count == MAX_RETRIES:
-            raise RuntimeError("Could not connect to Sync Gateway")
+        install_sync_gateway(sg_config)
 
-        # Get version from running sync_gateway and compare with expected version
-        resp_json = resp.json()
-        logging.info(resp_json)
-        sync_gateway_version = resp_json["version"]
-        resp_version_parts = re.split("[ /(;)]", sync_gateway_version)
-        actual_version = "{}-{}".format(resp_version_parts[3], resp_version_parts[4])
+        cluster_config = os.environ["CLUSTER_CONFIG"]
+        logging.info("Verfying versions for cluster: {}".format(cluster_config))
 
-        logging.info("Expected Version {}".format(self._version_build))
-        logging.info("Actual Version {}".format(actual_version))
+        with open("{}.json".format(cluster_config)) as f:
+            cluster_obj = json.loads(f.read())
 
-        assert (actual_version == self._version_build)
+        # Verify sync_gateway versions
+        for sg in cluster_obj["sync_gateways"]:
+            verify_sync_gateway_version(sg["ip"], sync_gateway_version)
 
-        logging.info("{} is running".format(sync_gateway_version))
-
-        return url, admin_url
+        # Verify sg_accel versions, use the same expected version for sync_gateway for now
+        for ac in cluster_obj["sg_accels"]:
+            verify_sg_accel_version(ac["ip"], sync_gateway_version)
 
     def start_sync_gateway(self, url, config):
         target = hostname_for_url(url)
@@ -70,6 +130,7 @@ class SyncGateway:
             subset=target
         )
         assert status == 0, "Could not start sync_gateway"
+
 
     def stop_sync_gateway(self, url):
         target = hostname_for_url(url)

--- a/keywords/SyncGateway.py
+++ b/keywords/SyncGateway.py
@@ -1,17 +1,15 @@
-import tarfile
-import os
-import shutil
-import logging
-import time
 import re
+import os
+import json
+import logging
 
-from jinja2 import Template
 import requests
 from requests import Session
-from requests import ConnectionError
 
-from constants import *
-from utils import *
+from utils import version_is_binary
+from utils import log_r
+from utils import version_and_build
+from utils import hostname_for_url
 
 from libraries.provision.ansible_runner import AnsibleRunner
 
@@ -25,8 +23,10 @@ def get_sync_gateway_version(host):
     running_version_parts = re.split("[ /(;)]", running_version)
 
     if running_version_parts[3] == "HEAD":
+        # Example: resp_obj["version"] = Couchbase Sync Gateway/HEAD(nobranch)(e986c8a)
         running_version_formatted = running_version_parts[6]
     else:
+        # Example: resp_obj["version"] = "Couchbase Sync Gateway/1.3.0(183;bfe61c7)"
         running_version_formatted = "{}-{}".format(running_version_parts[3], running_version_parts[4])
 
     # Returns the version as 338493 commit format or 1.2.1-4 version format
@@ -130,7 +130,6 @@ class SyncGateway:
             subset=target
         )
         assert status == 0, "Could not start sync_gateway"
-
 
     def stop_sync_gateway(self, url):
         target = hostname_for_url(url)

--- a/keywords/utils.py
+++ b/keywords/utils.py
@@ -18,6 +18,14 @@ def log_r(request):
     )
     logging.debug("{}".format(request.text))
 
+
+def version_is_binary(version):
+    if len(version.split(".")) > 1:
+        # ex 1.2.1 or 1.2.1-4
+        return True
+    else:
+        return False
+
 def version_and_build(full_version):
     version_parts = full_version.split("-")
     assert (len(version_parts) == 2)

--- a/resources/common.robot
+++ b/resources/common.robot
@@ -2,7 +2,6 @@
 Documentation    Common Variables / Keywords
 
 Library     Process
-Library     ${KEYWORDS}/ClusterKeywords.py
 
 *** Variables ***
 ${LIBRARIES}                libraries
@@ -27,21 +26,6 @@ Clean Cluster
     Log  ${result.stderr}
     Log  ${result.stdout}
     Should Be Equal As Integers  ${result.rc}  0
-
-Install Server
-    [Arguments]     ${server_version}
-    Log                         Cluster Config: %{CLUSTER_CONFIG}
-    ${server_arg}               Catenate  SEPARATOR=  --version=          ${server_version}
-    ${result} =  Run Process  python  ${LIBRARIES}/provision/install_couchbase_server.py  ${server_arg}
-    Log To Console  ${result.stderr}
-    Log To Console  ${result.stdout}
-
-Install Sync Gateway
-    [Arguments]     ${version}  ${config}
-    Log                         Cluster Config: %{CLUSTER_CONFIG}
-    ${result} =  Run Process  python  ${LIBRARIES}/provision/install_sync_gateway.py  --version\=${sync_gateway_version}  --config-file\=${sync_gateway_config}
-    Log  ${result.stderr}  console=True
-    Log  ${result.stdout}  console=True
 
 # LiteServ Keywords
 Install LiteServ

--- a/testsuites/listener/shared/client_sg/__init__.robot
+++ b/testsuites/listener/shared/client_sg/__init__.robot
@@ -5,6 +5,7 @@ Suite Setup       Setup Suite
 
 Library           OperatingSystem
 Library           ${KEYWORDS}/LiteServ.py
+Library           ${KEYWORDS}/SyncGateway.py
 
 *** Variables ***
 ${SYNC_GATEWAY_CONFIG}  ${SYNC_GATEWAY_CONFIGS}/walrus.json
@@ -16,4 +17,4 @@ Setup Suite
     Install LiteServ  platform-${PLATFORM}  version=${LITESERV_VERSION}
 
     Set Environment Variable  CLUSTER_CONFIG  ${CLUSTER_CONFIGS}/1sg
-    Install Sync Gateway  version=${SYNC_GATEWAY_VERSION}  config=${SYNC_GATEWAY_CONFIG}
+    Install Sync Gateway  sync_gateway_version=${SYNC_GATEWAY_VERSION}  sync_gateway_config=${SYNC_GATEWAY_CONFIG}

--- a/testsuites/listener/shared/client_sg/listener_sg_replication_compact_revs_limit.robot
+++ b/testsuites/listener/shared/client_sg/listener_sg_replication_compact_revs_limit.robot
@@ -11,6 +11,7 @@ Library           ${KEYWORDS}/Async.py
 Library           ${KEYWORDS}/MobileRestClient.py
 Library           ${KEYWORDS}/LiteServ.py
 
+Library           ${KEYWORDS}/ClusterKeywords.py
 Library           ${KEYWORDS}/SyncGateway.py
 Library           ${KEYWORDS}/CouchbaseServer.py
 Library           ${KEYWORDS}/Logging.py

--- a/testsuites/listener/shared/client_sg/listener_sg_replication_mismatch.robot
+++ b/testsuites/listener/shared/client_sg/listener_sg_replication_mismatch.robot
@@ -15,6 +15,7 @@ Library           ${KEYWORDS}/LiteServ.py
 Library           ${KEYWORDS}/SyncGateway.py
 Library           ${KEYWORDS}/CouchbaseServer.py
 Library           ${KEYWORDS}/Logging.py
+Library           ${KEYWORDS}/ClusterKeywords.py
 
 Test Setup        Setup Test
 Test Teardown     Teardown Test

--- a/testsuites/syncgateway/functional/1sg_1ac_1cbs/1sg_1ac_1cbs.robot
+++ b/testsuites/syncgateway/functional/1sg_1ac_1cbs/1sg_1ac_1cbs.robot
@@ -205,11 +205,6 @@ Suite Setup
     ...     sync_gateway_version=${SYNC_GATEWAY_VERSION}
     ...     sync_gateway_config=${SYNC_GATEWAY_CONFIG}
 
-    Verify Cluster Versions
-    ...  cluster_config=%{CLUSTER_CONFIG}
-    ...  expected_server_version=${SERVER_VERSION}
-    ...  expected_sync_gateway_version=${SYNC_GATEWAY_VERSION}
-
 Suite Teardown
     Log  Tearing down suite ...  console=True
 

--- a/testsuites/syncgateway/functional/1sg_1cbs/__init__.robot
+++ b/testsuites/syncgateway/functional/1sg_1cbs/__init__.robot
@@ -24,10 +24,6 @@ Suite Setup
     ...     sync_gateway_version=${SYNC_GATEWAY_VERSION}
     ...     sync_gateway_config=${SYNC_GATEWAY_CONFIG}
 
-    Verify Cluster Versions
-    ...  cluster_config=%{CLUSTER_CONFIG}
-    ...  expected_server_version=${SERVER_VERSION}
-    ...  expected_sync_gateway_version=${SYNC_GATEWAY_VERSION}
 
 Suite Teardown
     Log  Tearing down suite ...  console=True

--- a/testsuites/syncgateway/functional/1sg_2ac_1cbs/1sg_2ac_1cbs.robot
+++ b/testsuites/syncgateway/functional/1sg_2ac_1cbs/1sg_2ac_1cbs.robot
@@ -54,10 +54,6 @@ Suite Setup
     ...     sync_gateway_version=${SYNC_GATEWAY_VERSION}
     ...     sync_gateway_config=${SYNC_GATEWAY_CONFIG}
 
-    Verify Cluster Versions
-    ...  cluster_config=%{CLUSTER_CONFIG}
-    ...  expected_server_version=${SERVER_VERSION}
-    ...  expected_sync_gateway_version=${SYNC_GATEWAY_VERSION}
 
 Suite Teardown
     Log  Tearing down suite ...  console=True

--- a/testsuites/syncgateway/functional/2sg_1cbs/2sg_1cbs.robot
+++ b/testsuites/syncgateway/functional/2sg_1cbs/2sg_1cbs.robot
@@ -90,10 +90,6 @@ Suite Setup
     ...     sync_gateway_version=${SYNC_GATEWAY_VERSION}
     ...     sync_gateway_config=${SYNC_GATEWAY_CONFIG}
 
-    Verify Cluster Versions
-    ...  cluster_config=%{CLUSTER_CONFIG}
-    ...  expected_server_version=${SERVER_VERSION}
-    ...  expected_sync_gateway_version=${SYNC_GATEWAY_VERSION}
 
 Suite Teardown
     Log  Tearing down suite ...  console=True


### PR DESCRIPTION
- move runtime version check to keyword level
- Install Sync Gateway now uses ansible API approach

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbaselabs/mobile-testkit/499)
<!-- Reviewable:end -->
