### PR TITLE
Encryption support (Mac OSX / .NET)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ report.html
 
 results/*
 
+!results/dbs
+results/dbs/*
+!results/dbs/README.md
+
 !results/logs
 results/logs/*
 !results/logs/README.md

--- a/keywords/LiteServ.py
+++ b/keywords/LiteServ.py
@@ -13,6 +13,7 @@ from requests.exceptions import ConnectionError
 from constants import BINARY_DIR
 from constants import LATEST_BUILDS
 from constants import MAX_RETRIES
+from constants import REGISTERED_CLIENT_DBS
 from constants import RESULTS_DIR
 
 from utils import log_info
@@ -290,3 +291,14 @@ class LiteServ:
         log_info("LiteServ: {} is running".format(lite_version))
 
         return url
+
+    def build_name_passwords_for_registered_dbs(self):
+        """
+        Returns a list of name=password for each db in registered dbs
+        to allow the db to be encrypted for Mac OSX / .NET LiteServ
+        """
+        db_flags = []
+        for db_name in REGISTERED_CLIENT_DBS:
+            db_flags.append("--dbpassword")
+            db_flags.append("{}=pass".format(db_name))
+        return db_flags

--- a/keywords/MobileRestClient.py
+++ b/keywords/MobileRestClient.py
@@ -192,6 +192,11 @@ class MobileRestClient:
         return (name, password)
 
     def create_database(self, url, name, server=None):
+        """
+        Create a Listener or Sync Gateway database via REST.
+        IMPORTANT: If you want your database to run in encrypted mode on Mac, you must add the
+        database name=password to the 'Start MacOSX LiteServ' keyword (resources/common.robot)
+        """
 
         server_type = self.get_server_type(url)
 

--- a/keywords/MobileRestClient.py
+++ b/keywords/MobileRestClient.py
@@ -17,6 +17,7 @@ from constants import AuthType
 from constants import ServerType
 from constants import Platform
 from constants import CLIENT_REQUEST_TIMEOUT
+from constants import REGISTERED_CLIENT_DBS
 
 from utils import log_r
 from utils import log_info
@@ -201,6 +202,13 @@ class MobileRestClient:
         server_type = self.get_server_type(url)
 
         if server_type == ServerType.listener:
+
+            if name not in REGISTERED_CLIENT_DBS:
+                # If the db name is not in registered dbs and you are running in excrypted mode (SQLCipher or ForestDB+Encryption),
+                #  the db will be created with no encryption silently. Adding the db to REGISTERED_CLIENT_DBS makes sure that
+                #  the db has a password and will be encrypted upon creation.
+                raise ValueError("Make sure you have registered you db name in keywords/constants: {}".format(name))
+
             resp = self._session.put("{}/{}/".format(url, name))
         elif server_type == ServerType.syncgateway:
             if server is None:

--- a/keywords/constants.py
+++ b/keywords/constants.py
@@ -10,6 +10,10 @@ MAX_RETRIES = 5
 
 CLIENT_REQUEST_TIMEOUT = 120
 
+# Required to make sure that these are created with encryption
+# Use to build the command line flags for encryption
+REGISTERED_CLIENT_DBS = ["ls_db", "ls_db1", "ls_db2"]
+
 class ServerType(Enum):
     syncgateway = "syncgateway"
     listener = "listener"

--- a/resources/common.robot
+++ b/resources/common.robot
@@ -63,13 +63,46 @@ Start MacOSX LiteServ
     ...  The LiteServ binaries are located in deps/.
     [Arguments]  ${version}  ${host}  ${port}  ${storage_engine}
     [Timeout]       1 minute
+
     ${binary_path} =  Get LiteServ Binary Path  platform=macosx  version=${version}
-    Start Process   ${binary_path}  --port  ${port}  --storage  ${storage_engine}
-    ...             -Log  YES  -LogSync  YES  -LogCBLRouter  YES  -LogSyncVerbose  YES  -LogRemoteRequest  YES
-    ...             alias=liteserv-ios
-    ...             shell=True
-    ...             stdout=${RESULTS}/logs/${TEST_NAME}-macosx-liteserv-stdout.log
-    ...             stderr=${RESULTS}/logs/${TEST_NAME}-macosx-liteserv-stderr.log
+
+    Run Keyword If  '${storage_engine}' == 'ForestDB+Encryption'
+    ...  Start Process  ${binary_path}
+    ...    --port  ${port}
+    ...    --storage  ForestDB
+    ...    --dir  ${RESULTS}/dbs
+    ...    --dbpassword  ls_db\=pass
+    ...    --dbpassword  ls_db1\=pass
+    ...    --dbpassword  ls_db2\=pass
+    ...    -Log  YES  -LogSync  YES  -LogCBLRouter  YES  -LogSyncVerbose  YES  -LogRemoteRequest  YES
+    ...    alias=liteserv-ios
+    ...    shell=True
+    ...    stdout=${RESULTS}/logs/${TEST_NAME}-macosx-liteserv-stdout.log
+    ...    stderr=${RESULTS}/logs/${TEST_NAME}-macosx-liteserv-stderr.log
+    ...  ELSE IF  '${storage_engine}' == 'SQLCipher'
+    ...  Start Process  ${binary_path}
+    ...    --port  ${port}
+    ...    --storage  SQLite
+    ...    --dir  ${RESULTS}/dbs
+    ...    --dbpassword  ls_db\=pass
+    ...    --dbpassword  ls_db1\=pass
+    ...    --dbpassword  ls_db2\=pass
+    ...    -Log  YES  -LogSync  YES  -LogCBLRouter  YES  -LogSyncVerbose  YES  -LogRemoteRequest  YES
+    ...    alias=liteserv-ios
+    ...    shell=True
+    ...    stdout=${RESULTS}/logs/${TEST_NAME}-macosx-liteserv-stdout.log
+    ...    stderr=${RESULTS}/logs/${TEST_NAME}-macosx-liteserv-stderr.log
+    ...  ELSE
+    ...  Start Process  ${binary_path}
+    ...    --port  ${port}
+    ...    --storage  ${storage_engine}
+    ...    --dir  ${RESULTS}/dbs
+    ...    -Log  YES  -LogSync  YES  -LogCBLRouter  YES  -LogSyncVerbose  YES  -LogRemoteRequest  YES
+    ...    alias=liteserv-ios
+    ...    shell=True
+    ...    stdout=${RESULTS}/logs/${TEST_NAME}-macosx-liteserv-stdout.log
+    ...    stderr=${RESULTS}/logs/${TEST_NAME}-macosx-liteserv-stderr.log
+
     Process Should Be Running   handle=liteserv-ios
 
 Start Android LiteServ

--- a/resources/common.robot
+++ b/resources/common.robot
@@ -128,11 +128,42 @@ Start Net LiteServ
     [Arguments]  ${version}  ${host}  ${port}  ${storage_engine}
     [Timeout]       1 minute
     ${binary_path} =  Get LiteServ Binary Path  platform=net  version=${version}
-    Start Process   mono  ${binary_path}  --port\=${port}
-    ...             alias=liteserv-net
-    ...             shell=True
-    ...             stdout=${RESULTS}/logs/${TEST_NAME}-net-liteserv-stdout.log
-    ...             stderr=${RESULTS}/logs/${TEST_NAME}-net-liteserv-stderr.log
+
+    Run Keyword If  '${storage_engine}' == 'ForestDB+Encryption'
+    ...  Start Process  mono  ${binary_path}
+    ...    --port  ${port}
+    ...    --storage  ForestDB
+    ...    --dir  ${RESULTS}/dbs
+    ...    --dbpassword  ls_db\=pass
+    ...    --dbpassword  ls_db1\=pass
+    ...    --dbpassword  ls_db2\=pass
+    ...    alias=liteserv-net
+    ...    shell=True
+    ...    stdout=${RESULTS}/logs/${TEST_NAME}-net-liteserv-stdout.log
+    ...    stderr=${RESULTS}/logs/${TEST_NAME}-net-liteserv-stderr.log
+    ...  ELSE IF  '${storage_engine}' == 'SQLCipher'
+    ...  Start Process  mono  ${binary_path}
+    ...    --port  ${port}
+    ...    --storage  SQLite
+    ...    --dir  ${RESULTS}/dbs
+    ...    --dbpassword  ls_db\=pass
+    ...    --dbpassword  ls_db1\=pass
+    ...    --dbpassword  ls_db2\=pass
+    ...    alias=liteserv-net
+    ...    shell=True
+    ...    stdout=${RESULTS}/logs/${TEST_NAME}-net-liteserv-stdout.log
+    ...    stderr=${RESULTS}/logs/${TEST_NAME}-net-liteserv-stderr.log
+    ...  ELSE
+    ...  Start Process  mono  ${binary_path}
+    ...    --port  ${port}
+    ...    --storage  ${storage_engine}
+    ...    --dir  ${RESULTS}/dbs
+    ...    alias=liteserv-net
+    ...    shell=True
+    ...    stdout=${RESULTS}/logs/${TEST_NAME}-net-liteserv-stdout.log
+    ...    stderr=${RESULTS}/logs/${TEST_NAME}-net-liteserv-stderr.log
+
+    Process Should Be Running   handle=liteserv-net
 
 Shutdown MacOSX LiteServ
     [Documentation]   Stops Mac OSX LiteServ.

--- a/resources/common.robot
+++ b/resources/common.robot
@@ -66,14 +66,19 @@ Start MacOSX LiteServ
 
     ${binary_path} =  Get LiteServ Binary Path  platform=macosx  version=${version}
 
+     # Get a list of db names / password for running LiteServ with encrypted databases
+    @{db_name_passwords} =  Run Keyword If  '${storage_engine}' == 'ForestDB+Encryption' or '${storage_engine}' == 'SQLCipher'
+    ...  Build Name Passwords For Registered Dbs
+
+    Run Keyword If  '${storage_engine}' == 'ForestDB+Encryption' or '${storage_engine}' == 'SQLCipher'
+    ...  Log  Using ENCRYPTION: ${db_name_passwords}  console=yes
+
     Run Keyword If  '${storage_engine}' == 'ForestDB+Encryption'
     ...  Start Process  ${binary_path}
     ...    --port  ${port}
     ...    --storage  ForestDB
     ...    --dir  ${RESULTS}/dbs
-    ...    --dbpassword  ls_db\=pass
-    ...    --dbpassword  ls_db1\=pass
-    ...    --dbpassword  ls_db2\=pass
+    ...    @{db_name_passwords}
     ...    -Log  YES  -LogSync  YES  -LogCBLRouter  YES  -LogSyncVerbose  YES  -LogRemoteRequest  YES
     ...    alias=liteserv-ios
     ...    shell=True
@@ -84,9 +89,7 @@ Start MacOSX LiteServ
     ...    --port  ${port}
     ...    --storage  SQLite
     ...    --dir  ${RESULTS}/dbs
-    ...    --dbpassword  ls_db\=pass
-    ...    --dbpassword  ls_db1\=pass
-    ...    --dbpassword  ls_db2\=pass
+    ...    @{db_name_passwords}
     ...    -Log  YES  -LogSync  YES  -LogCBLRouter  YES  -LogSyncVerbose  YES  -LogRemoteRequest  YES
     ...    alias=liteserv-ios
     ...    shell=True
@@ -129,14 +132,19 @@ Start Net LiteServ
     [Timeout]       1 minute
     ${binary_path} =  Get LiteServ Binary Path  platform=net  version=${version}
 
+    # Get a list of db names / password for running LiteServ with encrypted databases
+    @{db_name_passwords} =  Run Keyword If  '${storage_engine}' == 'ForestDB+Encryption' or '${storage_engine}' == 'SQLCipher'
+    ...  Build Name Passwords For Registered Dbs
+
+    Run Keyword If  '${storage_engine}' == 'ForestDB+Encryption' or '${storage_engine}' == 'SQLCipher'
+    ...  Log  Using ENCRYPTION: ${db_name_passwords}  console=yes
+
     Run Keyword If  '${storage_engine}' == 'ForestDB+Encryption'
     ...  Start Process  mono  ${binary_path}
     ...    --port  ${port}
     ...    --storage  ForestDB
     ...    --dir  ${RESULTS}/dbs
-    ...    --dbpassword  ls_db\=pass
-    ...    --dbpassword  ls_db1\=pass
-    ...    --dbpassword  ls_db2\=pass
+    ...    @{db_name_passwords}
     ...    alias=liteserv-net
     ...    shell=True
     ...    stdout=${RESULTS}/logs/${TEST_NAME}-net-liteserv-stdout.log
@@ -146,9 +154,7 @@ Start Net LiteServ
     ...    --port  ${port}
     ...    --storage  SQLite
     ...    --dir  ${RESULTS}/dbs
-    ...    --dbpassword  ls_db\=pass
-    ...    --dbpassword  ls_db1\=pass
-    ...    --dbpassword  ls_db2\=pass
+    ...    @{db_name_passwords}
     ...    alias=liteserv-net
     ...    shell=True
     ...    stdout=${RESULTS}/logs/${TEST_NAME}-net-liteserv-stdout.log

--- a/results/dbs/README.md
+++ b/results/dbs/README.md
@@ -1,0 +1,1 @@
+## Location for client dbs


### PR DESCRIPTION
- Allow running Mac OSX / .NET testkit listener tests with encryption
- Client dbs are now created in results/dbs/ folder for easier inspection

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbaselabs/mobile-testkit/579)
<!-- Reviewable:end -->
