### PR TITLE
Set the revs limit on the perf test

### DIFF
--- a/resources/sync_gateway_configs/performance/sync_gateway_default_performance.json
+++ b/resources/sync_gateway_configs/performance/sync_gateway_default_performance.json
@@ -17,6 +17,7 @@
             "feed_type":"DCPSHARD",
             "server":"http://{{ couchbase_server_primary_node }}:8091",
             "bucket":"data-bucket",
+            "revs_limit":25,
             "channel_index":{
                 "server":"http://{{ couchbase_server_primary_node }}:8091",
                 "bucket":"index-bucket",


### PR DESCRIPTION
Limits docs from growing too large and skewing results