### PR TITLE
Fixes mono download path check (it is incorrect so it gets downloaded…

### DIFF
--- a/keywords/LiteServNetMono.py
+++ b/keywords/LiteServNetMono.py
@@ -26,7 +26,7 @@ class LiteServNetMono(LiteServBase):
         """
 
         # Skip download if packages is already downloaded
-        expected_binary = "{}/couchbase-lite-net-mono-{}-liteserv/LiteServ.exe".format(BINARY_DIR, self.version_build)
+        expected_binary = "{}/couchbase-lite-net-mono-{}-liteserv/net45/LiteServ.exe".format(BINARY_DIR, self.version_build)
         if os.path.isfile(expected_binary):
             log_info("Package already downloaded: {}".format(expected_binary))
             return

--- a/keywords/LiteServNetMsft.py
+++ b/keywords/LiteServNetMsft.py
@@ -52,12 +52,6 @@ class LiteServNetMsft(LiteServBase):
         2. Extracts the package and removes the zip
         """
 
-        # Skip download if packages is already downloaded
-        expected_binary = "couchbase-lite-net-msft-{}-liteserv/net45/LiteServ.exe".format(self.version_build)
-        if os.path.isfile(expected_binary):
-            log_info("Package already downloaded: {}".format(expected_binary))
-            return
-
         version, build = version_and_build(self.version_build)
         download_url = "{}/couchbase-lite-net/{}/{}/LiteServ.zip".format(LATEST_BUILDS, version, build)
         package_name = "couchbase-lite-net-msft-{}-liteserv".format(self.version_build)

--- a/keywords/LiteServNetMsft.py
+++ b/keywords/LiteServNetMsft.py
@@ -52,6 +52,12 @@ class LiteServNetMsft(LiteServBase):
         2. Extracts the package and removes the zip
         """
 
+        # Skip download if packages is already downloaded
+        expected_binary = "couchbase-lite-net-msft-{}-liteserv/net45/LiteServ.exe".format(self.version_build)
+        if os.path.isfile(expected_binary):
+            log_info("Package already downloaded: {}".format(expected_binary))
+            return
+
         version, build = version_and_build(self.version_build)
         download_url = "{}/couchbase-lite-net/{}/{}/LiteServ.zip".format(LATEST_BUILDS, version, build)
         package_name = "couchbase-lite-net-msft-{}-liteserv".format(self.version_build)
@@ -70,7 +76,7 @@ class LiteServNetMsft(LiteServBase):
         Installs needed packages on Windows host and removes any existing service wrappers for LiteServ
         """
 
-        directory_path = "couchbase-lite-net-msft-{}-liteserv/LiteServ.exe".format(self.version_build)
+        directory_path = "couchbase-lite-net-msft-{}-liteserv/net45/LiteServ.exe".format(self.version_build)
         status = self.ansible_runner.run_ansible_playbook("install-liteserv-windows.yml", extra_vars={
             "directory_path": directory_path
         })

--- a/libraries/provision/ansible/playbooks/download-liteserv-msft.yml
+++ b/libraries/provision/ansible/playbooks/download-liteserv-msft.yml
@@ -5,21 +5,38 @@
     package_name:
 
   tasks:
-  - debug: msg="download_url {{ download_url }}, package_name {{ package_name }}"
+  - debug:
+      msg: "download_url {{ download_url }}, package_name {{ package_name }}"
+
+  - win_stat:
+      path: C:\Users\{{ ansible_user }}\Desktop\LiteServ\{{ package_name }}\net45\LiteServ.exe
+    register: st
 
   - name: Delete any exiting packages
-    win_file: path=C:\Users\{{ ansible_user }}\Desktop\LiteServ state=absent
+    win_file: 
+      path: C:\Users\{{ ansible_user }}\Desktop\LiteServ 
+      state: absent
+    when: st.stat.exists == False
+
+  - debug:
+      msg: "{{ package_name }} already present, skipping download..."
+    when: st.stat.exists
 
   - name: Create LiteServ directory
-    win_file: path=C:\Users\{{ ansible_user }}\Desktop\LiteServ state=directory
+    win_file: 
+      path: C:\Users\{{ ansible_user }}\Desktop\LiteServ\{{ package_name }}
+      state: directory
+    when: st.stat.exists == False
 
   - name: Download LiteServ Windows .zip
     win_get_url:
       url: "{{ download_url }}"
       dest: C:\Users\{{ ansible_user }}\Desktop\LiteServ\{{ package_name }}.zip
+    when: st.stat.exists == False
 
   - name: Unzip package and remove .zip
     win_unzip:
       src: C:\Users\{{ ansible_user }}\Desktop\LiteServ\{{ package_name }}.zip
       dest: C:\Users\{{ ansible_user }}\Desktop\LiteServ\{{ package_name }}
       rm: true
+    when: st.stat.exists == False


### PR DESCRIPTION
… every time even if it exists) and adds similar logic to MSFT

- [X] Ran `flake8`

#### Changes proposed in this pull request:

- Check the correct directory for existing Mono LiteServ
- Perform similar logic for Windows LiteServ

