### PR TITLE
Remove parens around asserts

### DIFF
--- a/keywords/CouchbaseServer.py
+++ b/keywords/CouchbaseServer.py
@@ -43,13 +43,13 @@ def verify_server_version(host, expected_server_version):
         # 4.1.1-5487
         log_info("Expected Server Version: {}".format(expected_server_version))
         log_info("Running Server Version: {}".format(running_server_version))
-        assert(running_server_version == expected_server_version), "Unexpected server version!! Expected: {} Actual: {}".format(expected_server_version, running_server_version)
+        assert running_server_version == expected_server_version, "Unexpected server version!! Expected: {} Actual: {}".format(expected_server_version, running_server_version)
     elif len(expected_server_version_parts) == 1:
         # 4.1.1
         running_server_version_parts = running_server_version.split("-")
         log_info("Expected Server Version: {}".format(expected_server_version))
         log_info("Running Server Version: {}".format(running_server_version_parts[0]))
-        assert(expected_server_version == running_server_version_parts[0]), "Unexpected server version!! Expected: {} Actual: {}".format(expected_server_version, running_server_version_parts[0])
+        assert expected_server_version == running_server_version_parts[0], "Unexpected server version!! Expected: {} Actual: {}".format(expected_server_version, running_server_version_parts[0])
     else:
         raise ValueError("Unsupported version format")
 

--- a/keywords/LiteServ.py
+++ b/keywords/LiteServ.py
@@ -20,7 +20,7 @@ from utils import log_info
 
 def version_and_build(full_version):
     version_parts = full_version.split("-")
-    assert (len(version_parts) == 2)
+    assert len(version_parts) == 2
     return version_parts[0], version_parts[1]
 
 class LiteServ:

--- a/keywords/MobileRestClient.py
+++ b/keywords/MobileRestClient.py
@@ -1292,7 +1292,7 @@ class MobileRestClient:
 
             logging.debug("Expected: {}".format(expected_doc_map))
             logging.debug("Actual: {}".format(resp_docs))
-            assert(expected_doc_map == resp_docs), "Unable to verify docs present. Dictionaries are not equal"
+            assert expected_doc_map == resp_docs, "Unable to verify docs present. Dictionaries are not equal"
             break
 
     def verify_docs_in_changes(self, url, db, expected_docs, auth=None):

--- a/keywords/utils.py
+++ b/keywords/utils.py
@@ -39,7 +39,7 @@ def version_is_binary(version):
 
 def version_and_build(full_version):
     version_parts = full_version.split("-")
-    assert (len(version_parts) == 2)
+    assert len(version_parts) == 2
     return version_parts[0], version_parts[1]
 
 # Targeted playbooks need to use the host_name (i.e. sg1)

--- a/libraries/provision/clean_cluster.py
+++ b/libraries/provision/clean_cluster.py
@@ -14,7 +14,7 @@ def clean_cluster():
 
     ansible_runner = AnsibleRunner()
     status = ansible_runner.run_ansible_playbook("remove-previous-installs.yml")
-    assert(status == 0), "Failed to removed previous installs"
+    assert status == 0, "Failed to removed previous installs"
 
 
 if __name__ == "__main__":

--- a/libraries/provision/install_splunk_forwarder.py
+++ b/libraries/provision/install_splunk_forwarder.py
@@ -17,5 +17,5 @@ if __name__ == "__main__":
     )
 
     status = ansible_runner.run_ansible_playbook("install-splunkforwarder.yml", extra_vars=extra_vars, stop_on_fail=False)
-    assert(status == 0)
+    assert status == 0
 

--- a/libraries/provision/install_sync_gateway.py
+++ b/libraries/provision/install_sync_gateway.py
@@ -115,7 +115,7 @@ def install_sync_gateway(sync_gateway_config):
                 "skip_bucketflush": sync_gateway_config.skip_bucketflush
             }
         )
-        assert(status == 0), "Failed to install sync_gateway package"
+        assert status == 0, "Failed to install sync_gateway package"
 
 if __name__ == "__main__":
     usage = """usage: python install_sync_gateway.py

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -95,7 +95,7 @@ class Cluster:
                 # Delete buckets
                 log.info(">>> Deleting buckets on: {}".format(self.servers[0].ip))
                 status = self.servers[0].delete_buckets()
-                assert (status == 0)
+                assert status == 0
                 log.info(">>> Bucket deletion status: {}".format(status))
 
                 # Parse config and grab bucket names
@@ -108,7 +108,7 @@ class Cluster:
                 log.info(">>> Creating buckets on: {}".format(self.servers[0].ip))
                 log.info(">>> Creating buckets {}".format(bucket_name_set))
                 status = self.servers[0].create_buckets(bucket_name_set)
-                assert (status == 0)
+                assert status == 0
                 log.info(">>> Bucket creation status: {}".format(status))
 
                 # Wait for server to be in a warmup state to work around

--- a/libraries/utilities/download-release-packages.py
+++ b/libraries/utilities/download-release-packages.py
@@ -8,7 +8,7 @@ from zipfile import ZipFile
 
 def version_and_build(full_version):
     version_parts = full_version.split("-")
-    assert (len(version_parts) == 2)
+    assert len(version_parts) == 2
     return version_parts[0], version_parts[1]
 
 

--- a/testsuites/android/listener/test_listener_rest.py
+++ b/testsuites/android/listener/test_listener_rest.py
@@ -90,7 +90,7 @@ def test_selective_db_delete_and_replication_lifecycle():
 
     # Assert each endpoint has 601 docs
     for emu in all_emus:
-        assert(emu.get_num_docs(db_name) == 601)
+        assert emu.get_num_docs(db_name) == 601
 
     # Stop all replication
     stop_pull_replications(db_name, emu_1, targets)
@@ -120,7 +120,7 @@ def test_selective_db_delete_and_replication_lifecycle():
 
     # TODO Verify 3,4,5 have 621
     for emu in [emu_3, emu_4, emu_5]:
-        assert(emu.get_num_docs(db_name) == 621)
+        assert emu.get_num_docs(db_name) == 621
 
     # Create dbs on master and first slave
     emu_1.create_db(db_name)
@@ -140,7 +140,7 @@ def test_selective_db_delete_and_replication_lifecycle():
     for emu in emus:
         doc_num = emu.get_num_docs(db_name)
         log.info("emu: {} doc_num: {}".format(emu.target_device, doc_num))
-        assert (doc_num == 661)
+        assert doc_num == 661
 
 
 def test_replication_unstable_network():
@@ -189,9 +189,9 @@ def test_replication_unstable_network():
     time.sleep(10)
 
     # Assert each endpoint has 100 docs
-    assert(dev.get_num_docs(db_name) == 100)
+    assert dev.get_num_docs(db_name) == 100
     for emu in emus:
-        assert(emu.get_num_docs(db_name) == 100)
+        assert emu.get_num_docs(db_name) == 100
 
     # Create docs on targets
     emu_1_pusher = User(target=emu_1, db=db_name, name="emu1_doc_pusher", password="password", channels=["ABC"])
@@ -211,10 +211,10 @@ def test_replication_unstable_network():
     time.sleep(5)
 
     # Assert each endpoint has 140 docs
-    assert(dev.get_num_docs(db_name) == 160)
+    assert dev.get_num_docs(db_name) == 160
 
     for emu in emus:
-        assert(emu.get_num_docs(db_name) == 160)
+        assert emu.get_num_docs(db_name) == 160
 
 
 

--- a/testsuites/syncgateway/functional/2sg_1cbs_1lbs/load_balancer_scenarios.py
+++ b/testsuites/syncgateway/functional/2sg_1cbs_1lbs/load_balancer_scenarios.py
@@ -47,5 +47,5 @@ def test_load_balance_sanity(cluster_config):
             log_info("Found all docs ...")
             executor.submit(ct.stop)
         else:
-           executor.submit(ct.stop)
-           raise Exception("Could not find all changes in feed before timeout!!")
+            executor.submit(ct.stop)
+            raise Exception("Could not find all changes in feed before timeout!!")

--- a/testsuites/syncgateway/functional/test_bucket_shadow.py
+++ b/testsuites/syncgateway/functional/test_bucket_shadow.py
@@ -122,7 +122,7 @@ def test_bucket_shadow_low_revs_limit_repeated_deletes():
 
     # Check if SG's are up
     errors = cluster.verify_alive(sc.mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
     # Restart Shadow SG
     sc.shadower_sg.stop()
@@ -130,7 +130,7 @@ def test_bucket_shadow_low_revs_limit_repeated_deletes():
         
     # Check if SG's are up
     errors = cluster.verify_alive(sc.mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
     
 
 def test_bucket_shadow_low_revs_limit():
@@ -170,7 +170,7 @@ def test_bucket_shadow_low_revs_limit():
     # Look for panics
     time.sleep(5) # Give tap feed a chance to initialize
     errors = cluster.verify_alive(sc.mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
     
     # Verify that the latest revision sync'd to source bucket
     get_doc_with_content_from_source_bucket_retry(doc_id, fake_doc_content, sc.source_bucket)
@@ -185,7 +185,7 @@ def test_bucket_shadow_low_revs_limit():
     # Look for panics
     time.sleep(5) # Wait until the shadower can process
     errors = cluster.verify_alive(sc.mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
     
 def test_bucket_shadow_multiple_sync_gateways():
@@ -231,7 +231,7 @@ def test_bucket_shadow_multiple_sync_gateways():
     
     # Verify SG shadower comes up without panicking, given writes from non-shadower during downtime.
     errors = cluster.verify_alive(sc.mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
     # If SG shadower does come up without panicking, bump a rev on a document that was modified during the downtime of the SG shadower
     sc.bob_non_shadower.update_doc(doc_id_bob, num_revision=10)
@@ -247,7 +247,7 @@ def test_bucket_shadow_multiple_sync_gateways():
     # Verify SG shadower comes up without panicking, given writes from non-shadower during downtime.
     time.sleep(5) # Give tap feed a chance to initialize
     errors = cluster.verify_alive(sc.mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 def get_doc_with_content_from_source_bucket_retry(doc_id, content_dict, bucket):

--- a/testsuites/syncgateway/functional/test_bulk_get_compression.py
+++ b/testsuites/syncgateway/functional/test_bulk_get_compression.py
@@ -64,31 +64,31 @@ def verify_response_size(user_agent, accept_encoding, x_accept_part_encoding, re
 
         if accept_encoding is None and x_accept_part_encoding is None:
             # Response size should not be compressed
-            assert((uncompressed_size - 500) < response_size < (uncompressed_size + 500))
+            assert (uncompressed_size - 500) < response_size < (uncompressed_size + 500)
         elif accept_encoding == "gzip" and x_accept_part_encoding is None:
             # Response size should not be compressed
-            assert((uncompressed_size - 500) < response_size < (uncompressed_size + 500))
+            assert (uncompressed_size - 500) < response_size < (uncompressed_size + 500)
         elif accept_encoding is None and x_accept_part_encoding == "gzip":
             # Response size should be part compressed
-            assert((part_encoded_size - 500) < response_size < (part_encoded_size + 500))
+            assert (part_encoded_size - 500) < response_size < (part_encoded_size + 500)
         elif accept_encoding == "gzip" and x_accept_part_encoding == "gzip":
             # Response size should be part compressed
-            assert((part_encoded_size - 500) < response_size < (part_encoded_size + 500))
+            assert (part_encoded_size - 500) < response_size < (part_encoded_size + 500)
 
     elif user_agent == "CouchbaseLite/1.2":
 
         if accept_encoding is None and x_accept_part_encoding is None:
             # Response size should not be compressed
-            assert((uncompressed_size - 500) < response_size < (uncompressed_size + 500))
+            assert (uncompressed_size - 500) < response_size < (uncompressed_size + 500)
         elif accept_encoding == "gzip" and x_accept_part_encoding is None:
             # Response size should be fully compressed
-            assert((whole_response_compressed_size - 500) < response_size < (whole_response_compressed_size + 500))
+            assert (whole_response_compressed_size - 500) < response_size < (whole_response_compressed_size + 500)
         elif accept_encoding is None and x_accept_part_encoding == "gzip":
             # Response size should be part compressed
-            assert((part_encoded_size - 500) < response_size < (part_encoded_size + 500))
+            assert (part_encoded_size - 500) < response_size < (part_encoded_size + 500)
         elif accept_encoding == "gzip" and x_accept_part_encoding == "gzip":
             # Response size should be fully compressed
-            assert((whole_response_compressed_size - 500) < response_size < (whole_response_compressed_size + 500))
+            assert (whole_response_compressed_size - 500) < response_size < (whole_response_compressed_size + 500)
 
     else:
         raise ValueError("Unsupported user agent")
@@ -130,7 +130,7 @@ def test_bulk_get_compression(conf, num_docs, accept_encoding=None, x_accept_par
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 

--- a/testsuites/syncgateway/functional/test_cbgt_pindex.py
+++ b/testsuites/syncgateway/functional/test_cbgt_pindex.py
@@ -11,7 +11,7 @@ def test_pindex_distribution():
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 

--- a/testsuites/syncgateway/functional/test_continuous.py
+++ b/testsuites/syncgateway/functional/test_continuous.py
@@ -39,7 +39,7 @@ def test_continuous_changes_parametrized(conf, num_users, num_docs, num_revision
             if task_name == "doc_pusher":
 
                 errors = future.result()
-                assert(len(errors) == 0)
+                assert len(errors) == 0
                 abc_doc_pusher.update_docs(num_revs_per_doc=num_revisions)
 
                 time.sleep(10)
@@ -56,7 +56,7 @@ def test_continuous_changes_parametrized(conf, num_users, num_docs, num_revision
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 def test_continuous_changes_sanity(conf, num_docs, num_revisions):
@@ -102,4 +102,4 @@ def test_continuous_changes_sanity(conf, num_docs, num_revisions):
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0

--- a/testsuites/syncgateway/functional/test_db_online_offline.py
+++ b/testsuites/syncgateway/functional/test_db_online_offline.py
@@ -635,7 +635,7 @@ def test_db_offline_tap_loss_sanity(conf, num_docs):
     assert len(errors) == NUM_ENDPOINTS + (num_docs * 2)
     for error_tuple in errors:
         log.info("({},{})".format(error_tuple[0], error_tuple[1]))
-        assert error_tuple[1] == 500
+        assert error_tuple[1] == 503
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)

--- a/testsuites/syncgateway/functional/test_db_online_offline.py
+++ b/testsuites/syncgateway/functional/test_db_online_offline.py
@@ -103,9 +103,9 @@ def rest_scan(sync_gateway, db, online, num_docs, user_name, channels):
     try:
         db_info = admin.get_db_info(db=db)
         if not online:
-            assert (db_info["state"] == "Offline")
+            assert db_info["state"] == "Offline"
         else:
-            assert (db_info["state"] == "Online")
+            assert db_info["state"] == "Online"
         log.info(db_info)
     except HTTPError as e:
         log.info((e.response.url, e.response.status_code))
@@ -155,7 +155,7 @@ def rest_scan(sync_gateway, db, online, num_docs, user_name, channels):
     # GET /{db}/{local-doc-id}
     try:
         doc = user.get_doc("_local/{}".format(local_doc_id))
-        assert(doc["content"]["message"] == "I should not be replicated")
+        assert doc["content"]["message"] == "I should not be replicated"
     except HTTPError as e:
         log.info((e.response.url, e.response.status_code))
         error_responses.append((e.response.url, e.response.status_code))
@@ -164,7 +164,7 @@ def rest_scan(sync_gateway, db, online, num_docs, user_name, channels):
     try:
         all_docs_result = user.get_all_docs()
         # num_docs /{db}/{doc} PUT + num_docs /{db}/_bulk_docs + num_docs POST /{db}/
-        assert(len(all_docs_result["rows"]) == num_docs * 3)
+        assert len(all_docs_result["rows"]) == num_docs * 3
     except HTTPError as e:
         log.info((e.response.url, e.response.status_code))
         error_responses.append((e.response.url, e.response.status_code))
@@ -174,7 +174,7 @@ def rest_scan(sync_gateway, db, online, num_docs, user_name, channels):
         doc_ids = list(user.cache.keys())
         first_ten_ids = doc_ids[:10]
         first_ten = user.get_docs(first_ten_ids)
-        assert(len(first_ten) == 10)
+        assert len(first_ten) == 10
     except HTTPError as e:
         log.info((e.response.url, e.response.status_code))
         error_responses.append((e.response.url, e.response.status_code))
@@ -205,18 +205,18 @@ def test_online_default_rest(conf, num_docs):
 
     # all db endpoints should function as expected
     errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
     # Scenario 4
     # Check the db has an Online state at each running sync_gateway
     for sg in cluster.sync_gateways:
         admin = Admin(sg)
         db_info = admin.get_db_info("db")
-        assert (db_info["state"] == "Online")
+        assert db_info["state"] == "Online"
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 # Scenario 2
@@ -231,18 +231,18 @@ def test_offline_false_config_rest(conf, num_docs):
     # all db endpoints should function as expected
     errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
 
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
     # Scenario 4
     # Check the db has an Online state at each running sync_gateway
     for sg in cluster.sync_gateways:
         admin = Admin(sg)
         db_info = admin.get_db_info("db")
-        assert (db_info["state"] == "Online")
+        assert db_info["state"] == "Online"
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 # Scenario 3
@@ -257,24 +257,24 @@ def test_online_to_offline_check_503(conf, num_docs):
 
     # all db endpoints should function as expected
     errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
     # Take bucket offline
     status = admin.take_db_offline(db="db")
-    assert(status == 200)
+    assert status == 200
 
     # all db endpoints should return 503
     errors = rest_scan(cluster.sync_gateways[0], db="db", online=False, num_docs=num_docs, user_name="seth", channels=["ABC"])
 
     # We hit NUM_ENDPOINT unique REST endpoints + num of doc PUT failures
-    assert(len(errors) == NUM_ENDPOINTS + (num_docs * 2))
+    assert len(errors) == NUM_ENDPOINTS + (num_docs * 2)
     for error_tuple in errors:
         log.info("({},{})".format(error_tuple[0], error_tuple[1]))
-        assert(error_tuple[1] == 503)
+        assert error_tuple[1] == 503
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 # Scenario 5 - continuous
@@ -305,7 +305,7 @@ def test_online_to_offline_changes_feed_controlled_close_continuous(conf, num_do
             if task_name == "db_offline_task":
                 log.info("DB OFFLINE")
                 # make sure db_offline returns 200
-                assert(future.result() == 200)
+                assert future.result() == 200
             elif task_name == "docs_push":
                 log.info("DONE PUSHING DOCS")
                 doc_add_errors = future.result()
@@ -319,11 +319,11 @@ def test_online_to_offline_changes_feed_controlled_close_continuous(conf, num_do
     log.info("Number of docs add errors ({})".format(len(doc_add_errors)))
 
     # Some docs should have made it to _changes
-    assert(len(docs_in_changes) > 0)
+    assert len(docs_in_changes) > 0
 
     # Bring db back online
     status = admin.bring_db_online("db")
-    assert(status == 200)
+    assert status == 200
 
     # Get all docs that have been pushed
     # Verify that changes returns all of them
@@ -333,11 +333,11 @@ def test_online_to_offline_changes_feed_controlled_close_continuous(conf, num_do
 
     # Check that the number of errors return when trying to push while db is offline + num of docs in db
     # should equal the number of docs
-    assert(num_docs_pushed + len(doc_add_errors) == num_docs)
+    assert num_docs_pushed + len(doc_add_errors) == num_docs
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 # Scenario 6 - longpoll
@@ -367,7 +367,7 @@ def test_online_to_offline_continous_changes_feed_controlled_close_sanity_mulitp
             if task_name == "db_offline_task":
                 log.info("DB OFFLINE")
                 # make sure db_offline returns 200
-                assert(future.result() == 200)
+                assert future.result() == 200
             if task_name.startswith("user"):
                 # Long poll will exit with 503, return docs in the exception
                 log.info("POLLING DONE")
@@ -377,18 +377,18 @@ def test_online_to_offline_continous_changes_feed_controlled_close_sanity_mulitp
                 except Exception as e:
                     log.error("Continious feed close error: {}".format(e))
                     # continuous should be closed so this exception should never happen
-                    assert(0)
+                    assert 0
 
     # Assert that the feed close results length is num_users
-    assert(len(feed_close_results) == num_users)
+    assert len(feed_close_results) == num_users
 
     # No docs should be returned
     for feed_result in feed_close_results:
-        assert(len(feed_result) == 0)
+        assert len(feed_result) == 0
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 # Scenario 6 - longpoll
@@ -418,7 +418,7 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll_sanity(conf, n
             if task_name == "db_offline_task":
                 log.info("DB OFFLINE")
                 # make sure db_offline returns 200
-                assert(future.result() == 200)
+                assert future.result() == 200
             if task_name == "polling":
                 # Long poll will exit with 503, return docs in the exception
                 log.info("POLLING DONE")
@@ -427,17 +427,17 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll_sanity(conf, n
                 except Exception as e:
                     log.error("Longpoll feed close error: {}".format(e))
                     # long poll should be closed so this exception should never happen
-                    assert(0)
+                    assert 0
 
     # Account for _user doc
     # last_seq may be of the form '1' for channel cache or '1-0' for distributed index
     seq_num_component = last_seq_num.split("-")
-    assert(1 == int(seq_num_component[0]))
-    assert(len(docs_in_changes) == 0)
+    assert 1 == int(seq_num_component[0])
+    assert len(docs_in_changes) == 0
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 # Scenario 6 - longpoll
@@ -467,7 +467,7 @@ def test_online_to_offline_longpoll_changes_feed_controlled_close_sanity_mulitpl
             if task_name == "db_offline_task":
                 log.info("DB OFFLINE")
                 # make sure db_offline returns 200
-                assert(future.result() == 200)
+                assert future.result() == 200
             if task_name.startswith("user"):
                 # Long poll will exit with 503, return docs in the exception
                 log.info("POLLING DONE")
@@ -477,23 +477,23 @@ def test_online_to_offline_longpoll_changes_feed_controlled_close_sanity_mulitpl
                 except Exception as e:
                     log.error("Longpoll feed close error: {}".format(e))
                     # long poll should be closed so this exception should never happen
-                    assert(0)
+                    assert 0
 
     # Assert that the feed close results length is num_users
-    assert(len(feed_close_results) == num_users)
+    assert len(feed_close_results) == num_users
 
     # Account for _user doc
     # last_seq may be of the form '1' for channel cache or '1-0' for distributed index
     for feed_result in feed_close_results:
         docs_in_changes = feed_result[0]
         seq_num_component = feed_result[1].split("-")
-        assert(len(docs_in_changes) == 0)
-        assert(int(seq_num_component[0]) > 0)
+        assert len(docs_in_changes) == 0
+        assert int(seq_num_component[0]) > 0
 
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 # Scenario 6 - longpoll
@@ -525,7 +525,7 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll(conf, num_docs
             if task_name == "db_offline_task":
                 log.info("DB OFFLINE")
                 # make sure db_offline returns 200
-                assert(future.result() == 200)
+                assert future.result() == 200
             if task_name == "docs_push":
                 log.info("DONE PUSHING DOCS")
                 doc_add_errors = future.result()
@@ -550,18 +550,18 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll(conf, num_docs
     log.info("Number of docs add errors ({})".format(len(doc_add_errors)))
 
     # Some docs should have made it to _changes
-    assert(len(docs_in_changes) > 0)
+    assert len(docs_in_changes) > 0
 
     seq_num_component = last_seq_num.split("-")
 
     # last_seq may be of the form '1' for channel cache or '1-0' for distributed index
     # assert the last_seq_number == number _changes + 2 (_user doc starts and one and docs start at _user doc seq + 2)
     seq_num_component = last_seq_num.split("-")
-    assert(len(docs_in_changes) + 2 == int(seq_num_component[0]))
+    assert len(docs_in_changes) + 2 == int(seq_num_component[0])
 
     # Bring db back online
     status = admin.bring_db_online("db")
-    assert(status == 200)
+    assert status == 200
     #
     # Get all docs that have been pushed
     # Verify that changes returns all of them
@@ -571,11 +571,11 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll(conf, num_docs
 
     # Check that the number of errors return when trying to push while db is offline + num of docs in db
     # should equal the number of docs
-    assert(num_docs_pushed + len(doc_add_errors) == num_docs)
+    assert num_docs_pushed + len(doc_add_errors) == num_docs
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 # Scenario 6
@@ -592,10 +592,10 @@ def test_offline_true_config_bring_online(conf, num_docs):
     # all db endpoints should fail with 503
     errors = rest_scan(cluster.sync_gateways[0], db="db", online=False, num_docs=num_docs, user_name="seth", channels=["ABC"])
 
-    assert(len(errors) == NUM_ENDPOINTS + (num_docs * 2))
+    assert len(errors) == NUM_ENDPOINTS + (num_docs * 2)
     for error_tuple in errors:
         log.info("({},{})".format(error_tuple[0], error_tuple[1]))
-        assert(error_tuple[1] == 503)
+        assert error_tuple[1] == 503
 
     # Scenario 9
     # POST /db/_online
@@ -604,11 +604,11 @@ def test_offline_true_config_bring_online(conf, num_docs):
 
     # all db endpoints should succeed
     errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 # Scenario 14
@@ -624,22 +624,22 @@ def test_db_offline_tap_loss_sanity(conf, num_docs):
 
     # all db rest enpoints should succeed
     errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
     # Delete bucket to sever TAP feed
     status = cluster.servers[0].delete_bucket("data-bucket")
-    assert (status == 0)
+    assert status == 0
 
     # Check that bucket is in offline state
     errors = rest_scan(cluster.sync_gateways[0], db="db", online=False, num_docs=num_docs, user_name="seth", channels=["ABC"])
-    assert(len(errors) == NUM_ENDPOINTS + (num_docs * 2))
+    assert len(errors) == NUM_ENDPOINTS + (num_docs * 2)
     for error_tuple in errors:
         log.info("({},{})".format(error_tuple[0], error_tuple[1]))
-        assert(error_tuple[1] == 503)
+        assert error_tuple[1] == 500
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 # Scenario 11
@@ -661,7 +661,7 @@ def test_db_delayed_online(conf, num_docs):
     pool = ThreadPool(processes=1)
 
     db_info = admin.get_db_info("db")
-    assert (db_info["state"] == "Offline")
+    assert db_info["state"] == "Offline"
 
     async_result = pool.apply_async(admin.bring_db_online, ("db", 15,))
     status = async_result.get(timeout=15)
@@ -670,15 +670,15 @@ def test_db_delayed_online(conf, num_docs):
     time.sleep(20)
 
     db_info = admin.get_db_info("db")
-    assert (db_info["state"] == "Online")
+    assert db_info["state"] == "Online"
 
     # all db rest enpoints should succeed
     errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 def test_multiple_dbs_unique_buckets_lose_tap(conf, num_docs):
@@ -694,29 +694,29 @@ def test_multiple_dbs_unique_buckets_lose_tap(conf, num_docs):
     # all db rest endpoints should succeed
     for db in dbs:
         errors = rest_scan(cluster.sync_gateways[0], db=db, online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
-        assert(len(errors) == 0)
+        assert len(errors) == 0
 
     status = cluster.servers[0].delete_bucket("data-bucket-1")
-    assert(status == 0)
+    assert status == 0
     status = cluster.servers[0].delete_bucket("data-bucket-3")
-    assert(status == 0)
+    assert status == 0
 
     # Check that db2 and db4 are still Online
     for db in ["db2", "db4"]:
         errors = rest_scan(cluster.sync_gateways[0], db=db, online=True, num_docs=num_docs, user_name="adam", channels=["CBS"])
-        assert(len(errors) == 0)
+        assert len(errors) == 0
 
     # Check that db1 and db3 go offline
     for db in ["db1", "db3"]:
         errors = rest_scan(cluster.sync_gateways[0], db=db, online=False, num_docs=num_docs, user_name="seth", channels=["ABC"])
-        assert(len(errors) == NUM_ENDPOINTS + (num_docs * 2))
+        assert len(errors) == NUM_ENDPOINTS + (num_docs * 2)
         for error_tuple in errors:
             log.info("({},{})".format(error_tuple[0], error_tuple[1]))
-            assert(error_tuple[1] == 503)
+            assert error_tuple[1] == 503
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 # Reenable for 1.3

--- a/testsuites/syncgateway/functional/test_db_online_offline_resync.py
+++ b/testsuites/syncgateway/functional/test_db_online_offline_resync.py
@@ -81,7 +81,7 @@ def test_bucket_online_offline_resync_sanity(num_users, num_docs, num_revisions)
 
     # Take "db" offline
     status = admin.take_db_offline(db="db")
-    assert(status == 200)
+    assert status == 200
 
     restart_status = cluster.sync_gateways[0].restart("resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_restricted_cc.json")
     assert restart_status == 0
@@ -90,10 +90,10 @@ def test_bucket_online_offline_resync_sanity(num_users, num_docs, num_revisions)
 
     num_changes = admin.db_resync(db="db")
     log.info("expecting num_changes {} == num_docs {} * num_users {}".format(num_changes, num_docs, num_users))
-    assert(num_changes['payload']['changes'] == num_docs * num_users)
+    assert num_changes['payload']['changes'] == num_docs * num_users
 
     status = admin.bring_db_online(db="db")
-    assert(status == 200)
+    assert status == 200
 
     time.sleep(5)
     global_cache = list()
@@ -106,7 +106,7 @@ def test_bucket_online_offline_resync_sanity(num_users, num_docs, num_revisions)
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
     end = time.time()
     log.info("Test ended.")
@@ -191,7 +191,7 @@ def test_bucket_online_offline_resync_with_online(num_users, num_docs, num_revis
 
     # Take "db" offline
     status = admin.take_db_offline(db="db")
-    assert(status == 200)
+    assert status == 200
 
     restart_status = cluster.sync_gateways[0].restart("resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_restricted_cc.json")
     assert restart_status == 0
@@ -205,7 +205,7 @@ def test_bucket_online_offline_resync_with_online(num_users, num_docs, num_revis
 
     db_info = admin.get_db_info("db")
     log.info("Status of db = {}".format(db_info["state"]))
-    assert(db_info["state"] == "Offline")
+    assert db_info["state"] == "Offline"
 
     try:
         async_resync_result = pool.apply_async(admin.db_resync, ("db",))
@@ -245,13 +245,13 @@ def test_bucket_online_offline_resync_with_online(num_users, num_docs, num_revis
     time.sleep(5)
     db_info = admin.get_db_info("db")
     log.info("Status of db = {}".format(db_info["state"]))
-    assert (db_info["state"] == "Online")
+    assert db_info["state"] == "Online"
 
     resync_result = async_resync_result.get()
     log.info("resync_changes {}".format(resync_result))
     log.info("expecting num_changes  == num_docs {} * num_users {}".format( num_docs, num_users))
-    assert(resync_result['payload']['changes'] == num_docs * num_users)
-    assert(resync_result['status_code'] == 200)
+    assert resync_result['payload']['changes'] == num_docs * num_users
+    assert resync_result['status_code'] == 200
 
     time.sleep(5)
     global_cache = list()
@@ -264,7 +264,7 @@ def test_bucket_online_offline_resync_with_online(num_users, num_docs, num_revis
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
     end = time.time()
     log.info("Test ended.")
@@ -350,7 +350,7 @@ def test_bucket_online_offline_resync_with_offline(num_users, num_docs, num_revi
 
     # Take "db" offline
     status = admin.take_db_offline(db="db")
-    assert(status == 200)
+    assert status == 200
 
     restart_status = cluster.sync_gateways[0].restart("resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_restricted_cc.json")
     assert restart_status == 0
@@ -364,7 +364,7 @@ def test_bucket_online_offline_resync_with_offline(num_users, num_docs, num_revi
 
     db_info = admin.get_db_info("db")
     log.info("Status of db = {}".format(db_info["state"]))
-    assert(db_info["state"] == "Offline")
+    assert db_info["state"] == "Offline"
 
     try:
         async_resync_result = pool.apply_async(admin.db_resync, ("db",))
@@ -403,13 +403,13 @@ def test_bucket_online_offline_resync_with_offline(num_users, num_docs, num_revi
     time.sleep(5)
     db_info = admin.get_db_info("db")
     log.info("Status of db = {}".format(db_info["state"]))
-    assert (db_info["state"] == "Online")
+    assert db_info["state"] == "Online"
 
     resync_result = async_resync_result.get()
     log.info("resync_changes {}".format(resync_result))
     log.info("expecting num_changes  == num_docs {} * num_users {}".format( num_docs, num_users))
-    assert(resync_result['payload']['changes'] == num_docs * num_users)
-    assert(resync_result['status_code'] == 200)
+    assert resync_result['payload']['changes'] == num_docs * num_users
+    assert resync_result['status_code'] == 200
 
     time.sleep(5)
     global_cache = list()
@@ -422,7 +422,7 @@ def test_bucket_online_offline_resync_with_offline(num_users, num_docs, num_revi
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
     end = time.time()
     log.info("Test ended.")

--- a/testsuites/syncgateway/functional/test_db_online_offline_webhooks.py
+++ b/testsuites/syncgateway/functional/test_db_online_offline_webhooks.py
@@ -46,11 +46,11 @@ def test_webhooks(num_users, num_channels, num_docs, num_revisions):
     expected_events = (num_users * num_docs * num_revisions) + (num_users * num_docs)
     received_events = len(ws.get_data())
     log.info("expected_events: {} received_events {}".format(expected_events, received_events))
-    assert (expected_events == received_events)
+    assert expected_events == received_events
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 # implements scenarios: 18 and 19
@@ -92,22 +92,22 @@ def test_db_online_offline_webhooks_offline(num_users, num_channels, num_docs, n
     time.sleep(5)
     db_info = admin.get_db_info("db")
     log.info("Expecting db state {} found db state {}".format("Offline",db_info['state']))
-    assert (db_info["state"] == "Offline")
+    assert db_info["state"] == "Offline"
 
     webhook_events = ws.get_data()
     time.sleep(5)
     log.info("webhook event {}".format(webhook_events))
     last_event = webhook_events[-1]
-    assert (last_event['state'] == 'offline')
+    assert last_event['state'] == 'offline'
 
     admin.bring_db_online("db")
     time.sleep(5)
     db_info = admin.get_db_info("db")
     log.info("Expecting db state {} found db state {}".format("Online", db_info['state']))
-    assert (db_info["state"] == "Online")
+    assert db_info["state"] == "Online"
     webhook_events = ws.get_data()
     last_event = webhook_events[-1]
-    assert (last_event['state'] == 'online')
+    assert last_event['state'] == 'online'
     time.sleep(10)
     log.info("webhook event {}".format(webhook_events))
 
@@ -116,7 +116,7 @@ def test_db_online_offline_webhooks_offline(num_users, num_channels, num_docs, n
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 # implements scenarios: 21
@@ -155,7 +155,7 @@ def test_db_online_offline_webhooks_offline_two(num_users, num_channels, num_doc
     time.sleep(10)
 
     status = cluster.servers[0].delete_bucket("data-bucket")
-    assert(status == 0)
+    assert status == 0
 
     log.info("Sleeping for 120 seconds...")
     time.sleep(120)
@@ -164,11 +164,11 @@ def test_db_online_offline_webhooks_offline_two(num_users, num_channels, num_doc
     time.sleep(5)
     log.info("webhook event {}".format(webhook_events))
     last_event = webhook_events[-1]
-    assert (last_event['state'] == 'offline')
+    assert last_event['state'] == 'offline'
 
     ws.stop()
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 

--- a/testsuites/syncgateway/functional/test_dcp_reshard.py
+++ b/testsuites/syncgateway/functional/test_dcp_reshard.py
@@ -51,7 +51,7 @@ def test_dcp_reshard_sync_gateway_goes_down(conf):
 
     # Verify that the sg1 is down but the other sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 1 and errors[0][0].hostname == "ac1")
+    assert len(errors) == 1 and errors[0][0].hostname == "ac1"
 
 
 def test_dcp_reshard_sync_gateway_comes_up(conf):
@@ -98,7 +98,7 @@ def test_dcp_reshard_sync_gateway_comes_up(conf):
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 def test_dcp_reshard_single_sg_accel_goes_down_and_up(conf):
@@ -157,4 +157,4 @@ def test_dcp_reshard_single_sg_accel_goes_down_and_up(conf):
 
     # Verify that all sync_gateways and
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0

--- a/testsuites/syncgateway/functional/test_longpoll.py
+++ b/testsuites/syncgateway/functional/test_longpoll.py
@@ -56,7 +56,7 @@ def test_longpoll_changes_parametrized(conf, num_docs, num_revisions):
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 def test_longpoll_changes_sanity(conf, num_docs, num_revisions):
@@ -103,4 +103,4 @@ def test_longpoll_changes_sanity(conf, num_docs, num_revisions):
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0

--- a/testsuites/syncgateway/functional/test_multiple_dbs.py
+++ b/testsuites/syncgateway/functional/test_multiple_dbs.py
@@ -52,7 +52,7 @@ def test_multiple_db_unique_data_bucket_unique_index_bucket(conf, num_users, num
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 # Kind of an edge case in that most users would not point multiple dbs at the same server bucket
@@ -98,4 +98,4 @@ def test_multiple_db_single_data_bucket_single_index_bucket(conf, num_users, num
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0

--- a/testsuites/syncgateway/functional/test_multiple_users_multiple_channels_multiple_revisions.py
+++ b/testsuites/syncgateway/functional/test_multiple_users_multiple_channels_multiple_revisions.py
@@ -94,7 +94,7 @@ def test_mulitple_users_mulitiple_channels_mulitple_revisions(conf, num_users, n
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
     end = time.time()
     log.info("Test ended.")

--- a/testsuites/syncgateway/functional/test_openid_connect.py
+++ b/testsuites/syncgateway/functional/test_openid_connect.py
@@ -452,7 +452,7 @@ def test_openidconnect_large_scope(sg_url, sg_db):
 
     log_info("decoded_id_token: {}".format(decoded_id_token))
 
-    assert "nickname"  in decoded_id_token.keys()
+    assert "nickname" in decoded_id_token.keys()
 
 
 def test_openidconnect_public_session_endpoint(sg_url, sg_db):

--- a/testsuites/syncgateway/functional/test_overloaded_channel_cache.py
+++ b/testsuites/syncgateway/functional/test_overloaded_channel_cache.py
@@ -84,11 +84,11 @@ def test_overloaded_channel_cache(conf, num_docs, user_channels, filter, limit):
 
         if user_channels == "*" and num_docs == 5000:
             # "*" channel includes _user docs so the verify_changes will result in 10 view queries
-            assert(resp_obj["syncGateway_changeCache"]["view_queries"] == 10)
+            assert resp_obj["syncGateway_changeCache"]["view_queries"] == 10
         else:
             # If number of view queries == 0 the key will not exist in the expvars
-            assert("view_queries" not in resp_obj["syncGateway_changeCache"])
+            assert "view_queries" not in resp_obj["syncGateway_changeCache"]
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0

--- a/testsuites/syncgateway/functional/test_roles.py
+++ b/testsuites/syncgateway/functional/test_roles.py
@@ -64,7 +64,7 @@ def test_roles_sanity(conf):
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 # TODO - Add role mid scenario
 # TODO - Delete role mid scenario

--- a/testsuites/syncgateway/functional/test_seq.py
+++ b/testsuites/syncgateway/functional/test_seq.py
@@ -39,7 +39,7 @@ def test_seq(conf, num_users, num_docs, num_revisions):
     for user in users:
         changes = user.get_changes(since=doc_seq)
         log.info("Trying changes with since={}".format(doc_seq))
-        assert(len(changes["results"]) > 0)
+        assert len(changes["results"]) > 0
 
         second_to_last_doc_entry_seq = changes["results"][-2]["seq"]
         last_doc_entry_seq = changes["results"][-1]["seq"]
@@ -50,11 +50,11 @@ def test_seq(conf, num_users, num_docs, num_revisions):
         if mode == "distributed_index":
             # Verify last "seq" follows the formate 12313-0, not 12313-0::1023.15
             log.info('Verify that the last "seq" is a plain hashed value')
-            assert(len(second_to_last_doc_entry_seq.split("::")) == 2)
-            assert(len(last_doc_entry_seq.split("::")) == 1)
+            assert len(second_to_last_doc_entry_seq.split("::")) == 2
+            assert len(last_doc_entry_seq.split("::")) == 1
         else:
-            assert(second_to_last_doc_entry_seq > 0)
-            assert(last_doc_entry_seq > 0)
+            assert second_to_last_doc_entry_seq > 0
+            assert last_doc_entry_seq > 0
 
     all_doc_caches = [user.cache for user in users]
     all_docs = {k: v for cache in all_doc_caches for k, v in cache.items()}
@@ -62,7 +62,7 @@ def test_seq(conf, num_users, num_docs, num_revisions):
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 

--- a/testsuites/syncgateway/functional/test_single_user_single_channel_doc_updates.py
+++ b/testsuites/syncgateway/functional/test_single_user_single_channel_doc_updates.py
@@ -50,7 +50,7 @@ def test_single_user_single_channel_doc_updates(conf, num_docs, num_revisions):
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
     end = time.time()
     log.info("TIME:{}s".format(end - start))

--- a/testsuites/syncgateway/functional/test_sync.py
+++ b/testsuites/syncgateway/functional/test_sync.py
@@ -76,7 +76,7 @@ def test_issue_1524(conf, num_docs):
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 def test_sync_access_sanity(conf):
@@ -117,7 +117,7 @@ def test_sync_access_sanity(conf):
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 def test_sync_channel_sanity(conf):
@@ -171,7 +171,7 @@ def test_sync_channel_sanity(conf):
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
     # TODO Push more docs to channel and make sure they do not show up in the users changes feed.
 
@@ -235,7 +235,7 @@ def test_sync_role_sanity(conf):
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 def test_sync_sanity(conf):
@@ -274,7 +274,7 @@ def test_sync_sanity(conf):
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 def test_sync_sanity_backfill(conf):
@@ -313,7 +313,7 @@ def test_sync_sanity_backfill(conf):
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 def test_sync_require_roles(conf):
@@ -405,4 +405,4 @@ def test_sync_require_roles(conf):
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0

--- a/testsuites/syncgateway/functional/test_users_channels.py
+++ b/testsuites/syncgateway/functional/test_users_channels.py
@@ -57,7 +57,7 @@ def test_multiple_users_multiple_channels(conf):
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 def test_muliple_users_single_channel(conf):
@@ -98,7 +98,7 @@ def test_muliple_users_single_channel(conf):
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 def test_single_user_multiple_channels(conf):
@@ -130,7 +130,7 @@ def test_single_user_multiple_channels(conf):
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
     end = time.time()
     log.info("TIME:{}s".format(end - start))
@@ -171,7 +171,7 @@ def test_single_user_single_channel(conf):
 
     # Verify all sync_gateways are running
     errors = cluster.verify_alive(mode)
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 


### PR DESCRIPTION
Looking through our old functional tests, I removed all parens around assert expressions. It should have no functional change, but prevents some potential mistakes and it the best practice:

Please see http://stackoverflow.com/questions/3112171/python-assert-with-and-without-parenthesis to see why the tests assertions in the older tests were still functioning correctly. This explains why this was not caught before during test development. Although they were raising assertions correctly, this is not clean and can result in scenarios where assertions are always `True` if  a person is not careful (see below).

DO NOT write asserts like this (always evaluates to true):
```
assert(False, "I should raise an assertion error but I don't")
```

DO write asserts like this
```
assert False, "I will raise an assertion error"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbaselabs/mobile-testkit/673)
<!-- Reviewable:end -->