### PR TITLE
Adding the changes for vagrant ethernet public network

### DIFF
--- a/utilities/generate_cluster_configs_from_vagrant_hosts.py
+++ b/utilities/generate_cluster_configs_from_vagrant_hosts.py
@@ -17,8 +17,10 @@ def generate_cluster_configs_from_vagrant(private_network, public_network, publi
     3. Uses this IP list to build a pool.json file and generate the cluster configurations
     """
 
-    if private_network and public_network and public_network_ethernet:
-        raise ProvisioningError("Invalid private_network, public_network and public_network_ethernet flags")
+    if private_network and public_network:
+        raise ProvisioningError("Invalid private_network and public_network flags")
+    elif private_network and public_network_ethernet:
+        raise ProvisioningError("Invalid private_network and public_network_ethernet flags")
 
     if not private_network and not public_network and not public_network_ethernet:
         raise ProvisioningError("Invalid private_network, public_network and public_network_ethernet flags")

--- a/utilities/generate_cluster_configs_from_vagrant_hosts.py
+++ b/utilities/generate_cluster_configs_from_vagrant_hosts.py
@@ -10,26 +10,28 @@ import os
 from libraries.utilities.generate_clusters_from_pool import generate_clusters_from_pool
 
 
-def generate_cluster_configs_from_vagrant(private_network, public_network):
+def generate_cluster_configs_from_vagrant(private_network, public_network, public_network_ethernet):
     """
     1. Gets the status for a running vagrant vm set.
     2. Uses the host name to look up the ip allocated to each vagrant vm instance
     3. Uses this IP list to build a pool.json file and generate the cluster configurations
     """
 
-    if private_network and public_network:
-        raise ProvisioningError("Invalid private_network and public_network flags")
+    if private_network and public_network and public_network_ethernet:
+        raise ProvisioningError("Invalid private_network, public_network and public_network_ethernet flags")
 
-    if not private_network and not public_network:
-        raise ProvisioningError("Invalid private_network and public_network flags")
+    if not private_network and not public_network and not public_network_ethernet:
+        raise ProvisioningError("Invalid private_network, public_network and public_network_ethernet flags")
 
     cwd = os.getcwd()
 
     # Change directory to where the appropriate Vagrantfile lives
     if private_network:
         os.chdir("vagrant/private_network")
-    else:
+    elif public_network:
         os.chdir("vagrant/public_network")
+    else:
+	os.chdir("vagrant/public_network_ethernet")
 
     v = vagrant.Vagrant()
     status = v.status()
@@ -73,6 +75,11 @@ if __name__ == "__main__":
 
        usage: python generate_cluster_configs_from_vagrant_hosts.py
        --public-network
+
+       or
+
+       usage: python generate_cluster_configs_from_vagrant_hosts.py
+       --public-network-ethernet
        """
 
     parser = OptionParser(usage=usage)
@@ -84,9 +91,13 @@ if __name__ == "__main__":
     parser.add_option("", "--public-network",
                       action="store_true", dest="public_network", default=False,
                       help="Use Vagrant public network (Bridged)")
+    
+    parser.add_option("", "--public-network-ethernet",
+                      action="store_true", dest="public_network_ethernet", default=False,
+                      help="Use Vagrant public ethernet network (Bridged)")
 
     arg_parameters = sys.argv[1:]
 
     (opts, args) = parser.parse_args(arg_parameters)
 
-    generate_cluster_configs_from_vagrant(opts.private_network, opts.public_network)
+    generate_cluster_configs_from_vagrant(opts.private_network, opts.public_network, opts.public_network_ethernet)

--- a/utilities/generate_cluster_configs_from_vagrant_hosts.py
+++ b/utilities/generate_cluster_configs_from_vagrant_hosts.py
@@ -25,7 +25,7 @@ def generate_cluster_configs_from_vagrant(private_network, public_network, publi
     elif public_network:
         os.chdir("vagrant/public_network")
     else:
-	os.chdir("vagrant/public_network_ethernet")
+        os.chdir("vagrant/public_network_ethernet")
 
     v = vagrant.Vagrant()
     status = v.status()
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     parser.add_option("", "--public-network",
                       action="store_true", dest="public_network", default=False,
                       help="Use Vagrant public network (Bridged)")
-    
+
     parser.add_option("", "--public-network-ethernet",
                       action="store_true", dest="public_network_ethernet", default=False,
                       help="Use Vagrant public ethernet network (Bridged)")

--- a/utilities/generate_cluster_configs_from_vagrant_hosts.py
+++ b/utilities/generate_cluster_configs_from_vagrant_hosts.py
@@ -17,6 +17,18 @@ def generate_cluster_configs_from_vagrant(private_network, public_network, publi
     3. Uses this IP list to build a pool.json file and generate the cluster configurations
     """
 
+    # Check if only one of the options is set, private_network or public_network or public_network_ethernet
+    if opts.private_network and (opts.public_network or opts.public_network_ethernet):
+        raise ProvisioningError("Invalid private_network and public_network/public_network_ethernet flags")
+    elif opts.public_network and (opts.private_network or opts.public_network_ethernet):
+        raise ProvisioningError("Invalid public_network and private_network/public_network_ethernet flags")
+    elif opts.public_network_ethernet and (opts.public_network or opts.private_network):
+        raise ProvisioningError("Invalid public_network_ethernet and public_network/private_network flags")
+
+    # Check if none of the options are set
+    if not opts.private_network and not opts.public_network and not opts.public_network_ethernet:
+        raise ProvisioningError("Invalid private_network, public_network and public_network_ethernet flags")
+
     cwd = os.getcwd()
 
     # Change directory to where the appropriate Vagrantfile lives
@@ -93,17 +105,5 @@ if __name__ == "__main__":
     arg_parameters = sys.argv[1:]
 
     (opts, args) = parser.parse_args(arg_parameters)
-
-    # Check if only one of the options is set, private_network or public_network or public_network_ethernet
-    if opts.private_network and (opts.public_network or opts.public_network_ethernet):
-        raise ProvisioningError("Invalid private_network and public_network/public_network_ethernet flags")
-    elif opts.public_network and (opts.private_network or opts.public_network_ethernet):
-        raise ProvisioningError("Invalid public_network and private_network/public_network_ethernet flags")
-    elif opts.public_network_ethernet and (opts.public_network or opts.private_network):
-        raise ProvisioningError("Invalid public_network_ethernet and public_network/private_network flags")
-
-    # Check if none of the options are set
-    if not opts.private_network and not opts.public_network and not opts.public_network_ethernet:
-        raise ProvisioningError("Invalid private_network, public_network and public_network_ethernet flags")
 
     generate_cluster_configs_from_vagrant(opts.private_network, opts.public_network, opts.public_network_ethernet)

--- a/utilities/generate_cluster_configs_from_vagrant_hosts.py
+++ b/utilities/generate_cluster_configs_from_vagrant_hosts.py
@@ -18,15 +18,15 @@ def generate_cluster_configs_from_vagrant(private_network, public_network, publi
     """
 
     # Check if only one of the options is set, private_network or public_network or public_network_ethernet
-    if opts.private_network and (opts.public_network or opts.public_network_ethernet):
+    if private_network and (public_network or public_network_ethernet):
         raise ProvisioningError("Invalid private_network and public_network/public_network_ethernet flags")
-    elif opts.public_network and (opts.private_network or opts.public_network_ethernet):
+    elif public_network and (private_network or public_network_ethernet):
         raise ProvisioningError("Invalid public_network and private_network/public_network_ethernet flags")
-    elif opts.public_network_ethernet and (opts.public_network or opts.private_network):
+    elif public_network_ethernet and (public_network or private_network):
         raise ProvisioningError("Invalid public_network_ethernet and public_network/private_network flags")
 
     # Check if none of the options are set
-    if not opts.private_network and not opts.public_network and not opts.public_network_ethernet:
+    if not private_network and not public_network and not public_network_ethernet:
         raise ProvisioningError("Invalid private_network, public_network and public_network_ethernet flags")
 
     cwd = os.getcwd()

--- a/utilities/generate_cluster_configs_from_vagrant_hosts.py
+++ b/utilities/generate_cluster_configs_from_vagrant_hosts.py
@@ -17,14 +17,6 @@ def generate_cluster_configs_from_vagrant(private_network, public_network, publi
     3. Uses this IP list to build a pool.json file and generate the cluster configurations
     """
 
-    if private_network and public_network:
-        raise ProvisioningError("Invalid private_network and public_network flags")
-    elif private_network and public_network_ethernet:
-        raise ProvisioningError("Invalid private_network and public_network_ethernet flags")
-
-    if not private_network and not public_network and not public_network_ethernet:
-        raise ProvisioningError("Invalid private_network, public_network and public_network_ethernet flags")
-
     cwd = os.getcwd()
 
     # Change directory to where the appropriate Vagrantfile lives
@@ -101,5 +93,17 @@ if __name__ == "__main__":
     arg_parameters = sys.argv[1:]
 
     (opts, args) = parser.parse_args(arg_parameters)
+
+    # Check if only one of the options is set, private_network or public_network or public_network_ethernet
+    if opts.private_network and (opts.public_network or opts.public_network_ethernet):
+        raise ProvisioningError("Invalid private_network and public_network/public_network_ethernet flags")
+    elif opts.public_network and (opts.private_network or opts.public_network_ethernet):
+        raise ProvisioningError("Invalid public_network and private_network/public_network_ethernet flags")
+    elif opts.public_network_ethernet and (opts.public_network or opts.private_network):
+        raise ProvisioningError("Invalid public_network_ethernet and public_network/private_network flags")
+
+    # Check if none of the options are set
+    if not opts.private_network and not opts.public_network and not opts.public_network_ethernet:
+        raise ProvisioningError("Invalid private_network, public_network and public_network_ethernet flags")
 
     generate_cluster_configs_from_vagrant(opts.private_network, opts.public_network, opts.public_network_ethernet)

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,3 +1,4 @@
 
 * private_network - uses NAT, most users want this 
 * public_network - uses bridged networking, use this if connecting physical mobile devices
+* public_network_ethernet - uses bridged networking with thunderbolt ethernet, use this if connecting physical mobile devices

--- a/vagrant/public_network_ethernet/Vagrantfile
+++ b/vagrant/public_network_ethernet/Vagrantfile
@@ -1,0 +1,33 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+
+  host_ips = [
+    "host1",
+    "host2",
+    "host3",
+    "host4"
+  ]
+
+  host_ips.each do |host_name|
+      config.vm.define host_name do |host|
+        host.vm.box = "centos/7"
+        config.vm.network "public_network", bridge: "en4: Thunderbolt Ethernet"
+        host.vm.synced_folder ".", "/home/vagrant/sync", disabled: true
+        host.vm.provider "virtualbox" do |vb|
+            # Customize the amount of memory on the VM:
+            vb.memory = "2048"
+
+            # Allow vm to send data via VPN
+            vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+        end
+      end
+  end
+
+end
+

--- a/vagrant/public_network_ethernet/Vagrantfile
+++ b/vagrant/public_network_ethernet/Vagrantfile
@@ -11,7 +11,8 @@ Vagrant.configure(2) do |config|
     "host1",
     "host2",
     "host3",
-    "host4"
+    "host4",
+    "host5"
   ]
 
   host_ips.each do |host_name|


### PR DESCRIPTION
The vagrant file under public_network assumes en0 wifi as the connection type. It does not work for Thunderbolt ethernet connections. This change adds support to Thunderbolt ethernet connection.

generate_cluster_configs_from_vagrant_hosts.py was also modified to accommodate this new vagrant file.