### PR TITLE
Feature/test multiple replicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,13 +628,16 @@ Wait until the resources are up, then create the `pool.json` file by hand accord
 Debugging
 =========
 
-When developing custom keyworks, you may want to break and inspect at a certain point. Adding the following lines will do what you need
+When developing custom keyworks, you may want to break and inspect at a certain point in the python code. 
+Adding the following lines will do what you need
 
 ```
-import pdb
-for attr in ('stdin', 'stdout', 'stderr'):
-    setattr(sys, attr, getattr(sys, '__%s__' % attr))
-pdb.set_trace()
+from keywords.utils import breakpoint
+
+for thing in things:
+    breakpoint()
+    # break here ^
+    thing.do()
 ```
 
 They will redirect the stdin, stdout, and stderr from robot back to your control

--- a/keywords/MobileRestClient.py
+++ b/keywords/MobileRestClient.py
@@ -886,7 +886,30 @@ class MobileRestClient:
 
         return resp_obj
 
-    def start_replication(self, url, continuous, from_url=None, from_db=None, to_url=None, to_db=None, repl_filter=None, doc_ids=None):
+    def start_replication(self,
+                          url,
+                          continuous,
+                          from_url=None, from_db=None,
+                          to_url=None, to_db=None,
+                          repl_filter=None,
+                          doc_ids=None,
+                          channels_filter=None):
+        """
+        Starts a replication (one-shot or continous) between Lite instances (P2P),
+        Sync Gateways, or Lite <-> Sync Gateways
+
+        :param url: endpoint to start the replication on
+        :param continuous: True = continuous, False = one-shot
+        :param from_url: source url of the replication
+        :param from_db: source db of the replication
+        :param to_url: target url of the replication
+        :param to_db: target db of the replication
+        :param repl_filter: ** Lite only ** Custom filter that can be defined in design doc
+        :param doc_ids: ** Will not work with continuous pull from LITE <- SG ** Doc ids to filter
+            replication by
+        :param channels_filter: ** Only works with pull from Sync Gateway ** This will filter the
+            replication by the array of string channel names
+        """
 
         if from_url is None:
             source = from_db
@@ -907,6 +930,10 @@ class MobileRestClient:
         if repl_filter is not None:
             data["filter"] = repl_filter
 
+        if channels_filter is not None:
+            data["filter"] = "sync_gateway/bychannel"
+            data["query_params"] = {"channels": ",".join(channels_filter)}
+
         if doc_ids is not None:
             data["doc_ids"] = doc_ids
 
@@ -920,7 +947,31 @@ class MobileRestClient:
 
         return replication_id
 
-    def stop_replication(self, url, continuous, from_url=None, from_db=None, to_url=None, to_db=None, repl_filter=None, doc_ids=None):
+    def stop_replication(self,
+                         url,
+                         continuous,
+                         from_url=None, from_db=None,
+                         to_url=None, to_db=None,
+                         repl_filter=None,
+                         doc_ids=None,
+                         channels_filter=None):
+
+        """
+        Starts a replication (one-shot or continous) between Lite instances (P2P),
+        Sync Gateways, or Lite <-> Sync Gateways
+
+        :param url: endpoint to start the replication on
+        :param continuous: True = continuous, False = one-shot
+        :param from_url: source url of the replication
+        :param from_db: source db of the replication
+        :param to_url: target url of the replication
+        :param to_db: target db of the replication
+        :param repl_filter: ** Lite only ** Custom filter that can be defined in design doc
+        :param doc_ids: ** Will not work with continuous pull from LITE <- SG ** Doc ids to filter
+            replication by
+        :param channels_filter: ** Only works with pull from Sync Gateway ** This will filter the
+            replication by the array of string channel names
+        """
 
         if from_url is None:
             source = from_db
@@ -941,6 +992,10 @@ class MobileRestClient:
 
         if repl_filter is not None:
             data["filter"] = repl_filter
+
+        if channels_filter is not None:
+            data["filter"] = "sync_gateway/bychannel"
+            data["query_params"] = {"channels": ",".join(channels_filter)}
 
         if doc_ids is not None:
             data["doc_ids"] = doc_ids

--- a/keywords/MobileRestClient.py
+++ b/keywords/MobileRestClient.py
@@ -904,11 +904,11 @@ class MobileRestClient:
             "target": target
         }
 
-        if filter is not None:
+        if repl_filter is not None:
             data["filter"] = repl_filter
 
         if doc_ids is not None:
-            data["docids"] = doc_ids
+            data["doc_ids"] = doc_ids
 
         resp = self._session.post("{}/_replicate".format(url), data=json.dumps(data))
         log_r(resp)
@@ -939,11 +939,11 @@ class MobileRestClient:
             "target": target
         }
 
-        if filter is not None:
+        if repl_filter is not None:
             data["filter"] = repl_filter
 
         if doc_ids is not None:
-            data["docids"] = doc_ids
+            data["doc_ids"] = doc_ids
 
         resp = self._session.post("{}/_replicate".format(url), data=json.dumps(data))
 
@@ -1011,7 +1011,6 @@ class MobileRestClient:
     def get_replications(self, url):
         """
         Issues a GET on the /_active tasks endpoint and returns the response in the format below:
-
         """
         resp = self._session.get("{}/_active_tasks".format(url))
         resp.raise_for_status()

--- a/keywords/MobileRestClient.py
+++ b/keywords/MobileRestClient.py
@@ -1199,11 +1199,11 @@ class MobileRestClient:
 
             time.sleep(1)
 
-    def add_design_doc(self, url, db, name, view):
+    def add_design_doc(self, url, db, name, doc):
         """
         Keyword that adds a Design Doc to the database
         """
-        resp = self._session.put("{}/{}/_design/{}".format(url, db, name), data=view)
+        resp = self._session.put("{}/{}/_design/{}".format(url, db, name), data=doc)
         log_r(resp)
         resp.raise_for_status()
 

--- a/keywords/MobileRestClient.py
+++ b/keywords/MobileRestClient.py
@@ -886,7 +886,7 @@ class MobileRestClient:
 
         return resp_obj
 
-    def start_replication(self, url, continuous, from_url=None, from_db=None, to_url=None, to_db=None):
+    def start_replication(self, url, continuous, from_url=None, from_db=None, to_url=None, to_db=None, repl_filter=None, doc_ids=None):
 
         if from_url is None:
             source = from_db
@@ -904,6 +904,12 @@ class MobileRestClient:
             "target": target
         }
 
+        if filter is not None:
+            data["filter"] = repl_filter
+
+        if doc_ids is not None:
+            data["docids"] = doc_ids
+
         resp = self._session.post("{}/_replicate".format(url), data=json.dumps(data))
         log_r(resp)
         resp.raise_for_status()
@@ -914,7 +920,7 @@ class MobileRestClient:
 
         return replication_id
 
-    def stop_replication(self, url, continuous, from_url=None, from_db=None, to_url=None, to_db=None):
+    def stop_replication(self, url, continuous, from_url=None, from_db=None, to_url=None, to_db=None, repl_filter=None, doc_ids=None):
 
         if from_url is None:
             source = from_db
@@ -932,6 +938,12 @@ class MobileRestClient:
             "source": source,
             "target": target
         }
+
+        if filter is not None:
+            data["filter"] = repl_filter
+
+        if doc_ids is not None:
+            data["docids"] = doc_ids
 
         resp = self._session.post("{}/_replicate".format(url), data=json.dumps(data))
 

--- a/keywords/utils.py
+++ b/keywords/utils.py
@@ -1,6 +1,8 @@
 import logging
 import os
 import json
+import pdb
+import sys
 
 from robot.api.logger import console
 
@@ -72,3 +74,8 @@ def dump_file_contents_to_logs(filename):
         log_info("Contents of {}: {}".format(filename, open(filename).read()))
     except Exception as e:
         log_info("Error reading {}: {}".format(filename, e))
+
+def breakpoint():
+    for attr in ('stdin', 'stdout', 'stderr'):
+        setattr(sys, attr, getattr(sys, '__%s__' % attr))
+    pdb.set_trace()

--- a/libraries/provision/install_couchbase_server.py
+++ b/libraries/provision/install_couchbase_server.py
@@ -95,7 +95,7 @@ def resolve_cb_nas_url(version, build_number):
         base_url = "http://latestbuilds.hq.couchbase.com/"
     elif version.startswith("4.0") or version.startswith("4.1"):
         base_url = "{}/sherlock/{}".format(cbnas_base_url, build_number)
-    elif version.startswith("4.5"):
+    elif version.startswith("4.5") or version.startswith("4.6"):
         base_url = "{}/watson/{}".format(cbnas_base_url, build_number)
     elif version.startswith("4.7"):
         base_url = "{}/spock/{}".format(cbnas_base_url, build_number)

--- a/libraries/provision/install_sync_gateway.py
+++ b/libraries/provision/install_sync_gateway.py
@@ -22,7 +22,8 @@ class SyncGatewayConfig:
             "1.1.1",
             "1.2.0",
             "1.2.1",
-            "1.3.0"
+            "1.3.0",
+            "1.3.1"
         ]
 
         self.commit = commit

--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # This scripts attempts to setup an environment for running mobile testkit tests.
 # 1. Check that you have Python 2.7 and virtualenv installed
 # 2. Installs venv/ in this directory containing a python 2.7 interpreter

--- a/testsuites/listener/shared/client_sg/listener_replication.py
+++ b/testsuites/listener/shared/client_sg/listener_replication.py
@@ -353,36 +353,24 @@ def multiple_replications_created_with_unique_properties(ls_url, cluster_config)
     )
     assert repl_seven == "repl007", "Replication {} should have id: repl007".format(repl_seven)
 
+    # Start filtered pull from sync gateway to LiteServ
     repl_eight = client.start_replication(
         url=ls_url,
         continuous=True,
         from_url=sg_one_admin,
         from_db=sg_db,
         to_db=ls_db,
-        doc_ids=["doc_1", "doc_2"]
+        channels_filter=["ABC", "CBS"]
     )
     assert repl_eight == "repl008", "Replication {} should have id: repl008".format(repl_eight)
-
-    # Todo: Use sg filters
-    # repl_nine = client.start_replication(
-    #     url=ls_url,
-    #     continuous=True,
-    #     from_url=sg_one_admin,
-    #     from_db=sg_db,
-    #     to_db=ls_db,
-    #     repl_filter="by_type/sample_filter"
-    # )
-    # assert repl_nine == "repl009", "Replication {} should have id: repl009".format(repl_nine)
 
     # Verify 3 replicaitons are running
     replications = client.get_replications(ls_url)
     log_info(replications)
-    assert len(replications) == 3, "Number of replications, Expected: {} Actual: {}".format(
-        3,
+    assert len(replications) == 2, "Number of replications, Expected: {} Actual: {}".format(
+        2,
         len(replications)
     )
-
-    breakpoint()
 
     # Stop repl007
     client.stop_replication(
@@ -393,8 +381,6 @@ def multiple_replications_created_with_unique_properties(ls_url, cluster_config)
         to_db=ls_db
     )
 
-    breakpoint()
-
     # Stop repl008
     client.stop_replication(
         url=ls_url,
@@ -402,22 +388,8 @@ def multiple_replications_created_with_unique_properties(ls_url, cluster_config)
         from_url=sg_one_admin,
         from_db=sg_db,
         to_db=ls_db,
-        doc_ids=["doc_1", "doc_2"]
+        channels_filter=["ABC", "CBS"]
     )
-
-    breakpoint()
-
-    # Stop repl009
-    client.stop_replication(
-        url=ls_url,
-        continuous=True,
-        from_url=sg_one_admin,
-        from_db=sg_db,
-        to_db=ls_db,
-        repl_filter="by_type/sample_filter"
-    )
-
-    breakpoint()
 
     # Verify no replications are running
     replications = client.get_replications(ls_url)

--- a/testsuites/listener/shared/client_sg/listener_replication.py
+++ b/testsuites/listener/shared/client_sg/listener_replication.py
@@ -132,6 +132,7 @@ def large_initial_push_replication(ls_url, cluster_config, num_docs, continuous)
     else:
         assert len(replications) == 0, "No replications should be running"
 
+
 def multiple_replications_not_created_with_same_properties(ls_url, cluster_config):
     sg_db = "db"
     ls_db = "ls_db"
@@ -233,3 +234,56 @@ def multiple_replications_not_created_with_same_properties(ls_url, cluster_confi
         0,
         len(replications)
     )
+
+
+def multiple_replications_created_with_unique_properties(ls_url, cluster_config):
+    sg_db = "db"
+    ls_db = "ls_db"
+
+    sg_one_admin = cluster_config["sync_gateways"][0]["admin"]
+    sg_one_public = cluster_config["sync_gateways"][0]["public"]
+
+    log_info("Running: multiple_replications_created_with_unique_properties")
+    log_info(ls_url)
+    log_info(sg_one_admin)
+    log_info(sg_one_public)
+
+    client = MobileRestClient()
+    client.create_database(url=ls_url, name=ls_db)
+
+    # Start 3 unique push replication requests
+    repl_one = client.start_replication(
+        url=ls_url,
+        continuous=True,
+        from_db=ls_db,
+        to_url=sg_one_admin,
+        to_db=sg_db
+    )
+    assert repl_one == "repl001", "Replication {} should have id: repl001".format(repl_one)
+
+    repl_two = client.start_replication(
+        url=ls_url,
+        continuous=True,
+        from_db=ls_db,
+        to_url=sg_one_admin,
+        to_db=sg_db,
+        doc_ids=["doc_1", "doc_2"]
+    )
+    assert repl_two == "repl002", "Replication {} should have id: repl002".format(repl_two)
+
+    # repl_two = client.start_replication(
+    #     url=ls_url,
+    #     continuous=True,
+    #     from_db=ls_db,
+    #     to_url=sg_one_admin,
+    #     to_db=sg_db,
+    #     repl_filter="filter1"
+    # )
+    #assert repl_two == "repl002", "Replication {} should have id: repl002".format(repl_two)
+
+    replications = client.get_replications(ls_url)
+    assert len(replications) == 2, "Number of replications, Expected: {} Actual: {}".format(
+        2,
+        len(replications)
+    )
+

--- a/testsuites/listener/shared/client_sg/listener_replication.robot
+++ b/testsuites/listener/shared/client_sg/listener_replication.robot
@@ -86,7 +86,21 @@ Multiple Replications Not Created With Same Properties
     ...  ls_url=${ls_url}
     ...  cluster_config=${cluster_hosts}
 
-
+Multiple Replications Created with Unique Properties
+    [Documentation]
+    ...  Regression test for couchbase/couchbase-lite-java-core#1386
+    ...  1. Setup SGW with a remote database name db for an example
+    ...  2. Create a local database such as ls_db
+    ...  3. Send POST /_replicate with source = ls_db, target = http://localhost:4985/db, continuous = true
+    ...  4. Send POST /_replicate with source = ls_db, target = http://localhost:4985/db, continuous = true, doc_ids=["doc1", "doc2"]
+    ...  5. Send POST /_replicate with source = ls_db, target = http://localhost:498\5/db, continuous = true, filter="filter1"
+    ...  6. Make sure that the session_id from each POST /_replicate are different.
+    ...  7. Send GET /_active_tasks to make sure that there are 3 tasks created.
+    ...  8. Send 3 POST /_replicate withe the same parameter as Step 3=5 plus cancel=true to stop those replicators
+    ...  9. Repeat Step 3 - 8 with source = and target = db for testing the pull replicator.
+    Multiple Replications Created with Unique Properties
+    ...  ls_url=${ls_url}
+    ...  cluster_config=${cluster_hosts}
 
 *** Keywords ***
 Setup Test

--- a/testsuites/listener/shared/client_sg/listener_replication.robot
+++ b/testsuites/listener/shared/client_sg/listener_replication.robot
@@ -15,7 +15,7 @@ Library           ${KEYWORDS}/ClusterKeywords.py
 Library           ${KEYWORDS}/SyncGateway.py
 Library           ${KEYWORDS}/CouchbaseServer.py
 Library           ${KEYWORDS}/Logging.py
-Library           listener_initial_replication.py
+Library           listener_replication.py
 
 Test Setup        Setup Test
 Test Teardown     Teardown Test
@@ -25,7 +25,7 @@ ${sg_db}  db
 ${num_docs}  ${10000}
 
 *** Test Cases ***
-Large One Shot Pull Replication
+Large Initial One Shot Pull Replication
     [Documentation]
     ...  1. Prepare sync-gateway to have 10000 documents.
     ...  2. Create a single shot pull replicator and to pull the docs into a database.
@@ -37,7 +37,7 @@ Large One Shot Pull Replication
     ...  num_docs=${num_docs}
     ...  continuous=${False}
 
-Large Continuous Pull Replication
+Large Initial Continuous Pull Replication
     [Documentation]
     ...  1. Prepare sync-gateway to have 10000 documents.
     ...  2. Create a single continuous pull replicator and to pull the docs into a database.
@@ -48,7 +48,7 @@ Large Continuous Pull Replication
     ...  num_docs=${num_docs}
     ...  continuous=${True}
 
-Large One Shot Push Replication
+Large Initial One Shot Push Replication
     [Documentation]
     ...  1. Prepare LiteServ to have 10000 documents.
     ...  2. Create a single shot push replicator and to push the docs into a sync_gateway database.
@@ -59,7 +59,7 @@ Large One Shot Push Replication
     ...  num_docs=${num_docs}
     ...  continuous=${False}
 
-Large Continuous Push Replication
+Large Initial Continuous Push Replication
     [Documentation]
     ...  1. Prepare LiteServ to have 10000 documents.
     ...  2. Create continuous push replicator and to push the docs into a sync_gateway database.
@@ -69,6 +69,23 @@ Large Continuous Push Replication
     ...  cluster_config=${cluster_hosts}
     ...  num_docs=${num_docs}
     ...  continuous=${True}
+
+Multiple Replications Not Created With Same Properties
+    [Documentation]
+    ...  Regression test for https://github.com/couchbase/couchbase-lite-android/issues/939
+    ...  1. Create LiteServ database and launch sync_gateway with database
+    ...  2. Start 5 continuous push replicators with the same source and target
+    ...  3. Make sure the sample replication id is returned
+    ...  4. Check that 1 one replication exists in 'active_tasks'
+    ...  5. Stop the replication with POST /_replicate cancel=true
+    ...  6. Start 5 continuous pull replicators with the same source and target
+    ...  7. Make sure the sample replication id is returned
+    ...  8. Check that 1 one replication exists in 'active_tasks'
+    ...  9. Stop the replication with POST /_replicate cancel=true
+    Multiple Replications Not Created With Same Properties
+    ...  ls_url=${ls_url}
+    ...  cluster_config=${cluster_hosts}
+
 
 
 *** Keywords ***

--- a/testsuites/listener/shared/client_sg/view_indexing.robot
+++ b/testsuites/listener/shared/client_sg/view_indexing.robot
@@ -72,7 +72,7 @@ Stale revision should not be in the index
     ...  from_url=${sg_url_admin}  from_db=${sg_db}
     ...  to_db=${ls_db}
 
-    ${design_doc_id} =  Add Design Doc  url=${ls_url}  db=${ls_db}  name=${d_doc_name}  view=${view}
+    ${design_doc_id} =  Add Design Doc  url=${ls_url}  db=${ls_db}  name=${d_doc_name}  doc=${view}
     ${design_doc} =  Get Doc  url=${ls_url}  db=${ls_db}  doc_id=${design_doc_id}
 
     ${doc_body} =  Create Doc  id=doc_1  content={"hi": "I should be in the view"}  channels=${sg_user_channels}


### PR DESCRIPTION
- add breakpoint() utility method for breaking in native python while executing under robot.
- enhance client.start_replication to allow doc_ids and channel filters
- Fixes #633 (Add test cases)
- Fixes #632 (Add test cases)
- Add support for provisioning CBS 4.6 and SG 1.3.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbaselabs/mobile-testkit/643)
<!-- Reviewable:end -->
