### PR TITLE
Install NTP package and update clock

### DIFF
--- a/libraries/provision/ansible/playbooks/install-common-tools.yml
+++ b/libraries/provision/ansible/playbooks/install-common-tools.yml
@@ -10,6 +10,12 @@
   - name: DEPS | install epel-release
     yum: pkg=epel-release state=latest
 
+  - name: DEPS | install ntp
+    yum: pkg=ntp state=latest
+
+  - name: DEPS | update clock
+    shell: ntpdate 0.us.pool.ntp.org
+
   - name: DEPS | install git
     yum: pkg=git state=latest
 


### PR DESCRIPTION
I just ran into this error :

```
fatal: [ma1]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to validate the SSL certificate for storage.googleapis.com:443. Make sure your managed systems have a valid CA certificate installed. You can use validate_certs=False if you do not need to confirm the servers identity but this is unsafe and not recommended. Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible"}
```

and noticed my clock is wayyyy out of date!

```
[vagrant@localhost tmp]$ date
Fri Jul  1 20:36:45 EDT 2016

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbaselabs/mobile-testkit/645)
<!-- Reviewable:end -->
