### PR TITLE
Enable revs limit for long running tests

### DIFF
--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_revslimit50_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_revslimit50_cc.json
@@ -1,0 +1,26 @@
+{
+    "interface":":4984",
+    "adminInterface": "0.0.0.0:4985",
+    "maxIncomingConnections": 0,
+    "maxCouchbaseConnections": 16,
+    "maxFileDescriptors": 90000,
+    "slowServerCallWarningThreshold": 500,
+    "compressResponses": true,
+    "log": ["CRUD+", "Cache+", "HTTP+", "Changes+"],
+    "databases":{
+        "db":{
+            "server":"http://{{ couchbase_server_primary_node }}:8091",
+            "bucket":"data-bucket",
+            "users":{
+                "GUEST":{
+                    "disabled":true,
+                    "admin_channels":[
+                        "*"
+                    ]
+                }
+            },
+            "revs_limit": 50
+        }
+    }
+}
+

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_revslimit50_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_revslimit50_di.json
@@ -1,0 +1,40 @@
+{
+    "interface":":4984",
+    "adminInterface": "0.0.0.0:4985",
+    "maxIncomingConnections": 0,
+    "maxCouchbaseConnections": 16,
+    "maxFileDescriptors": 90000,
+    "slowServerCallWarningThreshold": 500,
+    "compressResponses": true,
+    "log": ["CRUD+", "Cache+", "HTTP+", "Changes+"],
+    "cluster_config": {
+        "server":"http://{{ couchbase_server_primary_node }}:8091",
+        "data_dir":".",
+        "bucket":"data-bucket"
+    },
+    "databases":{
+        "db":{
+            "feed_type":"DCPSHARD",
+            "feed_params":{
+                "num_shards":64
+            },
+            "server":"http://{{ couchbase_server_primary_node }}:8091",
+            "bucket":"data-bucket",
+            "users":{
+                "GUEST":{
+                    "disabled":true,
+                    "admin_channels":[
+                        "*"
+                    ]
+                }
+            },
+            "channel_index":{
+                "server":"http://{{ couchbase_server_primary_node }}:8091",
+                "bucket":"index-bucket",
+                "writer":{{ is_index_writer }}
+            },
+            "revs_limit": 50
+        }
+    }
+}
+

--- a/testsuites/syncgateway/functional/1sg_1ac_1cbs/1sg_1ac_1cbs.robot
+++ b/testsuites/syncgateway/functional/1sg_1ac_1cbs/1sg_1ac_1cbs.robot
@@ -22,7 +22,7 @@ Suite Teardown  Suite Teardown
 
 Test Teardown   Test Teardown
 
-Test Timeout    60 minutes
+Test Timeout    30 minutes
 
 *** Variables ***
 ${CLUSTER_CONFIG}           ${CLUSTER_CONFIGS}/1sg_1ac_1cbs
@@ -46,7 +46,7 @@ test continuous changes parametrized 50 users 10 docs 10 revisions
 
 test continuous changes parametrized 50 user 50 docs 1000 revisions
     [Tags]   nightly
-    test continuous changes parametrized    ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_di.json  ${50}  ${50}  ${1000}
+    test continuous changes parametrized    ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_revslimit50_di.json  ${50}  ${50}  ${1000}
 
 test continuous changes sanity
     [Tags]   sanity

--- a/testsuites/syncgateway/functional/1sg_1cbs/1sg_1cbs-Part1.robot
+++ b/testsuites/syncgateway/functional/1sg_1cbs/1sg_1cbs-Part1.robot
@@ -90,7 +90,7 @@ test continuous changes parametrized 50 users 10 docs 10 revisions
 
 test continuous changes parametrized 50 user 50 docs 1000 revisions
     [Tags]   nightly
-    test continuous changes parametrized    ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_cc.json  ${50}  ${50}  ${1000}
+    test continuous changes parametrized    ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_revslimit50_cc.json  ${50}  ${50}  ${1000}
 
 test continuous changes sanity
     [Tags]   sanity

--- a/testsuites/syncgateway/functional/1sg_1cbs/__init__.robot
+++ b/testsuites/syncgateway/functional/1sg_1cbs/__init__.robot
@@ -7,7 +7,7 @@ Library     OperatingSystem
 Suite Setup     Suite Setup
 Suite Teardown  Suite Teardown
 
-Test Timeout    60 minutes
+Test Timeout    30 minutes
 
 *** Variables ***
 ${SYNC_GATEWAY_CONFIG}      ${SYNC_GATEWAY_CONFIGS}/sync_gateway_default_functional_tests_cc.json


### PR DESCRIPTION
Lower revs limit to 50 for 2 long running tests.

Fixes #422 

Results before:
test continuous changes parametrized 50 user 50 docs 1000 revisions (channel cache): 52 min
test continuous changes parametrized 50 user 50 docs 1000 revisions (channel cache): 15.5 min

Results after change:
test continuous changes parametrized 50 user 50 docs 1000 revisions (channel cache): 7.5 min
test continuous changes parametrized 50 user 50 docs 1000 revisions (channel cache): 12.25 min

@adamcfraser's theory about large revs (since revs are return with each GET) as being a bottleneck as the revs depth grows to default depth seems to be a large factor in the run time of these tests. 

@tleyden do you see any reason not to merge these changes? We can now run our entire nightly profile in ~2 hours with this change instead of 3+ hrs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbaselabs/mobile-testkit/535)
<!-- Reviewable:end -->
