### PR TITLE
Add indexing support for 4.5 in provisioning due to new cli flag

### DIFF
--- a/libraries/provision/ansible/playbooks/install-couchbase-server-package.yml
+++ b/libraries/provision/ansible/playbooks/install-couchbase-server-package.yml
@@ -72,8 +72,13 @@
     - name: Wait for node to be listening on port 8091
       wait_for: port=8091 delay=5 timeout=30
 
-    - name: Configure cluster settings
+    - name: Configure cluster settings (4.0.X and 4.1.X)
       shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli cluster-init -c {{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --user={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --cluster-init-username={{ couchbase_server_admin }} --cluster-init-password={{ couchbase_server_password }} --cluster-init-port={{couchbase_server_admin_port}} --cluster-init-ramsize={{ couchbase_server_cluster_ram }}  --services=data,index,query  --cluster-index-ramsize={{ couchbase_server_index_ram }}"
+      when:  "'4.0' in couchbase_server_package_name or '4.1' in couchbase_server_package_name"
+
+    - name: Configure cluster settings (4.5.X and up)
+      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli cluster-init -c {{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --user={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --cluster-init-username={{ couchbase_server_admin }} --cluster-init-password={{ couchbase_server_password }} --cluster-init-port={{couchbase_server_admin_port}} --cluster-init-ramsize={{ couchbase_server_cluster_ram }}  --services=data,index,query  --cluster-index-ramsize={{ couchbase_server_index_ram }}  --index-storage-setting=default"
+      when:  "not '4.0' in couchbase_server_package_name and not '4.1' in couchbase_server_package_name"
 
     - name: Initialize primary node
       shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli node-init -c {{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --user={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --cluster-init-username={{ couchbase_server_admin }} --node-init-hostname={{ couchbase_server_node }}"

--- a/libraries/provision/install_couchbase_server.py
+++ b/libraries/provision/install_couchbase_server.py
@@ -23,6 +23,7 @@ class CouchbaseServerConfig:
     def get_baseurl_package(self):
 
         released_versions = {
+            "4.5.0": "2601",
             "4.1.1": "5914",
             "4.1.0": "5005",
             "4.0.0": "4051",
@@ -47,7 +48,7 @@ class CouchbaseServerConfig:
             base_url = "http://cbnas01.sc.couchbase.com/builds/latestbuilds/couchbase-server/spock/{}".format(self.build)
             package_name = "couchbase-server-enterprise-{}-{}-centos7.x86_64.rpm".format(self.version, self.build)
         else:
-            raise ValueError("Unable to resolve dev build for version: {}-{}".format(self.version, self.build))
+            raise ValueError("Unable to resolve build for version: {}-{}".format(self.version, self.build))
 
         return base_url, package_name
 


### PR DESCRIPTION
Fixes #550 

This will provision couchbase server with a new required indexing flag in cluster-init if the the server version is not "4.0.X" or "4.1.X", or all newer versions. This will fix some tests when running the functional tests against 4.5.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbaselabs/mobile-testkit/567)
<!-- Reviewable:end -->
