### PR TITLE
Fix/net45 path in testkit unittests

### DIFF
--- a/mobile_testkit_tests/test_liteserv_net_mono.py
+++ b/mobile_testkit_tests/test_liteserv_net_mono.py
@@ -45,9 +45,9 @@ def test_net_mono_download(request):
 
     liteserv.download()
 
-    assert os.path.isdir("deps/binaries/net45/couchbase-lite-net-mono-{}-liteserv".format(net_version))
-    assert os.path.isfile("deps/binaries/net45/couchbase-lite-net-mono-{}-liteserv/LiteServ.exe".format(net_version))
-    assert not os.path.isfile("deps/binaries/net45/couchbase-lite-net-mono-{}-liteserv.zip".format(net_version))
+    assert os.path.isdir("deps/binaries/couchbase-lite-net-mono-{}-liteserv".format(net_version))
+    assert os.path.isfile("deps/binaries/couchbase-lite-net-mono-{}-liteserv/net45/LiteServ.exe".format(net_version))
+    assert not os.path.isfile("deps/binaries/couchbase-lite-net-mono-{}-liteserv.zip".format(net_version))
 
 
 def test_net_mono_install():

--- a/mobile_testkit_tests/test_liteserv_net_mono.py
+++ b/mobile_testkit_tests/test_liteserv_net_mono.py
@@ -45,9 +45,9 @@ def test_net_mono_download(request):
 
     liteserv.download()
 
-    assert os.path.isdir("deps/binaries/couchbase-lite-net-mono-{}-liteserv".format(net_version))
-    assert os.path.isfile("deps/binaries/couchbase-lite-net-mono-{}-liteserv/LiteServ.exe".format(net_version))
-    assert not os.path.isfile("deps/binaries/couchbase-lite-net-mono-{}-liteserv.zip".format(net_version))
+    assert os.path.isdir("deps/binaries/net45/couchbase-lite-net-mono-{}-liteserv".format(net_version))
+    assert os.path.isfile("deps/binaries/net45/couchbase-lite-net-mono-{}-liteserv/LiteServ.exe".format(net_version))
+    assert not os.path.isfile("deps/binaries/net45/couchbase-lite-net-mono-{}-liteserv.zip".format(net_version))
 
 
 def test_net_mono_install():


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`

#### Changes proposed in this pull request:

- Fix path for binary for LiteServ mono in testkit unit tests

