### PR TITLE
Delete previous sgload if there is one

### DIFF
--- a/libraries/provision/ansible/playbooks/build-sgload.yml
+++ b/libraries/provision/ansible/playbooks/build-sgload.yml
@@ -2,6 +2,13 @@
 - hosts: load_generators
   any_errors_fatal: true
   tasks:
+
+  - name: SGLOAD | Delete previous sgload if there is one
+    shell: rm -rf sgload
+    args:
+      - chdir: /opt/go/src/github.com/couchbaselabs
+    become: yes
+
   - name: SGLOAD | go get sgload
     shell: GOPATH=/opt/go go get -u -v github.com/couchbaselabs/sgload
     become: yes


### PR DESCRIPTION
I've run into annoying issues where if the sgload code is changed on the VM directly (for experimentation), then trying to run the test will fail until it's manually reset with `git reset --hard HEAD`

This change will delete any pre-existing sgload code and reclone from git.