### PR TITLE
Feature/add revs pruning test

### DIFF
--- a/resources/sync_gateway_configs/walrus-revs-limit.json
+++ b/resources/sync_gateway_configs/walrus-revs-limit.json
@@ -4,7 +4,7 @@
 	"log": ["*"],
 	"databases": {
 		"db": {
-			"revs_limit": 70,
+			"revs_limit": 100,
 			"server": "walrus:",
 			"sync":
 `function(doc){

--- a/testsuites/listener/shared/client_sg/listener_auto_prune.robot
+++ b/testsuites/listener/shared/client_sg/listener_auto_prune.robot
@@ -33,6 +33,8 @@ Test Auto Prune Listener Sanity
     Log  Using Sync Gateway: ${sg_url}
     Log  Using Sync Gateway: ${sg_url_admin}
 
+    Set Test Variable  ${num_docs}  ${100}
+    Set Test Variable  ${num_revs}  ${100}
 
     ${sg_user_channels} =  Create List  NBC
     ${sg_user} =     Create User  url=${sg_url_admin}  db=${sg_db}  name=${sg_user_name}  password=password  channels=${sg_user_channels}
@@ -58,6 +60,9 @@ Test Auto Prune Listener Keeps Confilts Sanity
     Log  Using LiteServ: ${ls_url}
     Log  Using Sync Gateway: ${sg_url}
     Log  Using Sync Gateway: ${sg_url_admin}
+
+    Set Test Variable  ${num_docs}  ${1}
+    Set Test Variable  ${num_revs}  ${100}
 
     ${sg_user_channels} =  Create List  NBC
     ${sg_user} =     Create User  url=${sg_url_admin}  db=${sg_db}  name=${sg_user_name}  password=password  channels=${sg_user_channels}
@@ -85,7 +90,7 @@ Test Auto Prune Listener Keeps Confilts Sanity
     ${conflict_doc} =  Get Doc  url=${ls_url}  db=${ls_db}  doc_id=${ls_db_docs[0]["id"]}  rev=${conflicting_revs[0]}
 
     # Update doc past revs limit and make sure conflict is still available
-    ${updated_doc} =  Update Doc  url=${ls_url}  db=${ls_db}  doc_id=${ls_db_docs[0]["id"]}  number_updates=${100}
+    ${updated_doc} =  Update Doc  url=${ls_url}  db=${ls_db}  doc_id=${ls_db_docs[0]["id"]}  number_updates=${num_revs}
     ${conflict_doc} =  Get Doc  url=${ls_url}  db=${ls_db}  doc_id=${ls_db_docs[0]["id"]}  rev=${conflicting_revs[0]}
 
     # Delete doc and ensure that the conflict is now the current rev
@@ -110,7 +115,7 @@ Setup Test
     Set Test Variable  ${sg_url}        ${cluster_hosts["sync_gateways"][0]["public"]}
     Set Test Variable  ${sg_url_admin}  ${cluster_hosts["sync_gateways"][0]["admin"]}
 
-    Set Test Variable  ${num_docs}  ${1}
+
 
     Stop Sync Gateway  url=${sg_url}
     Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus.json

--- a/testsuites/listener/shared/client_sg/listener_auto_prune.robot
+++ b/testsuites/listener/shared/client_sg/listener_auto_prune.robot
@@ -1,0 +1,99 @@
+*** Settings ***
+Documentation     A test suite containing functional tests of the Listener's
+...               replication with sync_gateway
+
+Resource          resources/common.robot
+Library           DebugLibrary
+Library           Process
+
+Library           OperatingSystem
+Library           ${KEYWORDS}/Async.py
+Library           ${KEYWORDS}/MobileRestClient.py
+Library           ${KEYWORDS}/LiteServ.py
+
+Library           ${KEYWORDS}/ClusterKeywords.py
+Library           ${KEYWORDS}/SyncGateway.py
+Library           ${KEYWORDS}/CouchbaseServer.py
+Library           ${KEYWORDS}/Logging.py
+
+Test Setup        Setup Test
+Test Teardown     Teardown Test
+
+*** Variables ***
+${sg_db}            db
+${sg_user_name}     sg_user
+
+*** Test Cases ***
+Test Auto Prune Listener Sanity
+    [Documentation]  Test to verify auto pruning is working for the listener
+    [Tags]           sanity     listener    ${PLATFORM}    syncgateway
+    [Timeout]        5 minutes
+
+    Log  Using LiteServ: ${ls_url}
+    Log  Using Sync Gateway: ${sg_url}
+    Log  Using Sync Gateway: ${sg_url_admin}
+
+
+    ${sg_user_channels} =  Create List  NBC
+    ${sg_user} =     Create User  url=${sg_url_admin}  db=${sg_db}  name=${sg_user_name}  password=password  channels=${sg_user_channels}
+    ${sg_session} =  Create Session  url=${sg_url_admin}  db=${sg_db}  name=${sg_user_name}
+
+    ${ls_db} =       Create Database  url=${ls_url}  name=ls_db
+    ${ls_db_docs} =  Add Docs  url=${ls_url}  db=${ls_db}  number=${num_docs}  id_prefix=ls_db  channels=${sg_user_channels}
+    ${ls_db_docs_update} =   Update Docs  url=${ls_url}  db=${ls_db}  docs=${ls_db_docs}  number_updates=${num_revs}
+
+    Verify Revs Num For Docs  url=${ls_url}  db=${ls_db}  docs=${ls_db_docs}  expected_revs_per_doc=${20}
+
+Test Auto Prune Listener Keeps Confilts Sanity
+    [Documentation]  Test to verify auto pruning is working for the listener
+    ...  1. Create db on LiteServ and add docs
+    ...  2. Create db on sync_gateway and add docs with the same id
+    ...  3. Create one shot push / pull replication
+    ...  4. Update LiteServ 50 times
+    ...  5. Assert that pruned conflict is still present
+    ...  6. Delete the current revision and check that a GET returns the old conflict as the current rev
+    [Tags]           sanity     listener    ${PLATFORM}    syncgateway
+    [Timeout]        5 minutes
+
+    Log  Using LiteServ: ${ls_url}
+    Log  Using Sync Gateway: ${sg_url}
+    Log  Using Sync Gateway: ${sg_url_admin}
+
+
+    ${sg_user_channels} =  Create List  NBC
+    ${sg_user} =     Create User  url=${sg_url_admin}  db=${sg_db}  name=${sg_user_name}  password=password  channels=${sg_user_channels}
+    ${sg_session} =  Create Session  url=${sg_url_admin}  db=${sg_db}  name=${sg_user_name}
+
+    ${ls_db} =       Create Database  url=${ls_url}  name=ls_db
+    ${ls_db_docs} =  Add Docs  url=${ls_url}  db=${ls_db}  number=${num_docs}  id_prefix=ls_db  channels=${sg_user_channels}
+    ${ls_db_docs_update} =   Update Docs  url=${ls_url}  db=${ls_db}  docs=${ls_db_docs}  number_updates=${num_revs}
+
+    Verify Revs Num For Docs  url=${ls_url}  db=${ls_db}  docs=${ls_db_docs}  expected_revs_per_doc=${20}
+
+*** Keywords ***
+Setup Test
+    ${ls_url} =  Start LiteServ
+    ...  platform=${PLATFORM}
+    ...  version=${LITESERV_VERSION}
+    ...  host=${LITESERV_HOST}
+    ...  port=${LITESERV_PORT}
+    ...  storage_engine=${LITESERV_STORAGE_ENGINE}
+
+    Set Environment Variable  CLUSTER_CONFIG  ${CLUSTER_CONFIGS}/1sg
+    ${cluster_hosts} =  Get Cluster Topology  %{CLUSTER_CONFIG}
+
+    Set Test Variable  ${ls_url}
+    Set Test Variable  ${sg_url}        ${cluster_hosts["sync_gateways"][0]["public"]}
+    Set Test Variable  ${sg_url_admin}  ${cluster_hosts["sync_gateways"][0]["admin"]}
+
+    Set Test Variable  ${num_docs}  ${100}
+    Set Test Variable  ${num_revs}  ${100}
+
+    Stop Sync Gateway  url=${sg_url}
+    Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus-revs-limit.json
+
+Teardown Test
+    Delete Databases  ${ls_url}
+    Shutdown LiteServ  platform=${PLATFORM}
+    Stop Sync Gateway  url=${sg_url}
+    Run Keyword If Test Failed  Fetch And Analyze Logs  ${TEST_NAME}

--- a/testsuites/listener/shared/client_sg/listener_auto_prune.robot
+++ b/testsuites/listener/shared/client_sg/listener_auto_prune.robot
@@ -27,7 +27,7 @@ ${sg_user_name}     sg_user
 Test Auto Prune Listener Sanity
     [Documentation]  Test to verify auto pruning is working for the listener
     [Tags]           sanity     listener    ${PLATFORM}    syncgateway
-    #[Timeout]        5 minutes
+    [Timeout]        5 minutes
 
     Log  Using LiteServ: ${ls_url}
     Log  Using Sync Gateway: ${sg_url}
@@ -53,7 +53,7 @@ Test Auto Prune Listener Keeps Confilts Sanity
     ...  5. Assert that pruned conflict is still present
     ...  6. Delete the current revision and check that a GET returns the old conflict as the current rev
     [Tags]           sanity     listener    ${PLATFORM}    syncgateway
-    #[Timeout]        5 minutes
+    [Timeout]        5 minutes
 
     Log  Using LiteServ: ${ls_url}
     Log  Using Sync Gateway: ${sg_url}

--- a/testsuites/listener/shared/client_sg/listener_auto_prune.robot
+++ b/testsuites/listener/shared/client_sg/listener_auto_prune.robot
@@ -27,7 +27,7 @@ ${sg_user_name}     sg_user
 Test Auto Prune Listener Sanity
     [Documentation]  Test to verify auto pruning is working for the listener
     [Tags]           sanity     listener    ${PLATFORM}    syncgateway
-    [Timeout]        5 minutes
+    #[Timeout]        5 minutes
 
     Log  Using LiteServ: ${ls_url}
     Log  Using Sync Gateway: ${sg_url}
@@ -53,22 +53,46 @@ Test Auto Prune Listener Keeps Confilts Sanity
     ...  5. Assert that pruned conflict is still present
     ...  6. Delete the current revision and check that a GET returns the old conflict as the current rev
     [Tags]           sanity     listener    ${PLATFORM}    syncgateway
-    [Timeout]        5 minutes
+    #[Timeout]        5 minutes
 
     Log  Using LiteServ: ${ls_url}
     Log  Using Sync Gateway: ${sg_url}
     Log  Using Sync Gateway: ${sg_url_admin}
-
 
     ${sg_user_channels} =  Create List  NBC
     ${sg_user} =     Create User  url=${sg_url_admin}  db=${sg_db}  name=${sg_user_name}  password=password  channels=${sg_user_channels}
     ${sg_session} =  Create Session  url=${sg_url_admin}  db=${sg_db}  name=${sg_user_name}
 
     ${ls_db} =       Create Database  url=${ls_url}  name=ls_db
-    ${ls_db_docs} =  Add Docs  url=${ls_url}  db=${ls_db}  number=${num_docs}  id_prefix=ls_db  channels=${sg_user_channels}
-    ${ls_db_docs_update} =   Update Docs  url=${ls_url}  db=${ls_db}  docs=${ls_db_docs}  number_updates=${num_revs}
 
-    Verify Revs Num For Docs  url=${ls_url}  db=${ls_db}  docs=${ls_db_docs}  expected_revs_per_doc=${20}
+    # Create docs with same prefix to create conflicts when the dbs complete 1 shot replication
+    ${ls_db_docs} =  Add Docs  url=${ls_url}  db=${ls_db}  number=${num_docs}  id_prefix=doc  channels=${sg_user_channels}
+    ${ls_db_docs} =  Add Docs  url=${sg_url}  db=${sg_db}  number=${num_docs}  id_prefix=doc  channels=${sg_user_channels}  auth=${sg_session}
+
+    # Setup one shot pull replication and wait for idle.
+    ${repl_id} =  Start Replication
+    ...  url=${ls_url}
+    ...  continuous=${False}
+    ...  from_url=${sg_url_admin}  from_db=${sg_db}
+    ...  to_db=${ls_db}
+
+    Wait For No Replications  url=${ls_url}
+
+    # There should now be a conflict on the client
+    ${conflicting_revs} =  Get Conflict Revs  url=${ls_url}  db=${ls_db}  doc=${ls_db_docs[0]}
+
+    # Get the doc with conflict rev
+    ${conflict_doc} =  Get Doc  url=${ls_url}  db=${ls_db}  doc_id=${ls_db_docs[0]["id"]}  rev=${conflicting_revs[0]}
+
+    # Update doc past revs limit and make sure conflict is still available
+    ${updated_doc} =  Update Doc  url=${ls_url}  db=${ls_db}  doc_id=${ls_db_docs[0]["id"]}  number_updates=${100}
+    ${conflict_doc} =  Get Doc  url=${ls_url}  db=${ls_db}  doc_id=${ls_db_docs[0]["id"]}  rev=${conflicting_revs[0]}
+
+    # Delete doc and ensure that the conflict is now the current rev
+    ${deleted_doc} =  Delete Doc  url=${ls_url}  db=${ls_db}  doc_id=${ls_db_docs[0]["id"]}  rev=${updated_doc["rev"]}
+    ${current_doc} =  Get Doc  url=${ls_url}  db=${ls_db}  doc_id=${ls_db_docs[0]["id"]}
+    Should Be Equal  ${current_doc["_rev"]}  ${conflicting_revs[0]}
+
 
 *** Keywords ***
 Setup Test
@@ -86,11 +110,10 @@ Setup Test
     Set Test Variable  ${sg_url}        ${cluster_hosts["sync_gateways"][0]["public"]}
     Set Test Variable  ${sg_url_admin}  ${cluster_hosts["sync_gateways"][0]["admin"]}
 
-    Set Test Variable  ${num_docs}  ${100}
-    Set Test Variable  ${num_revs}  ${100}
+    Set Test Variable  ${num_docs}  ${1}
 
     Stop Sync Gateway  url=${sg_url}
-    Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus-revs-limit.json
+    Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus.json
 
 Teardown Test
     Delete Databases  ${ls_url}

--- a/testsuites/listener/shared/client_sg/listener_sg_replication_compact_revs_limit.robot
+++ b/testsuites/listener/shared/client_sg/listener_sg_replication_compact_revs_limit.robot
@@ -89,10 +89,10 @@ Client to Sync Gateway Complex Replication With Revs Limit
 
     Compact Database  url=${ls_url}  db=${ls_db}
 
-    # After compaction, Mac OSX LiteServ should only have 20 revisions due to built in client revs limit
+    # Mac OSX LiteServ should only have 20 revisions due to built in client revs limit
     Verify Revs Num For Docs  url=${ls_url}  db=${ls_db}  docs=${ls_db_docs}  expected_revs_per_doc=${20}
 
-    # Sync Gateway should have 100 or 20 revisions due to the specified revs_limit in the sg config and possible conflict winners from the liteserv db
+    # Sync Gateway should have 100 revisions due to the specified revs_limit in the sg config and possible conflict winners from the liteserv db
     Verify Max Revs Num For Docs  url=${sg_url}  db=${sg_db}  docs=${ls_db_docs}  expected_max_number_revs_per_doc=${100}  auth=${sg_session}
 
     Delete Conflicts  url=${ls_url}  db=${ls_db}  docs=${ls_db_docs}
@@ -120,9 +120,11 @@ Client to Sync Gateway Complex Replication With Revs Limit
 
     Verify Revs Num For Docs  url=${ls_url}  db=${ls_db}  docs=${ls_db_docs}  expected_revs_per_doc=${20}
 
+    Delete Conflicts  url=${ls_url}  db=${ls_db}  docs=${ls_db_docs}
+
     Delete Docs  url=${ls_url}  db=${ls_db}  docs=${ls_db_docs}
-    Verify Docs Deleted  url=${sg_url_admin}  db=${sg_db}  docs=${ls_db_docs}
     Verify Docs Deleted  url=${ls_url}  db=${ls_db}  docs=${ls_db_docs}
+    Verify Docs Deleted  url=${sg_url_admin}  db=${sg_db}  docs=${ls_db_docs}
 
 
 *** Keywords ***

--- a/testsuites/listener/shared/client_sg/listener_sg_replication_compact_revs_limit.robot
+++ b/testsuites/listener/shared/client_sg/listener_sg_replication_compact_revs_limit.robot
@@ -92,8 +92,8 @@ Client to Sync Gateway Complex Replication With Revs Limit
     # After compaction, Mac OSX LiteServ should only have 20 revisions due to built in client revs limit
     Verify Revs Num For Docs  url=${ls_url}  db=${ls_db}  docs=${ls_db_docs}  expected_revs_per_doc=${20}
 
-    # Sync Gateway should have 70 or 20 revisions due to the specified revs_limit in the sg config and possible conflict winners from the liteserv db
-    Verify Max Revs Num For Docs  url=${sg_url}  db=${sg_db}  docs=${ls_db_docs}  expected_max_number_revs_per_doc=${70}  auth=${sg_session}
+    # Sync Gateway should have 100 or 20 revisions due to the specified revs_limit in the sg config and possible conflict winners from the liteserv db
+    Verify Max Revs Num For Docs  url=${sg_url}  db=${sg_db}  docs=${ls_db_docs}  expected_max_number_revs_per_doc=${100}  auth=${sg_session}
 
     Delete Conflicts  url=${ls_url}  db=${ls_db}  docs=${ls_db_docs}
 

--- a/testsuites/listener/shared/client_sg/listener_sg_replication_push_revs_conflict.robot
+++ b/testsuites/listener/shared/client_sg/listener_sg_replication_push_revs_conflict.robot
@@ -55,7 +55,7 @@ Verify Open Revs With Revs Limit Push Conflict
     ${sg_docs_update} =  Update Docs  url=${sg_url}  db=${sg_db}  docs=${ls_db_docs}  number_updates=${num_revs}  auth=${sg_session}
     ${sg_current_doc} =  Get Doc  url=${sg_url}  db=${sg_db}  doc_id=ls_db_2  auth=${sg_session}
 
-    ${ls_db_docs_update} =   Update Docs  url=${ls_url}  db=${ls_db}  docs=${ls_db_docs}  number_updates=${num_revs}
+    ${ls_db_docs_update} =  Update Docs  url=${ls_url}  db=${ls_db}  docs=${ls_db_docs}  number_updates=${num_revs}
     ${ls_current_doc} =  Get Doc  url=${ls_url}  db=${ls_db}  doc_id=ls_db_2
 
     Wait For Replication Status Idle  url=${ls_url}  replication_id=${repl1}
@@ -63,8 +63,8 @@ Verify Open Revs With Revs Limit Push Conflict
     Log  ${sg_current_doc}
     Log  ${ls_current_doc}
 
-    Verify Doc Rev Generation  url=${ls_url}  db=${ls_db}  doc_id=${ls_current_doc["_id"]}  expected_generation=${101}
-    Verify Doc Rev Generation  url=${sg_url}  db=${sg_db}  doc_id=${sg_current_doc["_id"]}  expected_generation=${101}  auth=${sg_session}
+    Verify Doc Rev Generation  url=${ls_url}  db=${ls_db}  doc_id=${ls_current_doc["_id"]}  expected_generation=${21}
+    Verify Doc Rev Generation  url=${sg_url}  db=${sg_db}  doc_id=${sg_current_doc["_id"]}  expected_generation=${21}  auth=${sg_session}
 
     ${expected_ls_revs} =  Create List  ${ls_current_doc["_rev"]}
     Verify Open Revs  url=${ls_url}  db=${ls_db}  doc_id=${ls_current_doc["_id"]}  expected_open_revs=${expected_ls_revs}
@@ -89,11 +89,11 @@ Setup Test
     Set Test Variable  ${sg_url}        ${cluster_hosts["sync_gateways"][0]["public"]}
     Set Test Variable  ${sg_url_admin}  ${cluster_hosts["sync_gateways"][0]["admin"]}
 
-    Set Test Variable  ${num_docs}  ${10}
-    Set Test Variable  ${num_revs}  ${100}
+    Set Test Variable  ${num_docs}  ${100}
+    Set Test Variable  ${num_revs}  ${20}
 
     Stop Sync Gateway  url=${sg_url}
-    Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus-revs-limit.json
+    Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus.json
 
 Teardown Test
     Delete Databases  ${ls_url}

--- a/testsuites/syncgateway/functional/test_sync.py
+++ b/testsuites/syncgateway/functional/test_sync.py
@@ -377,7 +377,8 @@ def test_sync_require_roles(conf):
     # Dictionary should be empty if they were blocked from pushing docs
     assert len(read_only_user_docs.items()) == 0
 
-    # wait, some changes are not instant
+    # It seems be non deterministic but sometimes when issuing the changes call return, some of the documents are returned but not all.
+    # There is currently no retry loop in verify_changes and I'm guessing that the bulk_docs requests are still processing.
     time.sleep(5)
 
     # Should recieve docs from radio_channels

--- a/testsuites/syncgateway/functional/test_sync.py
+++ b/testsuites/syncgateway/functional/test_sync.py
@@ -377,6 +377,9 @@ def test_sync_require_roles(conf):
     # Dictionary should be empty if they were blocked from pushing docs
     assert len(read_only_user_docs.items()) == 0
 
+    # wait, some changes are not instant
+    time.sleep(5)
+
     # Should recieve docs from radio_channels
     verify_changes(radio_channels_no_roles_user, expected_num_docs=expected_num_radio_docs, expected_num_revisions=0, expected_docs=all_radio_docs)
 


### PR DESCRIPTION
Fixes #532 - Adds sanity tests for SQLite pruning

- get_conflict_revs Keyword
- wait_for_no_replications Keyword
- Fix a few robot tests
    - Delete conflicts before delete docs to avoid deleted doc reverting to a previous conflicted revision
    - Lower revs to avoid unexpected behavior https://github.com/couchbase/couchbase-lite-ios/issues/1277
    - Add sleep to intermittent failing test in CI, not the best fix but we don't have retry support in the old `user` class

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbaselabs/mobile-testkit/537)
<!-- Reviewable:end -->
