### PR TITLE
Remove deprecated CLI options to allow provisioning Spock

### DIFF
--- a/libraries/provision/ansible/playbooks/create-server-buckets.yml
+++ b/libraries/provision/ansible/playbooks/create-server-buckets.yml
@@ -22,7 +22,6 @@
     couchbase_server_password: password
 
     couchbase_server_bucket_type: couchbase
-    couchbase_server_bucket_port: 11211
     couchbase_server_bucket_replica: 1
 
     bucket_names:

--- a/libraries/provision/ansible/playbooks/create-server-buckets.yml
+++ b/libraries/provision/ansible/playbooks/create-server-buckets.yml
@@ -42,7 +42,7 @@
 
   # Create buckets and wait
   - name: COUCHBASE SERVER | Create new buckets
-    shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli bucket-create --cluster={{ couchbase_server_primary_node }}:{{ couchbase_server_admin_port }} --user={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --bucket={{ item }} --bucket-type={{ couchbase_server_bucket_type }} --bucket-port={{ couchbase_server_bucket_port }} --bucket-ramsize={{ couchbase_server_bucket_ram }} --bucket-replica={{ couchbase_server_bucket_replica }} --wait"
+    shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli bucket-create --cluster={{ couchbase_server_primary_node }}:{{ couchbase_server_admin_port }} --user={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --bucket={{ item }} --bucket-type={{ couchbase_server_bucket_type }} --bucket-ramsize={{ couchbase_server_bucket_ram }} --bucket-replica={{ couchbase_server_bucket_replica }} --wait"
     with_items: "{{ bucket_names }}"
     when: couchbase_server_node == couchbase_server_primary_node
 

--- a/libraries/provision/ansible/playbooks/install-couchbase-server-package.yml
+++ b/libraries/provision/ansible/playbooks/install-couchbase-server-package.yml
@@ -73,15 +73,15 @@
       wait_for: port=8091 delay=5 timeout=30
 
     - name: COUCHBASE SERVER | Configure cluster settings (4.0.X and 4.1.X)
-      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli cluster-init -c {{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --user={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --cluster-init-username={{ couchbase_server_admin }} --cluster-init-password={{ couchbase_server_password }} --cluster-init-port={{couchbase_server_admin_port}} --cluster-init-ramsize={{ couchbase_server_cluster_ram }}  --services=data,index,query  --cluster-index-ramsize={{ couchbase_server_index_ram }}"
+      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli cluster-init -c {{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --user={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --cluster-port={{couchbase_server_admin_port}} --cluster-ramsize={{ couchbase_server_cluster_ram }}  --services=data,index,query  --cluster-index-ramsize={{ couchbase_server_index_ram }}"
       when:  "'4.0' in couchbase_server_package_name or '4.1' in couchbase_server_package_name"
 
     - name: COUCHBASE SERVER | Configure cluster settings (4.5.X and up)
-      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli cluster-init -c {{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --user={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --cluster-init-username={{ couchbase_server_admin }} --cluster-init-password={{ couchbase_server_password }} --cluster-init-port={{couchbase_server_admin_port}} --cluster-init-ramsize={{ couchbase_server_cluster_ram }}  --services=data,index,query  --cluster-index-ramsize={{ couchbase_server_index_ram }}  --index-storage-setting=default"
+      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli cluster-init -c {{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --user={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --cluster-port={{couchbase_server_admin_port}} --cluster-ramsize={{ couchbase_server_cluster_ram }}  --services=data,index,query  --cluster-index-ramsize={{ couchbase_server_index_ram }}  --index-storage-setting=default"
       when:  "not '4.0' in couchbase_server_package_name and not '4.1' in couchbase_server_package_name"
 
     - name: COUCHBASE SERVER | Initialize primary node
-      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli node-init -c {{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --user={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --cluster-init-username={{ couchbase_server_admin }} --node-init-hostname={{ couchbase_server_node }}"
+      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli node-init -c {{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --user={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --node-init-hostname={{ couchbase_server_node }}"
       when: "{{ cb_major_version['stdout'] }} != 2"
 
     - name: COUCHBASE SERVER | Wait for node to be listening on port 8091

--- a/libraries/provision/ansible/playbooks/install-couchbase-server-package.yml
+++ b/libraries/provision/ansible/playbooks/install-couchbase-server-package.yml
@@ -24,7 +24,6 @@
     couchbase_server_node: "{{ hostvars[inventory_hostname]['ansible_host'] }}"
 
     couchbase_server_bucket_type: couchbase
-    couchbase_server_bucket_port: 11211
     couchbase_server_bucket_replica: 1
     couchbase_server_bucket_ram: "{{ ((couchbase_server_cluster_ram|int)*0.5)|int }}"
 

--- a/libraries/provision/ansible/playbooks/install-sync-gateway-package.yml
+++ b/libraries/provision/ansible/playbooks/install-sync-gateway-package.yml
@@ -28,7 +28,6 @@
     couchbase_server_password: password
 
     couchbase_server_bucket_type: couchbase
-    couchbase_server_bucket_port: 11211
     couchbase_server_bucket_replica: 1
     couchbase_server_cluster_ram: "{{ ((ansible_memtotal_mb|int)*0.8)|int - 512 }}"
     couchbase_server_bucket_ram: "{{ ((couchbase_server_cluster_ram|int)*0.5)|int }}"

--- a/libraries/provision/ansible/playbooks/install-sync-gateway-source.yml
+++ b/libraries/provision/ansible/playbooks/install-sync-gateway-source.yml
@@ -27,7 +27,6 @@
     couchbase_server_password: password
 
     couchbase_server_bucket_type: couchbase
-    couchbase_server_bucket_port: 11211
     couchbase_server_bucket_replica: 1
     couchbase_server_cluster_ram: "{{ ((ansible_memtotal_mb|int)*0.8)|int - 512 }}"
     couchbase_server_bucket_ram: "{{ ((couchbase_server_cluster_ram|int)*0.5)|int }}"

--- a/libraries/provision/ansible/playbooks/tasks/flush-server-buckets.yml
+++ b/libraries/provision/ansible/playbooks/tasks/flush-server-buckets.yml
@@ -14,7 +14,7 @@
 
 # Create buckets and wait
 - name: COUCHBASE SERVER | Create new buckets
-  shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli bucket-create --cluster={{ couchbase_server_primary_node }}:{{ couchbase_server_admin_port }} --user={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --bucket={{ item }} --bucket-type={{ couchbase_server_bucket_type }} --bucket-port={{ couchbase_server_bucket_port }} --bucket-ramsize={{ couchbase_server_bucket_ram }} --bucket-replica={{ couchbase_server_bucket_replica }} --wait"
+  shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli bucket-create --cluster={{ couchbase_server_primary_node }}:{{ couchbase_server_admin_port }} --user={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --bucket={{ item }} --bucket-type={{ couchbase_server_bucket_type }} --bucket-ramsize={{ couchbase_server_bucket_ram }} --bucket-replica={{ couchbase_server_bucket_replica }} --wait"
   with_items:
     - data-bucket
     - index-bucket


### PR DESCRIPTION
A few flags have been removed in the Spock CLI. They are:
- `--bucket-port`
- `--cluster-init-username`
- `--cluster-init-password`
- `--cluster-init-ramsize`

 I have tested with
- 4.0.0
- 4.1.1
- 4.5.0
- 4.7.0-XXX

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbaselabs/mobile-testkit/647)
<!-- Reviewable:end -->
