### PR TITLE
Feature/test multiple replicators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ conf/hosts.ini
 
 provisioning_config*
 !libraries/utilities/provisioning_config_parser.py
+*.retry
 
 results.xml
 test-framework.log

--- a/README.md
+++ b/README.md
@@ -628,13 +628,16 @@ Wait until the resources are up, then create the `pool.json` file by hand accord
 Debugging
 =========
 
-When developing custom keyworks, you may want to break and inspect at a certain point. Adding the following lines will do what you need
+When developing custom keyworks, you may want to break and inspect at a certain point in the python code. 
+Adding the following lines will do what you need
 
 ```
-import pdb
-for attr in ('stdin', 'stdout', 'stderr'):
-    setattr(sys, attr, getattr(sys, '__%s__' % attr))
-pdb.set_trace()
+from keywords.utils import breakpoint
+
+for thing in things:
+    breakpoint()
+    # break here ^
+    thing.do()
 ```
 
 They will redirect the stdin, stdout, and stderr from robot back to your control

--- a/keywords/ChangesTracker.py
+++ b/keywords/ChangesTracker.py
@@ -35,10 +35,13 @@ class ChangesTracker:
                     # Stored the doc with the list of rev changes
                     self.processed_changes[doc["id"]] = doc["changes"]
 
-    def start(self, timeout=1000):
+    def start(self, timeout=1000, request_timeout=None):
         """
         Start a longpoll changes feed and and store the results in self.processed changes
         """
+
+        # convert to seconds for use with requests lib api
+        request_timeout /= 1000
 
         auth_type = get_auth_type(self.auth)
         current_seq_num = 0
@@ -57,11 +60,11 @@ class ChangesTracker:
             log_info("Making Request")
 
             if auth_type == AuthType.session:
-                resp = requests.post("{}/_changes".format(self.endpoint), data=json.dumps(data), cookies=dict(SyncGatewaySession=self.auth[1]), stream=True)
+                resp = requests.post("{}/_changes".format(self.endpoint), data=json.dumps(data), cookies=dict(SyncGatewaySession=self.auth[1]), timeout=request_timeout)
             elif auth_type == AuthType.http_basic:
-                resp = requests.post("{}/_changes".format(self.endpoint), data=json.dumps(data), auth=self.auth, stream=True)
+                resp = requests.post("{}/_changes".format(self.endpoint), data=json.dumps(data), auth=self.auth, timeout=request_timeout)
             else:
-                resp = requests.post("{}/_changes".format(self.endpoint), data=json.dumps(data), stream=True)
+                resp = requests.post("{}/_changes".format(self.endpoint), data=json.dumps(data), timeout=request_timeout)
 
             log_r(resp)
             resp.raise_for_status()

--- a/keywords/ChangesTracker.py
+++ b/keywords/ChangesTracker.py
@@ -35,7 +35,7 @@ class ChangesTracker:
                     # Stored the doc with the list of rev changes
                     self.processed_changes[doc["id"]] = doc["changes"]
 
-    def start(self, timeout=1000, request_timeout=None):
+    def start(self, timeout=1000, heartbeat=None, request_timeout=None):
         """
         Start a longpoll changes feed and and store the results in self.processed changes
         """
@@ -53,11 +53,14 @@ class ChangesTracker:
             data = {
                 "feed": "longpoll",
                 "style": "all_docs",
-                "timeout": timeout,
                 "since": current_seq_num
             }
 
-            log_info("Making Request")
+            if timeout is not None:
+                data["timeout"] = timeout
+
+            if heartbeat is not None:
+                data["heartbeat"] = heartbeat
 
             if auth_type == AuthType.session:
                 resp = requests.post("{}/_changes".format(self.endpoint), data=json.dumps(data), cookies=dict(SyncGatewaySession=self.auth[1]), timeout=request_timeout)

--- a/keywords/ChangesTracker.py
+++ b/keywords/ChangesTracker.py
@@ -11,7 +11,7 @@ from keywords.utils import log_info
 
 class ChangesTracker:
 
-    def __init__(self, url, db, auth):
+    def __init__(self, url, db, auth=None):
         self.processed_changes = {}
         self.endpoint = "{}/{}".format(url, db)
         self.auth = auth
@@ -35,7 +35,7 @@ class ChangesTracker:
                     # Stored the doc with the list of rev changes
                     self.processed_changes[doc["id"]] = doc["changes"]
 
-    def start(self):
+    def start(self, timeout=1000):
         """
         Start a longpoll changes feed and and store the results in self.processed changes
         """
@@ -50,7 +50,7 @@ class ChangesTracker:
             data = {
                 "feed": "longpoll",
                 "style": "all_docs",
-                "timeout": 1000,
+                "timeout": timeout,
                 "since": current_seq_num
             }
 

--- a/keywords/ClusterKeywords.py
+++ b/keywords/ClusterKeywords.py
@@ -13,6 +13,7 @@ from SyncGateway import verify_sync_gateway_version
 from SyncGateway import verify_sg_accel_version
 from libraries.testkit.cluster import Cluster
 
+
 class ClusterKeywords:
 
     def get_cluster_topology(self, cluster_config):

--- a/keywords/LiteServ.py
+++ b/keywords/LiteServ.py
@@ -260,7 +260,7 @@ class LiteServ:
         shutil.rmtree(extracted_file_name)
         os.chdir("../..")
 
-    def verify_liteserv_launched(self, host, port, version_build):
+    def verify_liteserv_launched(self, platform, host, port, version_build):
 
         url = "http://{}:{}".format(host, port)
         logging.info("Verifying LiteServ running at {}".format(url))
@@ -294,6 +294,16 @@ class LiteServ:
             # Android
             lite_version = resp_json["version"]
             is_android = True
+
+        # Validate the running platform is the expected platform
+        if platform == "macosx":
+            assert is_macosx, "Tried to run macosx but different platform running on {}:{} ...".format(host, port)
+        elif platform == "android":
+            assert is_android, "Tried to run android but different platform running on {}:{} ...".format(host, port)
+        elif platform == "net":
+            assert  is_net, "Tried to run net but different platform running on {}:{} ...".format(host, port)
+        else:
+            raise ValueError("Unsupported platform: {}".format(platform))
 
         # Validate that the version launched is the expected LiteServ version
         # Mac OSX - LiteServ: 1.2.1 (build 13)

--- a/keywords/LiteServ.py
+++ b/keywords/LiteServ.py
@@ -28,7 +28,7 @@ class LiteServ:
     def __init__(self):
         self._session = Session()
 
-    def get_download_package_name(self, platform, version_build):
+    def get_download_package_name(self, platform, version_build, storage_engine):
 
         if platform == "macosx":
             package_name = "couchbase-lite-macosx-enterprise_{}.zip".format(version_build)
@@ -37,7 +37,10 @@ class LiteServ:
             if version == "1.2.1":
                 package_name = "couchbase-lite-android-liteserv-SQLite-{}-debug.apk".format(version)
             else:
-                package_name = "couchbase-lite-android-liteserv-SQLite-{}-debug.apk".format(version_build)
+                if storage_engine == "SQLite":
+                    package_name = "couchbase-lite-android-liteserv-SQLite-{}-debug.apk".format(version_build)
+                else:
+                    package_name = "couchbase-lite-android-liteserv-SQLCipher-ForestDB-Encryption-{}-debug.apk".format(version_build)
         elif platform == "net":
             package_name = "LiteServ.zip"
         else:
@@ -47,7 +50,7 @@ class LiteServ:
 
         return package_name
 
-    def get_binary(self, platform, version_build):
+    def get_binary(self, platform, version_build, storage_engine):
 
         version, build = version_and_build(version_build)
 
@@ -57,7 +60,10 @@ class LiteServ:
             if version == "1.2.1":
                 expected_binary = "couchbase-lite-android-liteserv-SQLite-{}-debug.apk".format(version)
             else:
-                expected_binary = "couchbase-lite-android-liteserv-SQLite-{}-debug.apk".format(version_build)
+                if storage_engine == "SQLite":
+                    expected_binary = "couchbase-lite-android-liteserv-SQLite-{}-debug.apk".format(version_build)
+                else:
+                    expected_binary = "couchbase-lite-android-liteserv-SQLCipher-ForestDB-Encryption-{}-debug.apk".format(version_build)
         elif platform == "net":
             expected_binary = "couchbase-lite-net-{}-liteserv/LiteServ.exe".format(version_build)
         else:
@@ -67,11 +73,11 @@ class LiteServ:
 
         return expected_binary
 
-    def get_download_url(self, platform, version_build):
+    def get_download_url(self, platform, version_build, storage_engine):
         log_info("Downloading {} LiteServ, version: {}".format(platform, version_build))
 
         version, build = version_and_build(version_build)
-        file_name = self.get_download_package_name(platform, version_build)
+        file_name = self.get_download_package_name(platform, version_build, storage_engine)
 
         if platform == "macosx":
             if version == "1.2.0":
@@ -90,13 +96,15 @@ class LiteServ:
 
         return url
 
-    def download_liteserv(self, platform, version):
+    def download_liteserv(self, platform, version, storage_engine):
 
-        supported_platforms = ["macosx", "android", "net"]
-        if platform not in supported_platforms:
-            raise ValueError("Unsupported version of LiteServ")
+        if platform not in ["macosx", "android", "net"]:
+            raise ValueError("Unsupported platform of LiteServ: ".format(platform))
 
-        expected_binary = self.get_binary(platform, version)
+        if storage_engine not in ["SQLite", "SQLCipher", "ForestDB", "ForestDB+Encryption"]:
+            raise ValueError("Unsupported storage engine for LiteServ: {}".format(storage_engine))
+
+        expected_binary = self.get_binary(platform, version, storage_engine)
         logging.info("{}/{}".format(BINARY_DIR, expected_binary))
 
         # Check if package is already downloaded and return if it is preset
@@ -114,7 +122,7 @@ class LiteServ:
             return
 
         # Download the packages to binary directory
-        url = self.get_download_url(platform, version)
+        url = self.get_download_url(platform, version, storage_engine)
         file_name = url.split("/")[-1]
         log_info("Downloading {} -> {}/{}".format(url, BINARY_DIR, file_name))
         resp = requests.get(url)
@@ -148,9 +156,9 @@ class LiteServ:
                 # Remove .zip file
                 os.remove("{}/{}".format(BINARY_DIR, file_name))
 
-    def get_liteserv_binary_path(self, platform, version):
+    def get_liteserv_binary_path(self, platform, version, storage_engine):
 
-        binary_name = self.get_binary(platform, version)
+        binary_name = self.get_binary(platform, version, storage_engine)
 
         if platform == "macosx" or platform == "net":
             binary_path = "{}/{}".format(BINARY_DIR, binary_name)
@@ -160,9 +168,9 @@ class LiteServ:
         log_info("Launching binary: {}".format(binary_path))
         return binary_path
 
-    def install_apk(self, version_build):
+    def install_apk(self, version_build, storage_engine):
 
-        binary = self.get_binary("android", version_build)
+        binary = self.get_binary("android", version_build, storage_engine)
 
         apk_path = "{}/{}".format(BINARY_DIR, binary)
         log_info("Installing: {}".format(apk_path))

--- a/keywords/MobileRestClient.py
+++ b/keywords/MobileRestClient.py
@@ -1171,7 +1171,7 @@ class MobileRestClient:
 
         return resp.json()
 
-    def verify_docs_present(self, url, db, expected_docs, auth=None):
+    def verify_docs_present(self, url, db, expected_docs, auth=None, timeout=CLIENT_REQUEST_TIMEOUT):
         """
         Verifies the expected docs are present in the database using a polling loop with
         POST _all_docs with Listener and a POST _bulk_get for sync_gateway
@@ -1199,7 +1199,7 @@ class MobileRestClient:
         start = time.time()
         while True:
 
-            if time.time() - start > CLIENT_REQUEST_TIMEOUT:
+            if time.time() - start > timeout:
                 raise Exception("Verify Docs Present: TIMEOUT")
 
             if server_type == ServerType.listener:
@@ -1250,7 +1250,8 @@ class MobileRestClient:
                     missing_docs.append(resp_doc)
                     all_docs_returned = False
 
-            logging.info("Missing Docs = {}".format(missing_docs))
+            logging.debug("Missing Docs = {}".format(missing_docs))
+            log_info("Num missing docs: {}".format(len(missing_docs)))
             # Issue the request again, docs my still be replicating
             if not all_docs_returned:
                 logging.info("Retrying to verify all docs are present ...")

--- a/keywords/MobileRestClient.py
+++ b/keywords/MobileRestClient.py
@@ -183,7 +183,8 @@ class MobileRestClient:
                 "ok": True
             }
 
-            assert resp.json() == expected_response, "Unexpected _session response from Listener"
+            resp_obj = resp.json()
+            assert resp_obj == expected_response, "Unexpected _session response from Listener"
 
         else:
             # Sync Gateway
@@ -195,9 +196,7 @@ class MobileRestClient:
             resp_obj = resp.json()
             assert resp_obj["ok"], "Make sure response includes 'ok'"
 
-            return resp.json()
-
-        return resp.json()
+        return resp_obj
 
     def request_session(self, url, db, name, password=None, ttl=86400):
         data = {

--- a/keywords/MobileRestClient.py
+++ b/keywords/MobileRestClient.py
@@ -323,6 +323,19 @@ class MobileRestClient:
         resp_obj = resp.json()
         return resp_obj["db_name"]
 
+    def get_databases(self, url):
+        """
+        Gets the databases for LiteServ or sync_gateway
+        :param url: url of running service
+        :return: array of database names
+        """
+
+        resp = self._session.get("{}/_all_dbs".format(url))
+        log_r(resp)
+        resp.raise_for_status()
+
+        return resp.json()
+
     def compact_database(self, url, db):
         """
         POST /{db}/_compact and will verify compaction by

--- a/keywords/MobileRestClient.py
+++ b/keywords/MobileRestClient.py
@@ -886,7 +886,30 @@ class MobileRestClient:
 
         return resp_obj
 
-    def start_replication(self, url, continuous, from_url=None, from_db=None, to_url=None, to_db=None, repl_filter=None, doc_ids=None):
+    def start_replication(self,
+                          url,
+                          continuous,
+                          from_url=None, from_db=None,
+                          to_url=None, to_db=None,
+                          repl_filter=None,
+                          doc_ids=None,
+                          channels_filter=None):
+        """
+        Starts a replication (one-shot or continous) between Lite instances (P2P),
+        Sync Gateways, or Lite <-> Sync Gateways
+
+        :param url: endpoint to start the replication on
+        :param continuous: True = continuous, False = one-shot
+        :param from_url: source url of the replication
+        :param from_db: source db of the replication
+        :param to_url: target url of the replication
+        :param to_db: target db of the replication
+        :param repl_filter: ** Lite only ** Custom filter that can be defined in design doc
+        :param doc_ids: ** Will not work with continuous pull from LITE <- SG ** Doc ids to filter
+            replication by
+        :param channels_filter: ** Only works with pull from Sync Gateway ** This will filter the
+            replication by the array of string channel names
+        """
 
         if from_url is None:
             source = from_db
@@ -907,6 +930,10 @@ class MobileRestClient:
         if repl_filter is not None:
             data["filter"] = repl_filter
 
+        if channels_filter is not None:
+            data["filter"] = "sync_gateway/bychannel"
+            data["query_params"] = {"channels": ",".join(channels_filter)}
+
         if doc_ids is not None:
             data["doc_ids"] = doc_ids
 
@@ -920,7 +947,31 @@ class MobileRestClient:
 
         return replication_id
 
-    def stop_replication(self, url, continuous, from_url=None, from_db=None, to_url=None, to_db=None, repl_filter=None, doc_ids=None):
+    def stop_replication(self,
+                         url,
+                         continuous,
+                         from_url=None, from_db=None,
+                         to_url=None, to_db=None,
+                         repl_filter=None,
+                         doc_ids=None,
+                         channels_filter=None):
+
+        """
+        Starts a replication (one-shot or continous) between Lite instances (P2P),
+        Sync Gateways, or Lite <-> Sync Gateways
+
+        :param url: endpoint to start the replication on
+        :param continuous: True = continuous, False = one-shot
+        :param from_url: source url of the replication
+        :param from_db: source db of the replication
+        :param to_url: target url of the replication
+        :param to_db: target db of the replication
+        :param repl_filter: ** Lite only ** Custom filter that can be defined in design doc
+        :param doc_ids: ** Will not work with continuous pull from LITE <- SG ** Doc ids to filter
+            replication by
+        :param channels_filter: ** Only works with pull from Sync Gateway ** This will filter the
+            replication by the array of string channel names
+        """
 
         if from_url is None:
             source = from_db
@@ -941,6 +992,10 @@ class MobileRestClient:
 
         if repl_filter is not None:
             data["filter"] = repl_filter
+
+        if channels_filter is not None:
+            data["filter"] = "sync_gateway/bychannel"
+            data["query_params"] = {"channels": ",".join(channels_filter)}
 
         if doc_ids is not None:
             data["doc_ids"] = doc_ids

--- a/keywords/MobileRestClient.py
+++ b/keywords/MobileRestClient.py
@@ -904,11 +904,11 @@ class MobileRestClient:
             "target": target
         }
 
-        if filter is not None:
+        if repl_filter is not None:
             data["filter"] = repl_filter
 
         if doc_ids is not None:
-            data["docids"] = doc_ids
+            data["doc_ids"] = doc_ids
 
         resp = self._session.post("{}/_replicate".format(url), data=json.dumps(data))
         log_r(resp)
@@ -939,11 +939,11 @@ class MobileRestClient:
             "target": target
         }
 
-        if filter is not None:
+        if repl_filter is not None:
             data["filter"] = repl_filter
 
         if doc_ids is not None:
-            data["docids"] = doc_ids
+            data["doc_ids"] = doc_ids
 
         resp = self._session.post("{}/_replicate".format(url), data=json.dumps(data))
 
@@ -1011,7 +1011,6 @@ class MobileRestClient:
     def get_replications(self, url):
         """
         Issues a GET on the /_active tasks endpoint and returns the response in the format below:
-
         """
         resp = self._session.get("{}/_active_tasks".format(url))
         resp.raise_for_status()

--- a/keywords/MobileRestClient.py
+++ b/keywords/MobileRestClient.py
@@ -336,6 +336,19 @@ class MobileRestClient:
 
         return resp.json()
 
+    def get_database(self, url, db_name):
+        """
+        Gets the databases for LiteServ or sync_gateway
+        :param url: url of running service
+        :return: array of database names
+        """
+
+        resp = self._session.get("{}/{}".format(url, db_name))
+        log_r(resp)
+        resp.raise_for_status()
+
+        return resp.json()
+
     def compact_database(self, url, db):
         """
         POST /{db}/_compact and will verify compaction by

--- a/keywords/MobileRestClient.py
+++ b/keywords/MobileRestClient.py
@@ -1199,11 +1199,11 @@ class MobileRestClient:
 
             time.sleep(1)
 
-    def add_design_doc(self, url, db, name, view):
+    def add_design_doc(self, url, db, name, doc):
         """
         Keyword that adds a Design Doc to the database
         """
-        resp = self._session.put("{}/{}/_design/{}".format(url, db, name), data=view)
+        resp = self._session.put("{}/{}/_design/{}".format(url, db, name), data=doc)
         log_r(resp)
         resp.raise_for_status()
 

--- a/keywords/MobileRestClient.py
+++ b/keywords/MobileRestClient.py
@@ -235,7 +235,7 @@ class MobileRestClient:
 
         return cookie_name, session_id
 
-    def get_session_header(self, url, db, name, password=None, ttl=86400):
+    def create_session_header(self, url, db, name, password=None, ttl=86400):
         """
         Issues a POST to the public _session enpoint on sync_gateway for a user.
         Return the entire 'Set-Cookie' header. This is useful for creating authenticated

--- a/keywords/MobileRestClient.py
+++ b/keywords/MobileRestClient.py
@@ -886,7 +886,7 @@ class MobileRestClient:
 
         return resp_obj
 
-    def start_replication(self, url, continuous, from_url=None, from_db=None, to_url=None, to_db=None):
+    def start_replication(self, url, continuous, from_url=None, from_db=None, to_url=None, to_db=None, repl_filter=None, doc_ids=None):
 
         if from_url is None:
             source = from_db
@@ -904,6 +904,12 @@ class MobileRestClient:
             "target": target
         }
 
+        if filter is not None:
+            data["filter"] = repl_filter
+
+        if doc_ids is not None:
+            data["docids"] = doc_ids
+
         resp = self._session.post("{}/_replicate".format(url), data=json.dumps(data))
         log_r(resp)
         resp.raise_for_status()
@@ -914,7 +920,7 @@ class MobileRestClient:
 
         return replication_id
 
-    def stop_replication(self, url, continuous, from_url=None, from_db=None, to_url=None, to_db=None):
+    def stop_replication(self, url, continuous, from_url=None, from_db=None, to_url=None, to_db=None, repl_filter=None, doc_ids=None):
 
         if from_url is None:
             source = from_db
@@ -932,6 +938,12 @@ class MobileRestClient:
             "source": source,
             "target": target
         }
+
+        if filter is not None:
+            data["filter"] = repl_filter
+
+        if doc_ids is not None:
+            data["docids"] = doc_ids
 
         resp = self._session.post("{}/_replicate".format(url), data=json.dumps(data))
 

--- a/keywords/SyncGateway.py
+++ b/keywords/SyncGateway.py
@@ -13,6 +13,7 @@ from utils import hostname_for_url
 
 from libraries.provision.ansible_runner import AnsibleRunner
 
+
 def get_sync_gateway_version(host):
     resp = requests.get("http://{}:4984".format(host))
     log_r(resp)

--- a/keywords/constants.py
+++ b/keywords/constants.py
@@ -4,6 +4,7 @@ BINARY_DIR = "deps/binaries"
 LATEST_BUILDS = "http://latestbuilds.hq.couchbase.com"
 RESULTS_DIR = "results"
 CLUSTER_CONFIGS_DIR = "resources/cluster_configs"
+SYNC_GATEWAY_CONFIGS = "resources/sync_gateway_configs"
 DATA_DIR = "resources/data"
 
 MAX_RETRIES = 5

--- a/keywords/utils.py
+++ b/keywords/utils.py
@@ -1,6 +1,8 @@
 import logging
 import os
 import json
+import pdb
+import sys
 
 from robot.api.logger import console
 
@@ -72,3 +74,8 @@ def dump_file_contents_to_logs(filename):
         log_info("Contents of {}: {}".format(filename, open(filename).read()))
     except Exception as e:
         log_info("Error reading {}: {}".format(filename, e))
+
+def breakpoint():
+    for attr in ('stdin', 'stdout', 'stderr'):
+        setattr(sys, attr, getattr(sys, '__%s__' % attr))
+    pdb.set_trace()

--- a/libraries/provision/install_couchbase_server.py
+++ b/libraries/provision/install_couchbase_server.py
@@ -95,7 +95,7 @@ def resolve_cb_nas_url(version, build_number):
         base_url = "http://latestbuilds.hq.couchbase.com/"
     elif version.startswith("4.0") or version.startswith("4.1"):
         base_url = "{}/sherlock/{}".format(cbnas_base_url, build_number)
-    elif version.startswith("4.5"):
+    elif version.startswith("4.5") or version.startswith("4.6"):
         base_url = "{}/watson/{}".format(cbnas_base_url, build_number)
     elif version.startswith("4.7"):
         base_url = "{}/spock/{}".format(cbnas_base_url, build_number)

--- a/resources/common.robot
+++ b/resources/common.robot
@@ -34,7 +34,7 @@ Install LiteServ
     ...  The LiteServ binaries are located in deps/.
     [Arguments]  ${platform}  ${version}  ${storage_engine}
     [Timeout]       2 minutes
-    Run Keyword If  "${platform}" == "android"  Install Apk  ${version}  ELSE  Log  No install need
+    Run Keyword If  "${platform}" == "android"  Install Apk  ${version}  ${storage_engine}  ELSE  Log  No install need
 
 Start LiteServ
     [Documentation]   Starts LiteServ for a specific platform.
@@ -64,7 +64,7 @@ Start MacOSX LiteServ
     [Arguments]  ${version}  ${host}  ${port}  ${storage_engine}
     [Timeout]       1 minute
 
-    ${binary_path} =  Get LiteServ Binary Path  platform=macosx  version=${version}
+    ${binary_path} =  Get LiteServ Binary Path  platform=macosx  version=${version}  storage_engine=${storage_engine}
 
      # Get a list of db names / password for running LiteServ with encrypted databases
     @{db_name_passwords} =  Run Keyword If  '${storage_engine}' == 'ForestDB+Encryption' or '${storage_engine}' == 'SQLCipher'
@@ -130,7 +130,7 @@ Start Net LiteServ
     ...  The LiteServ binaries are located in deps/.
     [Arguments]  ${version}  ${host}  ${port}  ${storage_engine}
     [Timeout]       1 minute
-    ${binary_path} =  Get LiteServ Binary Path  platform=net  version=${version}
+    ${binary_path} =  Get LiteServ Binary Path  platform=net  version=${version}  storage_engine=${storage_engine}
 
     # Get a list of db names / password for running LiteServ with encrypted databases
     @{db_name_passwords} =  Run Keyword If  '${storage_engine}' == 'ForestDB+Encryption' or '${storage_engine}' == 'SQLCipher'

--- a/resources/common.robot
+++ b/resources/common.robot
@@ -46,7 +46,7 @@ Start LiteServ
     ${ls_url} =  Run Keyword If  "${platform}" == "android"  Start Android LiteServ                       host=${host}  port=${port}  storage_engine=${storage_engine}
     ${ls_url} =  Run Keyword If  "${platform}" == "net"      Start Net LiteServ       version=${version}  host=${host}  port=${port}  storage_engine=${storage_engine}
 
-    ${ls_url} =  Verify LiteServ Launched  host=${host}  port=${port}  version_build=${version}
+    ${ls_url} =  Verify LiteServ Launched  platform=${platform}  host=${host}  port=${port}  version_build=${version}
     [return]  ${ls_url}
 
 Shutdown LiteServ

--- a/resources/sync_gateway_configs/walrus-user.json
+++ b/resources/sync_gateway_configs/walrus-user.json
@@ -1,0 +1,20 @@
+{
+  "interface": ":4984",
+  "adminInterface": "0.0.0.0:4985",
+  "log": [
+    "*"
+  ],
+  "databases": {
+    "db": {
+      "server": "walrus:",
+      "users": {
+        "user_1": {
+          "admin_channels": [
+            "ABC"
+          ],
+          "password": "foo"
+        }
+      }
+    }
+  }
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # This scripts attempts to setup an environment for running mobile testkit tests.
 # 1. Check that you have Python 2.7 and virtualenv installed
 # 2. Installs venv/ in this directory containing a python 2.7 interpreter

--- a/testsuites/listener/shared/client_client/__init__.robot
+++ b/testsuites/listener/shared/client_client/__init__.robot
@@ -12,8 +12,8 @@ Library           ${KEYWORDS}/LiteServ.py
 Setup Suite
     [Documentation]  Download, install, and launch LiteServ.
 
-    Download LiteServ  platform=${LITESERV_ONE_PLATFORM}  version=${LITESERV_ONE_VERSION}
-    Download LiteServ  platform=${LITESERV_TWO_PLATFORM}  version=${LITESERV_TWO_VERSION}
+    Download LiteServ  platform=${LITESERV_ONE_PLATFORM}  version=${LITESERV_ONE_VERSION}  storage_engine=${LITESERV_ONE_STORAGE_ENGINE}
+    Download LiteServ  platform=${LITESERV_TWO_PLATFORM}  version=${LITESERV_TWO_VERSION}  storage_engine=${LITESERV_TWO_STORAGE_ENGINE}
 
     Install LiteServ  platform=${LITESERV_ONE_PLATFORM}  version=${LITESERV_ONE_VERSION}  storage_engine=${LITESERV_ONE_STORAGE_ENGINE}
     Install LiteServ  platform=${LITESERV_TWO_PLATFORM}  version=${LITESERV_TWO_VERSION}  storage_engine=${LITESERV_TWO_STORAGE_ENGINE}

--- a/testsuites/listener/shared/client_sg/__init__.robot
+++ b/testsuites/listener/shared/client_sg/__init__.robot
@@ -14,7 +14,7 @@ Test Timeout      10 minutes
 *** Keywords ***
 Setup Suite
     [Documentation]  Download, install, and launch LiteServ.
-    Download LiteServ  platform=${PLATFORM}  version=${LITESERV_VERSION}
+    Download LiteServ  platform=${PLATFORM}  version=${LITESERV_VERSION}  storage_engine=${LITESERV_STORAGE_ENGINE}
     Install LiteServ   platform=${PLATFORM}  version=${LITESERV_VERSION}  storage_engine=${LITESERV_STORAGE_ENGINE}
 
     Set Environment Variable  CLUSTER_CONFIG  ${CLUSTER_CONFIGS}/1sg

--- a/testsuites/listener/shared/client_sg/listener_changes.py
+++ b/testsuites/listener/shared/client_sg/listener_changes.py
@@ -30,6 +30,9 @@ def longpoll_changes_termination_timeout(ls_url, cluster_config):
             request_timeout=2000
         ) for _ in range(30)]
 
+        for futures in as_completed(futures):
+            log_info("Future _changes loop complete")
+
     log_info("Futures exited")
 
     # make sure client can still take connections
@@ -59,6 +62,9 @@ def longpoll_changes_termination_heartbeat(ls_url, cluster_config):
             heartbeat=5000,
             request_timeout=2000
         ) for _ in range(30)]
+
+        for futures in as_completed(futures):
+            log_info("Future _changes loop complete")
 
     log_info("Futures exited")
 

--- a/testsuites/listener/shared/client_sg/listener_changes.py
+++ b/testsuites/listener/shared/client_sg/listener_changes.py
@@ -9,12 +9,7 @@ from keywords.MobileRestClient import MobileRestClient
 from keywords.ChangesTracker import ChangesTracker
 
 
-def start_changes_tracking(url, db):
-    ct = ChangesTracker(url, db)
-    ct.start(timeout=5000, request_timeout=2000)
-    return ct
-
-def longpoll_changes_termination(ls_url, cluster_config):
+def longpoll_changes_termination_timeout(ls_url, cluster_config):
     log_info("ls_url: {}".format(ls_url))
     log_info("cluster_config: {}".format(cluster_config))
     log_info("Running 'longpoll_changes_termination' ...")
@@ -25,22 +20,53 @@ def longpoll_changes_termination(ls_url, cluster_config):
     client = MobileRestClient()
     client.create_database(ls_url, ls_db)
 
+    ct = ChangesTracker(ls_url, ls_db)
+
     with ThreadPoolExecutor(max_workers=35) as executor:
 
         futures = [executor.submit(
-            start_changes_tracking,
-            ls_url,
-            ls_db
+            ct.start,
+            timeout=5000,
+            request_timeout=2000
         ) for _ in range(30)]
-
-        # for future in as_completed(futures):
-        #     future.stop()
 
     log_info("Futures exited")
 
     # make sure client can still take connections
     dbs = client.get_databases(url=ls_url)
     log_info(dbs)
+    database = client.get_database(url=ls_url, db_name=ls_db)
+    log_info(database)
+
+
+def longpoll_changes_termination_heartbeat(ls_url, cluster_config):
+    log_info("ls_url: {}".format(ls_url))
+    log_info("cluster_config: {}".format(cluster_config))
+    log_info("Running 'longpoll_changes_termination' ...")
+
+    ls_db = "ls_db"
+    sg_url = cluster_config["sync_gateways"][0]["admin"]
+
+    client = MobileRestClient()
+    client.create_database(ls_url, ls_db)
+
+    ct = ChangesTracker(ls_url, ls_db)
+
+    with ThreadPoolExecutor(max_workers=35) as executor:
+        futures = [executor.submit(
+            ct.start,
+            timeout=None,
+            heartbeat=5000,
+            request_timeout=2000
+        ) for _ in range(30)]
+
+    log_info("Futures exited")
+
+    # make sure client can still take connections
+    dbs = client.get_databases(url=ls_url)
+    log_info(dbs)
+    database = client.get_database(url=ls_url, db_name=ls_db)
+    log_info(database)
 
 
 

--- a/testsuites/listener/shared/client_sg/listener_changes.py
+++ b/testsuites/listener/shared/client_sg/listener_changes.py
@@ -1,0 +1,50 @@
+import time
+
+from concurrent.futures import as_completed
+from concurrent.futures import ThreadPoolExecutor
+
+from keywords.utils import log_info
+from keywords.utils import breakpoint
+from keywords.MobileRestClient import MobileRestClient
+from keywords.ChangesTracker import ChangesTracker
+
+
+def start_changes_tracking(url, db):
+    ct = ChangesTracker(url, db)
+    ct.start(timeout=5000)
+    return ct
+
+def longpoll_changes_termination(ls_url, cluster_config):
+    log_info("ls_url: {}".format(ls_url))
+    log_info("cluster_config: {}".format(cluster_config))
+    log_info("Running 'longpoll_changes_termination' ...")
+
+    ls_db = "ls_db"
+    sg_url = cluster_config["sync_gateways"][0]["admin"]
+
+    client = MobileRestClient()
+    client.create_database(ls_url, ls_db)
+
+    with ThreadPoolExecutor(max_workers=35) as executor:
+
+        futures = [executor.submit(
+            start_changes_tracking,
+            ls_url,
+            ls_db
+
+        ) for _ in range(30)]
+
+        time.sleep(2)
+
+        for future in as_completed(futures):
+            future.stop()
+
+
+
+
+
+
+
+
+
+

--- a/testsuites/listener/shared/client_sg/listener_changes.py
+++ b/testsuites/listener/shared/client_sg/listener_changes.py
@@ -55,7 +55,7 @@ def longpoll_changes_termination_heartbeat(ls_url, cluster_config):
     with ThreadPoolExecutor(max_workers=35) as executor:
         futures = [executor.submit(
             ct.start,
-            timeout=None,
+            timeout=5000,
             heartbeat=5000,
             request_timeout=2000
         ) for _ in range(30)]

--- a/testsuites/listener/shared/client_sg/listener_changes.py
+++ b/testsuites/listener/shared/client_sg/listener_changes.py
@@ -11,7 +11,7 @@ from keywords.ChangesTracker import ChangesTracker
 
 def start_changes_tracking(url, db):
     ct = ChangesTracker(url, db)
-    ct.start(timeout=5000)
+    ct.start(timeout=5000, request_timeout=2000)
     return ct
 
 def longpoll_changes_termination(ls_url, cluster_config):
@@ -31,13 +31,16 @@ def longpoll_changes_termination(ls_url, cluster_config):
             start_changes_tracking,
             ls_url,
             ls_db
-
         ) for _ in range(30)]
 
-        time.sleep(2)
+        # for future in as_completed(futures):
+        #     future.stop()
 
-        for future in as_completed(futures):
-            future.stop()
+    log_info("Futures exited")
+
+    # make sure client can still take connections
+    dbs = client.get_databases(url=ls_url)
+    log_info(dbs)
 
 
 

--- a/testsuites/listener/shared/client_sg/listener_changes.robot
+++ b/testsuites/listener/shared/client_sg/listener_changes.robot
@@ -20,7 +20,7 @@ Test Teardown     Teardown Test
 ${sg_db}  db
 
 *** Test Cases ***
-Longpoll Changes Termination
+Longpoll Changes Termination Timeout
     [Tags]  Listener  Sync Gateway  Changes
     [Documentation]
     ...  https://github.com/couchbase/couchbase-lite-java-core/issues/1296
@@ -28,9 +28,22 @@ Longpoll Changes Termination
     ...  Cancel the request after 2s
     ...  Wait 5.1s
     ...  Create another request GET /db/ on listener and make sure the listener responds
-    Longpoll Changes Termination
+    Longpoll Changes Termination Timeout
     ...  ls_url=${ls_url}
     ...  cluster_config=${cluster_hosts}
+
+Longpoll Changes Termination Heartbeat
+    [Tags]  Listener  Sync Gateway  Changes
+    [Documentation]
+    ...  https://github.com/couchbase/couchbase-lite-java-core/issues/1296
+    ...  Create 30 longpoll _changes in a loop (with heartbeat parameter = 5s)
+    ...  Cancel the request after 2s
+    ...  Wait 5.1s
+    ...  Create another request GET /db/ on listener and make sure the listener responds
+    Longpoll Changes Termination Heartbeat
+    ...  ls_url=${ls_url}
+    ...  cluster_config=${cluster_hosts}
+
 
 *** Keywords ***
 Setup Test

--- a/testsuites/listener/shared/client_sg/listener_changes.robot
+++ b/testsuites/listener/shared/client_sg/listener_changes.robot
@@ -1,0 +1,61 @@
+*** Settings ***
+Documentation     A test suite containing functional tests for the
+...               Listener's changes feed
+
+Resource          resources/common.robot
+
+Library           OperatingSystem
+Library           ${KEYWORDS}/MobileRestClient.py
+Library           ${KEYWORDS}/LiteServ.py
+Library           ${KEYWORDS}/ClusterKeywords.py
+Library           ${KEYWORDS}/SyncGateway.py
+Library           ${KEYWORDS}/Logging.py
+
+Library           listener_changes.py
+
+Test Setup        Setup Test
+Test Teardown     Teardown Test
+
+*** Variables ***
+${sg_db}  db
+
+*** Test Cases ***
+Longpoll Changes Termination
+    [Tags]  Listener  Sync Gateway  Changes
+    [Documentation]
+    ...  https://github.com/couchbase/couchbase-lite-java-core/issues/1296
+    ...  Create 30 longpoll _changes in a loop (with timeout parameter = 5s)
+    ...  Cancel the request after 2s
+    ...  Wait 5.1s
+    ...  Create another request GET /db/ on listener and make sure the listener responds
+    Longpoll Changes Termination
+    ...  ls_url=${ls_url}
+    ...  cluster_config=${cluster_hosts}
+
+*** Keywords ***
+Setup Test
+    ${ls_url} =  Start LiteServ
+    ...  platform=${PLATFORM}
+    ...  version=${LITESERV_VERSION}
+    ...  host=${LITESERV_HOST}
+    ...  port=${LITESERV_PORT}
+    ...  storage_engine=${LITESERV_STORAGE_ENGINE}
+    Set Test Variable  ${ls_url}
+
+    Set Environment Variable  CLUSTER_CONFIG  ${CLUSTER_CONFIGS}/1sg
+    ${cluster_hosts} =  Get Cluster Topology  %{CLUSTER_CONFIG}
+
+    Set Test Variable  ${cluster_hosts}
+    Set Test Variable  ${ls_url}
+    Set Test Variable  ${sg_url}        ${cluster_hosts["sync_gateways"][0]["public"]}
+
+
+    Stop Sync Gateway  url=${sg_url}
+    Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus.json
+
+Teardown Test
+
+    Delete Databases  ${ls_url}
+    Shutdown LiteServ  platform=${PLATFORM}
+    Stop Sync Gateway  url=${sg_url}
+    Run Keyword If Test Failed  Fetch And Analyze Logs  ${TEST_NAME}

--- a/testsuites/listener/shared/client_sg/listener_changes.robot
+++ b/testsuites/listener/shared/client_sg/listener_changes.robot
@@ -16,6 +16,8 @@ Library           listener_changes.py
 Test Setup        Setup Test
 Test Teardown     Teardown Test
 
+Test Timeout      1 minute
+
 *** Variables ***
 ${sg_db}  db
 

--- a/testsuites/listener/shared/client_sg/listener_replication.py
+++ b/testsuites/listener/shared/client_sg/listener_replication.py
@@ -104,7 +104,7 @@ def large_initial_push_replication(ls_url, cluster_config, num_docs, continuous)
 
     client.create_database(url=ls_url, name=ls_db)
 
-    # Create 'num_docs' docs on sync_gateway
+    # Create 'num_docs' docs on LiteServ
     docs = client.add_docs(
         url=ls_url,
         db=ls_db,

--- a/testsuites/listener/shared/client_sg/listener_replication.py
+++ b/testsuites/listener/shared/client_sg/listener_replication.py
@@ -353,36 +353,24 @@ def multiple_replications_created_with_unique_properties(ls_url, cluster_config)
     )
     assert repl_seven == "repl007", "Replication {} should have id: repl007".format(repl_seven)
 
+    # Start filtered pull from sync gateway to LiteServ
     repl_eight = client.start_replication(
         url=ls_url,
         continuous=True,
         from_url=sg_one_admin,
         from_db=sg_db,
         to_db=ls_db,
-        doc_ids=["doc_1", "doc_2"]
+        channels_filter=["ABC", "CBS"]
     )
     assert repl_eight == "repl008", "Replication {} should have id: repl008".format(repl_eight)
-
-    # Todo: Use sg filters
-    # repl_nine = client.start_replication(
-    #     url=ls_url,
-    #     continuous=True,
-    #     from_url=sg_one_admin,
-    #     from_db=sg_db,
-    #     to_db=ls_db,
-    #     repl_filter="by_type/sample_filter"
-    # )
-    # assert repl_nine == "repl009", "Replication {} should have id: repl009".format(repl_nine)
 
     # Verify 3 replicaitons are running
     replications = client.get_replications(ls_url)
     log_info(replications)
-    assert len(replications) == 3, "Number of replications, Expected: {} Actual: {}".format(
-        3,
+    assert len(replications) == 2, "Number of replications, Expected: {} Actual: {}".format(
+        2,
         len(replications)
     )
-
-    breakpoint()
 
     # Stop repl007
     client.stop_replication(
@@ -393,8 +381,6 @@ def multiple_replications_created_with_unique_properties(ls_url, cluster_config)
         to_db=ls_db
     )
 
-    breakpoint()
-
     # Stop repl008
     client.stop_replication(
         url=ls_url,
@@ -402,22 +388,8 @@ def multiple_replications_created_with_unique_properties(ls_url, cluster_config)
         from_url=sg_one_admin,
         from_db=sg_db,
         to_db=ls_db,
-        doc_ids=["doc_1", "doc_2"]
+        channels_filter=["ABC", "CBS"]
     )
-
-    breakpoint()
-
-    # Stop repl009
-    client.stop_replication(
-        url=ls_url,
-        continuous=True,
-        from_url=sg_one_admin,
-        from_db=sg_db,
-        to_db=ls_db,
-        repl_filter="by_type/sample_filter"
-    )
-
-    breakpoint()
 
     # Verify no replications are running
     replications = client.get_replications(ls_url)

--- a/testsuites/listener/shared/client_sg/listener_replication.py
+++ b/testsuites/listener/shared/client_sg/listener_replication.py
@@ -4,6 +4,8 @@ from concurrent.futures import as_completed
 from concurrent.futures import ThreadPoolExecutor
 
 from keywords.utils import log_info
+from keywords.constants import SYNC_GATEWAY_CONFIGS
+from keywords.SyncGateway import SyncGateway
 from keywords.utils import breakpoint
 from keywords.MobileRestClient import MobileRestClient
 
@@ -405,5 +407,10 @@ def replication_with_session_cookie(ls_url, sg_admin_url, sg_url):
     log_info("ls_url: {}".format(ls_url))
     log_info("sg_admin_url: {}".format(sg_admin_url))
     log_info("sg_url: {}".format(sg_url))
-    pass
+
+    sg = SyncGateway()
+    sg.stop_sync_gateway(sg_url)
+    sg.start_sync_gateway(sg_url, "{}/walrus-user.json".format(SYNC_GATEWAY_CONFIGS))
+
+
 

--- a/testsuites/listener/shared/client_sg/listener_replication.py
+++ b/testsuites/listener/shared/client_sg/listener_replication.py
@@ -15,7 +15,7 @@ from keywords.utils import breakpoint
 from keywords.MobileRestClient import MobileRestClient
 
 
-def large_initial_pull_replication(ls_url, cluster_config, num_docs, continuous):
+def initial_pull_replication(ls_url, cluster_config, num_docs, continuous):
 
     sg_db = "db"
     ls_db = "ls_db"
@@ -85,7 +85,7 @@ def large_initial_pull_replication(ls_url, cluster_config, num_docs, continuous)
         assert len(replications) == 0, "No replications should be running"
 
 
-def large_initial_push_replication(ls_url, cluster_config, num_docs, continuous):
+def initial_push_replication(ls_url, cluster_config, num_docs, continuous):
 
     sg_db = "db"
     ls_db = "ls_db"

--- a/testsuites/listener/shared/client_sg/listener_replication.py
+++ b/testsuites/listener/shared/client_sg/listener_replication.py
@@ -31,7 +31,7 @@ def large_initial_pull_replication(ls_url, cluster_config, num_docs, continuous)
     client.create_user(sg_one_admin, sg_db, "seth", password="password", channels=["ABC", "NBC"])
     session = client.create_session(sg_one_admin, sg_db, "seth")
 
-    # Create 10000 docs on sync_gateway
+    # Create 'num_docs' docs on sync_gateway
     docs = client.add_docs(
         url=sg_one_public,
         db=sg_db,
@@ -104,7 +104,7 @@ def large_initial_push_replication(ls_url, cluster_config, num_docs, continuous)
 
     client.create_database(url=ls_url, name=ls_db)
 
-    # Create 10000 docs on LiteServ
+    # Create 'num_docs' docs on sync_gateway
     docs = client.add_docs(
         url=ls_url,
         db=ls_db,

--- a/testsuites/listener/shared/client_sg/listener_replication.py
+++ b/testsuites/listener/shared/client_sg/listener_replication.py
@@ -56,6 +56,8 @@ def large_initial_pull_replication(ls_url, cluster_config, num_docs, continuous)
 
     if continuous:
         log_info("Waiting for replication status 'Idle' for: {}".format(repl_id))
+        # Android will report IDLE status, and drop into the 'verify_docs_present' below
+        # due to https://github.com/couchbase/couchbase-lite-java-core/issues/1409
         client.wait_for_replication_status_idle(ls_url, repl_id)
     else:
         log_info("Waiting for no replications".format(repl_id))

--- a/testsuites/listener/shared/client_sg/listener_replication.py
+++ b/testsuites/listener/shared/client_sg/listener_replication.py
@@ -75,7 +75,7 @@ def large_initial_pull_replication(ls_url, cluster_config, num_docs, continuous)
     if continuous:
         assert len(replications) == 1, "There should only be one replication running"
         assert replications[0]["status"] == "Idle", "Replication Status should be 'Idle'"
-        assert replications[0]["continuous"] == True, "Running replication should be continuous"
+        assert replications[0]["continuous"], "Running replication should be continuous"
         # Only .NET has an 'error' property
         if "error" in replications[0]:
             assert len(replications[0]["error"]) == 0

--- a/testsuites/listener/shared/client_sg/listener_replication.py
+++ b/testsuites/listener/shared/client_sg/listener_replication.py
@@ -287,9 +287,7 @@ def multiple_replications_created_with_unique_properties(ls_url, cluster_config)
         to_url=sg_one_admin,
         to_db=sg_db
     )
-    client.wait_for_replication_status_idle(ls_url, "repl001")
-    assert repl_one == "repl001", "Replication {} should have id: repl001".format(repl_one)
-
+    client.wait_for_replication_status_idle(ls_url, repl_one)
 
     repl_two = client.start_replication(
         url=ls_url,
@@ -299,8 +297,7 @@ def multiple_replications_created_with_unique_properties(ls_url, cluster_config)
         to_db=sg_db,
         doc_ids=["doc_1", "doc_2"]
     )
-    client.wait_for_replication_status_idle(ls_url, "repl002")
-    assert repl_two == "repl002", "Replication {} should have id: repl002".format(repl_two)
+    client.wait_for_replication_status_idle(ls_url, repl_two)
 
     # Create doc filter and add to the design doc
     filters = {
@@ -319,8 +316,7 @@ def multiple_replications_created_with_unique_properties(ls_url, cluster_config)
         to_db=sg_db,
         repl_filter="by_type/sample_filter"
     )
-    client.wait_for_replication_status_idle(ls_url, "repl003")
-    assert repl_three == "repl003", "Replication {} should have id: repl003".format(repl_three)
+    client.wait_for_replication_status_idle(ls_url, repl_three)
 
     # Verify 3 replicaitons are running
     replications = client.get_replications(ls_url)
@@ -373,18 +369,17 @@ def multiple_replications_created_with_unique_properties(ls_url, cluster_config)
     # PULL #
     ########
     # Start 3 unique push replication requests
-    repl_seven = client.start_replication(
+    repl_four = client.start_replication(
         url=ls_url,
         continuous=True,
         from_url=sg_one_admin,
         from_db=sg_db,
         to_db=ls_db
     )
-    client.wait_for_replication_status_idle(ls_url, "repl007")
-    assert repl_seven == "repl007", "Replication {} should have id: repl007".format(repl_seven)
+    client.wait_for_replication_status_idle(ls_url, repl_four)
 
     # Start filtered pull from sync gateway to LiteServ
-    repl_eight = client.start_replication(
+    repl_five = client.start_replication(
         url=ls_url,
         continuous=True,
         from_url=sg_one_admin,
@@ -392,8 +387,7 @@ def multiple_replications_created_with_unique_properties(ls_url, cluster_config)
         to_db=ls_db,
         channels_filter=["ABC", "CBS"]
     )
-    client.wait_for_replication_status_idle(ls_url, "repl008")
-    assert repl_eight == "repl008", "Replication {} should have id: repl008".format(repl_eight)
+    client.wait_for_replication_status_idle(ls_url, repl_five)
 
     # Verify 3 replicaitons are running
     replications = client.get_replications(ls_url)
@@ -403,7 +397,7 @@ def multiple_replications_created_with_unique_properties(ls_url, cluster_config)
         len(replications)
     )
 
-    # Stop repl007
+    # Stop repl_four
     client.stop_replication(
         url=ls_url,
         continuous=True,
@@ -412,7 +406,7 @@ def multiple_replications_created_with_unique_properties(ls_url, cluster_config)
         to_db=ls_db
     )
 
-    # Stop repl008
+    # Stop repl_five
     client.stop_replication(
         url=ls_url,
         continuous=True,

--- a/testsuites/listener/shared/client_sg/listener_replication.py
+++ b/testsuites/listener/shared/client_sg/listener_replication.py
@@ -132,6 +132,7 @@ def large_initial_push_replication(ls_url, cluster_config, num_docs, continuous)
     else:
         assert len(replications) == 0, "No replications should be running"
 
+
 def multiple_replications_not_created_with_same_properties(ls_url, cluster_config):
     sg_db = "db"
     ls_db = "ls_db"
@@ -233,3 +234,56 @@ def multiple_replications_not_created_with_same_properties(ls_url, cluster_confi
         0,
         len(replications)
     )
+
+
+def multiple_replications_created_with_unique_properties(ls_url, cluster_config):
+    sg_db = "db"
+    ls_db = "ls_db"
+
+    sg_one_admin = cluster_config["sync_gateways"][0]["admin"]
+    sg_one_public = cluster_config["sync_gateways"][0]["public"]
+
+    log_info("Running: multiple_replications_created_with_unique_properties")
+    log_info(ls_url)
+    log_info(sg_one_admin)
+    log_info(sg_one_public)
+
+    client = MobileRestClient()
+    client.create_database(url=ls_url, name=ls_db)
+
+    # Start 3 unique push replication requests
+    repl_one = client.start_replication(
+        url=ls_url,
+        continuous=True,
+        from_db=ls_db,
+        to_url=sg_one_admin,
+        to_db=sg_db
+    )
+    assert repl_one == "repl001", "Replication {} should have id: repl001".format(repl_one)
+
+    repl_two = client.start_replication(
+        url=ls_url,
+        continuous=True,
+        from_db=ls_db,
+        to_url=sg_one_admin,
+        to_db=sg_db,
+        doc_ids=["doc_1", "doc_2"]
+    )
+    assert repl_two == "repl002", "Replication {} should have id: repl002".format(repl_two)
+
+    # repl_two = client.start_replication(
+    #     url=ls_url,
+    #     continuous=True,
+    #     from_db=ls_db,
+    #     to_url=sg_one_admin,
+    #     to_db=sg_db,
+    #     repl_filter="filter1"
+    # )
+    #assert repl_two == "repl002", "Replication {} should have id: repl002".format(repl_two)
+
+    replications = client.get_replications(ls_url)
+    assert len(replications) == 2, "Number of replications, Expected: {} Actual: {}".format(
+        2,
+        len(replications)
+    )
+

--- a/testsuites/listener/shared/client_sg/listener_replication.py
+++ b/testsuites/listener/shared/client_sg/listener_replication.py
@@ -400,5 +400,10 @@ def multiple_replications_created_with_unique_properties(ls_url, cluster_config)
     )
 
 
-
+def replication_with_session_cookie(ls_url, sg_admin_url, sg_url):
+    log_info("Running 'replication_with_session_cookie' ...")
+    log_info("ls_url: {}".format(ls_url))
+    log_info("sg_admin_url: {}".format(sg_admin_url))
+    log_info("sg_url: {}".format(sg_url))
+    pass
 

--- a/testsuites/listener/shared/client_sg/listener_replication.robot
+++ b/testsuites/listener/shared/client_sg/listener_replication.robot
@@ -86,7 +86,21 @@ Multiple Replications Not Created With Same Properties
     ...  ls_url=${ls_url}
     ...  cluster_config=${cluster_hosts}
 
-
+Multiple Replications Created with Unique Properties
+    [Documentation]
+    ...  Regression test for couchbase/couchbase-lite-java-core#1386
+    ...  1. Setup SGW with a remote database name db for an example
+    ...  2. Create a local database such as ls_db
+    ...  3. Send POST /_replicate with source = ls_db, target = http://localhost:4985/db, continuous = true
+    ...  4. Send POST /_replicate with source = ls_db, target = http://localhost:4985/db, continuous = true, doc_ids=["doc1", "doc2"]
+    ...  5. Send POST /_replicate with source = ls_db, target = http://localhost:498\5/db, continuous = true, filter="filter1"
+    ...  6. Make sure that the session_id from each POST /_replicate are different.
+    ...  7. Send GET /_active_tasks to make sure that there are 3 tasks created.
+    ...  8. Send 3 POST /_replicate withe the same parameter as Step 3=5 plus cancel=true to stop those replicators
+    ...  9. Repeat Step 3 - 8 with source = and target = db for testing the pull replicator.
+    Multiple Replications Created with Unique Properties
+    ...  ls_url=${ls_url}
+    ...  cluster_config=${cluster_hosts}
 
 *** Keywords ***
 Setup Test

--- a/testsuites/listener/shared/client_sg/listener_replication.robot
+++ b/testsuites/listener/shared/client_sg/listener_replication.robot
@@ -33,7 +33,7 @@ Large Initial One Shot Pull Replication
     ...  3. Verify if all of the docs get pulled.
     ...  Referenced issue: couchbase/couchbase-lite-android#955.
     Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus.json
-    Large Initial Pull Replication
+    Initial Pull Replication
     ...  ls_url=${ls_url}
     ...  cluster_config=${cluster_hosts}
     ...  num_docs=${num_docs}
@@ -46,7 +46,7 @@ Large Initial Continuous Pull Replication
     ...  2. Create a single continuous pull replicator and to pull the docs into a database.
     ...  3. Verify if all of the docs get pulled.
     Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus.json
-    Large Initial Pull Replication
+    Initial Pull Replication
     ...  ls_url=${ls_url}
     ...  cluster_config=${cluster_hosts}
     ...  num_docs=${num_docs}
@@ -59,7 +59,7 @@ Large Initial One Shot Push Replication
     ...  2. Create a single shot push replicator and to push the docs into a sync_gateway database.
     ...  3. Verify if all of the docs get pushed.
     Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus.json
-    Large Initial Push Replication
+    Initial Push Replication
     ...  ls_url=${ls_url}
     ...  cluster_config=${cluster_hosts}
     ...  num_docs=${num_docs}
@@ -72,7 +72,7 @@ Large Initial Continuous Push Replication
     ...  2. Create continuous push replicator and to push the docs into a sync_gateway database.
     ...  3. Verify if all of the docs get pushed.
     Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus.json
-    Large Initial Push Replication
+    Initial Push Replication
     ...  ls_url=${ls_url}
     ...  cluster_config=${cluster_hosts}
     ...  num_docs=${num_docs}

--- a/testsuites/listener/shared/client_sg/listener_replication.robot
+++ b/testsuites/listener/shared/client_sg/listener_replication.robot
@@ -32,6 +32,7 @@ Large Initial One Shot Pull Replication
     ...  2. Create a single shot pull replicator and to pull the docs into a database.
     ...  3. Verify if all of the docs get pulled.
     ...  Referenced issue: couchbase/couchbase-lite-android#955.
+    Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus.json
     Large Initial Pull Replication
     ...  ls_url=${ls_url}
     ...  cluster_config=${cluster_hosts}
@@ -44,6 +45,7 @@ Large Initial Continuous Pull Replication
     ...  1. Prepare sync-gateway to have 10000 documents.
     ...  2. Create a single continuous pull replicator and to pull the docs into a database.
     ...  3. Verify if all of the docs get pulled.
+    Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus.json
     Large Initial Pull Replication
     ...  ls_url=${ls_url}
     ...  cluster_config=${cluster_hosts}
@@ -56,6 +58,7 @@ Large Initial One Shot Push Replication
     ...  1. Prepare LiteServ to have 10000 documents.
     ...  2. Create a single shot push replicator and to push the docs into a sync_gateway database.
     ...  3. Verify if all of the docs get pushed.
+    Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus.json
     Large Initial Push Replication
     ...  ls_url=${ls_url}
     ...  cluster_config=${cluster_hosts}
@@ -68,6 +71,7 @@ Large Initial Continuous Push Replication
     ...  1. Prepare LiteServ to have 10000 documents.
     ...  2. Create continuous push replicator and to push the docs into a sync_gateway database.
     ...  3. Verify if all of the docs get pushed.
+    Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus.json
     Large Initial Push Replication
     ...  ls_url=${ls_url}
     ...  cluster_config=${cluster_hosts}
@@ -87,6 +91,7 @@ Multiple Replications Not Created With Same Properties
     ...  7. Make sure the sample replication id is returned
     ...  8. Check that 1 one replication exists in 'active_tasks'
     ...  9. Stop the replication with POST /_replicate cancel=true
+    Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus.json
     Multiple Replications Not Created With Same Properties
     ...  ls_url=${ls_url}
     ...  cluster_config=${cluster_hosts}
@@ -104,6 +109,7 @@ Multiple Replications Created with Unique Properties
     ...  7. Send GET /_active_tasks to make sure that there are 3 tasks created.
     ...  8. Send 3 POST /_replicate withe the same parameter as Step 3=5 plus cancel=true to stop those replicators
     ...  9. Repeat Step 3 - 8 with source = and target = db for testing the pull replicator.
+    Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus.json
     Multiple Replications Created with Unique Properties
     ...  ls_url=${ls_url}
     ...  cluster_config=${cluster_hosts}
@@ -120,6 +126,7 @@ Replication with Session Cookie
     ...  4. Delete the session from SGW by sending DELETE /_sessions/ to SGW
     ...  5. Cancel both push and pull replicator on the LiteServ
     ...  6. Repeat step 1 and 2
+    Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus-user.json
     Replication with Session Cookie
     ...  ls_url=${ls_url}
     ...  sg_admin_url=${sg_admin_url}
@@ -144,7 +151,6 @@ Setup Test
     Set Test Variable  ${sg_url}        ${cluster_hosts["sync_gateways"][0]["public"]}
 
     Stop Sync Gateway  url=${sg_url}
-    Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus.json
 
 Teardown Test
 

--- a/testsuites/listener/shared/client_sg/listener_replication.robot
+++ b/testsuites/listener/shared/client_sg/listener_replication.robot
@@ -15,7 +15,7 @@ Library           ${KEYWORDS}/ClusterKeywords.py
 Library           ${KEYWORDS}/SyncGateway.py
 Library           ${KEYWORDS}/CouchbaseServer.py
 Library           ${KEYWORDS}/Logging.py
-Library           listener_initial_replication.py
+Library           listener_replication.py
 
 Test Setup        Setup Test
 Test Teardown     Teardown Test
@@ -25,7 +25,7 @@ ${sg_db}  db
 ${num_docs}  ${10000}
 
 *** Test Cases ***
-Large One Shot Pull Replication
+Large Initial One Shot Pull Replication
     [Documentation]
     ...  1. Prepare sync-gateway to have 10000 documents.
     ...  2. Create a single shot pull replicator and to pull the docs into a database.
@@ -37,7 +37,7 @@ Large One Shot Pull Replication
     ...  num_docs=${num_docs}
     ...  continuous=${False}
 
-Large Continuous Pull Replication
+Large Initial Continuous Pull Replication
     [Documentation]
     ...  1. Prepare sync-gateway to have 10000 documents.
     ...  2. Create a single continuous pull replicator and to pull the docs into a database.
@@ -48,7 +48,7 @@ Large Continuous Pull Replication
     ...  num_docs=${num_docs}
     ...  continuous=${True}
 
-Large One Shot Push Replication
+Large Initial One Shot Push Replication
     [Documentation]
     ...  1. Prepare LiteServ to have 10000 documents.
     ...  2. Create a single shot push replicator and to push the docs into a sync_gateway database.
@@ -59,7 +59,7 @@ Large One Shot Push Replication
     ...  num_docs=${num_docs}
     ...  continuous=${False}
 
-Large Continuous Push Replication
+Large Initial Continuous Push Replication
     [Documentation]
     ...  1. Prepare LiteServ to have 10000 documents.
     ...  2. Create continuous push replicator and to push the docs into a sync_gateway database.
@@ -69,6 +69,23 @@ Large Continuous Push Replication
     ...  cluster_config=${cluster_hosts}
     ...  num_docs=${num_docs}
     ...  continuous=${True}
+
+Multiple Replications Not Created With Same Properties
+    [Documentation]
+    ...  Regression test for https://github.com/couchbase/couchbase-lite-android/issues/939
+    ...  1. Create LiteServ database and launch sync_gateway with database
+    ...  2. Start 5 continuous push replicators with the same source and target
+    ...  3. Make sure the sample replication id is returned
+    ...  4. Check that 1 one replication exists in 'active_tasks'
+    ...  5. Stop the replication with POST /_replicate cancel=true
+    ...  6. Start 5 continuous pull replicators with the same source and target
+    ...  7. Make sure the sample replication id is returned
+    ...  8. Check that 1 one replication exists in 'active_tasks'
+    ...  9. Stop the replication with POST /_replicate cancel=true
+    Multiple Replications Not Created With Same Properties
+    ...  ls_url=${ls_url}
+    ...  cluster_config=${cluster_hosts}
+
 
 
 *** Keywords ***

--- a/testsuites/listener/shared/client_sg/listener_replication.robot
+++ b/testsuites/listener/shared/client_sg/listener_replication.robot
@@ -26,6 +26,7 @@ ${num_docs}  ${10000}
 
 *** Test Cases ***
 Large Initial One Shot Pull Replication
+    [Tags]  Listener  Sync Gateway  Replication
     [Documentation]
     ...  1. Prepare sync-gateway to have 10000 documents.
     ...  2. Create a single shot pull replicator and to pull the docs into a database.
@@ -38,6 +39,7 @@ Large Initial One Shot Pull Replication
     ...  continuous=${False}
 
 Large Initial Continuous Pull Replication
+    [Tags]  Listener  Sync Gateway  Replication
     [Documentation]
     ...  1. Prepare sync-gateway to have 10000 documents.
     ...  2. Create a single continuous pull replicator and to pull the docs into a database.
@@ -49,6 +51,7 @@ Large Initial Continuous Pull Replication
     ...  continuous=${True}
 
 Large Initial One Shot Push Replication
+    [Tags]  Listener  Sync Gateway  Replication
     [Documentation]
     ...  1. Prepare LiteServ to have 10000 documents.
     ...  2. Create a single shot push replicator and to push the docs into a sync_gateway database.
@@ -60,6 +63,7 @@ Large Initial One Shot Push Replication
     ...  continuous=${False}
 
 Large Initial Continuous Push Replication
+    [Tags]  Listener  Sync Gateway  Replication
     [Documentation]
     ...  1. Prepare LiteServ to have 10000 documents.
     ...  2. Create continuous push replicator and to push the docs into a sync_gateway database.
@@ -71,6 +75,7 @@ Large Initial Continuous Push Replication
     ...  continuous=${True}
 
 Multiple Replications Not Created With Same Properties
+    [Tags]  Listener  Sync Gateway  Replication
     [Documentation]
     ...  Regression test for https://github.com/couchbase/couchbase-lite-android/issues/939
     ...  1. Create LiteServ database and launch sync_gateway with database
@@ -87,6 +92,7 @@ Multiple Replications Not Created With Same Properties
     ...  cluster_config=${cluster_hosts}
 
 Multiple Replications Created with Unique Properties
+    [Tags]  Listener  Sync Gateway  Replication
     [Documentation]
     ...  Regression test for couchbase/couchbase-lite-java-core#1386
     ...  1. Setup SGW with a remote database name db for an example

--- a/testsuites/listener/shared/client_sg/listener_replication.robot
+++ b/testsuites/listener/shared/client_sg/listener_replication.robot
@@ -108,6 +108,23 @@ Multiple Replications Created with Unique Properties
     ...  ls_url=${ls_url}
     ...  cluster_config=${cluster_hosts}
 
+Replication with Session Cookie
+    [Tags]  Listener  Sync Gateway  Replication  Sessions
+    [Documentation]
+    ...  Regression test for https://github.com/couchbase/couchbase-lite-android/issues/817
+    ...  1. SyncGateway Config with guest disabled = true and One user added (e.g. user1 / 1234)
+    ...  2. Create a new session on SGW for the user1 by using POST /_session.
+    ...     Capture the SyncGatewaySession cookie from the set-cookie in the response header.
+    ...  3. Start continuous push and pull replicator on the LiteServ with SyncGatewaySession cookie.
+    ...     Make sure that both replicators start correctly
+    ...  4. Delete the session from SGW by sending DELETE /_sessions/ to SGW
+    ...  5. Cancel both push and pull replicator on the LiteServ
+    ...  6. Repeat step 1 and 2
+    Replication with Session Cookie
+    ...  ls_url=${ls_url}
+    ...  sg_admin_url=${sg_admin_url}
+    ...  sg_url=${sg_url}
+
 *** Keywords ***
 Setup Test
     ${ls_url} =  Start LiteServ
@@ -123,8 +140,8 @@ Setup Test
 
     Set Test Variable  ${cluster_hosts}
     Set Test Variable  ${ls_url}
+    Set Test Variable  ${sg_admin_url}        ${cluster_hosts["sync_gateways"][0]["admin"]}
     Set Test Variable  ${sg_url}        ${cluster_hosts["sync_gateways"][0]["public"]}
-
 
     Stop Sync Gateway  url=${sg_url}
     Start Sync Gateway  url=${sg_url}  config=${SYNC_GATEWAY_CONFIGS}/walrus.json

--- a/testsuites/listener/shared/client_sg/view_indexing.robot
+++ b/testsuites/listener/shared/client_sg/view_indexing.robot
@@ -72,7 +72,7 @@ Stale revision should not be in the index
     ...  from_url=${sg_url_admin}  from_db=${sg_db}
     ...  to_db=${ls_db}
 
-    ${design_doc_id} =  Add Design Doc  url=${ls_url}  db=${ls_db}  name=${d_doc_name}  view=${view}
+    ${design_doc_id} =  Add Design Doc  url=${ls_url}  db=${ls_db}  name=${d_doc_name}  doc=${view}
     ${design_doc} =  Get Doc  url=${ls_url}  db=${ls_db}  doc_id=${design_doc_id}
 
     ${doc_body} =  Create Doc  id=doc_1  content={"hi": "I should be in the view"}  channels=${sg_user_channels}


### PR DESCRIPTION
- Ignore ansible *.retry files
- add breakpoint() method for debugging native python when running under robot
- changes_tracker.start() now supports timeout / heartbeat / request_timeout
- Fixes #632 
- Fixes #633 
- Fixes #641 
- Fixes #630 
- Add support for provisioning SQLite / Other platforms for Android .apks
- Add `get_session`,  `request_session`, `get_database`, `get_databases`
- Add support for auth and filters for `start_replication` and `stop_replication` keywords
- Add support for provisioning CBS `4.6` Sync Gateway `1.3.1`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbaselabs/mobile-testkit/650)
<!-- Reviewable:end -->
