### PR TITLE
Upload cloudformation template to s3 and create stack from there

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ temp_gateload_node
 temp_cbagent_config_template.conf
 temp_cbagent_config_template.conf-e
 
-cloudformation_template.json
+*_cf_template.json
 temp_ansible_hosts
 conf/hosts.ini
 


### PR DESCRIPTION


#### Fixes #896.

- [x] Ran `flake8`

#### Changes proposed in this pull request:

- Before, generate cloudformation template locally, then create stack
- Now, generate cloudformation stack, upload to s3, create stack from s3 url to get around filesize limit of 54000 bytes

