### PR TITLE
Fix provisioning for 4.1.0 Couchbase Server build

### DIFF
--- a/libraries/provision/ansible/playbooks/install-couchbase-server-package.yml
+++ b/libraries/provision/ansible/playbooks/install-couchbase-server-package.yml
@@ -55,11 +55,11 @@
     # Start via init scipt if running CBS 4.1.0 on CentOS 7.2 due to https://issues.couchbase.com/browse/MB-17193
     - name: Start Couchbase Service (Hack around 7.2 and CBS 4.1.0 issue)
       shell: /opt/couchbase/etc/couchbase_init.d start
-      when: ansible_distribution == 'CentOS' and (ansible_distribution_version == '7.2.1511' and couchbase_server_package_name == 'couchbase-server-enterprise-4.1.0-centos7.x86_64.rpm')
+      when: ansible_distribution == 'CentOS' and (ansible_distribution_version == '7.2.1511' and couchbase_server_package_name == 'couchbase-server-enterprise-4.1.0-5005-centos7.x86_64.rpm')
 
     - name: Restart Couchbase Service
       service: name=couchbase-server state=restarted
-      when: ansible_distribution == 'CentOS' and (not ansible_distribution_version == '7.2.1511' or not couchbase_server_package_name == 'couchbase-server-enterprise-4.1.0-centos7.x86_64.rpm')
+      when: ansible_distribution == 'CentOS' and (not ansible_distribution_version == '7.2.1511' or not couchbase_server_package_name == 'couchbase-server-enterprise-4.1.0-5005-centos7.x86_64.rpm')
 
     # Configure
     - debug: msg="Couchbase cluster RAM {{ couchbase_server_cluster_ram }}"


### PR DESCRIPTION
We need to include the build number to support provisioning changes from a month or so ago to workaround known issue with CBS 4.1.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbaselabs/mobile-testkit/566)
<!-- Reviewable:end -->
