### PR TITLE
Feature/sg accel support to log rotation tests

### DIFF
--- a/keywords/utils.py
+++ b/keywords/utils.py
@@ -71,6 +71,20 @@ def version_and_build(full_version):
     return version_parts[0], version_parts[1]
 
 
+def host_for_url(url):
+    """ Takes a url in the form of http://192.168.33.10:4985
+    and returns an host in the form 192.168.33.10
+    """
+
+    import pdb
+    pdb.set_trace()
+
+    host = url.replace("http://", "")
+    host = host.split(":")[0]
+    log_info("Extracted host () from url ()".format(host, url))
+
+    return host
+
 # Targeted playbooks need to use the host_name (i.e. sg1)
 def hostname_for_url(cluster_config, url):
     cluster_config = "{}.json".format(cluster_config)

--- a/keywords/utils.py
+++ b/keywords/utils.py
@@ -76,14 +76,12 @@ def host_for_url(url):
     and returns an host in the form 192.168.33.10
     """
 
-    import pdb
-    pdb.set_trace()
-
     host = url.replace("http://", "")
     host = host.split(":")[0]
     log_info("Extracted host () from url ()".format(host, url))
 
     return host
+
 
 # Targeted playbooks need to use the host_name (i.e. sg1)
 def hostname_for_url(cluster_config, url):

--- a/libraries/provision/ansible/playbooks/tasks/create-sg-accel-user.yml
+++ b/libraries/provision/ansible/playbooks/tasks/create-sg-accel-user.yml
@@ -2,3 +2,8 @@
 - name: SG ACCEL | Create sg_accel user
   user: name=sg_accel createhome=yes
 
+# Add tmp logging dir (Log Rotation testing)
+- name: SG ACCEL  | Create /tmp/sg_logs
+  file:
+    path: /tmp/sg_logs
+    state: directory

--- a/libraries/provision/ansible/playbooks/tasks/remove-sg-accel.yml
+++ b/libraries/provision/ansible/playbooks/tasks/remove-sg-accel.yml
@@ -32,3 +32,7 @@
 - name: SG ACCEL | Remove sg accel source .repo directory
   shell: rm -rf /home/centos/.repo
   ignore_errors: yes
+
+- name: SG ACCEL | Remove tmp logging dir (log rotation tests)
+  shell: rm -rf /tmp/sg_logs
+  ignore_errors: yes

--- a/resources/sync_gateway_configs/log_rotation_di.json
+++ b/resources/sync_gateway_configs/log_rotation_di.json
@@ -1,0 +1,33 @@
+{
+  "adminInterface": "0.0.0.0:4985",
+  "logging": {
+    "default": {
+      "logFilePath": "/tmp/sg_logs/sg_log_rotation.log",
+      "logKeys": ["*"],
+      "logLevel": "debug",
+      "rotation": {
+        "maxsize": 1,
+        "maxage": 30,
+        "maxbackups": 2,
+        "localtime": true
+      }
+    }
+  },
+  "cluster_config": {
+    "server":"http://{{ couchbase_server_primary_node }}:8091",
+    "data_dir":".",
+    "bucket":"data-bucket"
+  },
+  "databases": {
+    "db": {
+      "server":"http://{{ couchbase_server_primary_node }}:8091",
+      "bucket":"data-bucket",
+      "users": {"GUEST": {"disabled": false,"admin_channels": ["*"]}},
+      "channel_index":{
+        "server":"http://{{ couchbase_server_primary_node }}:8091",
+        "bucket":"index-bucket",
+        "writer":{{ is_index_writer }}
+      }
+    }
+  }
+}

--- a/resources/sync_gateway_configs/testfest_todo_di.json
+++ b/resources/sync_gateway_configs/testfest_todo_di.json
@@ -22,6 +22,7 @@
         "hideki": {"password": "pass", "admin_channels": ["hideki"]},
         "pasin": {"password": "pass", "admin_channels": ["pasin"]},
         "jens": {"password": "pass", "admin_channels": ["jens"]},
+        "jim": {"password": "pass", "admin_channels": ["jim"]},
         "seth": {"password": "pass", "admin_channels": ["seth"]},
         "raghu": {"password": "pass", "admin_channels": ["raghu"]},
         "mod": {"password": "pass", "admin_roles": ["moderator"]},

--- a/testsuites/syncgateway/functional/tests/test_log_rotation.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation.py
@@ -203,6 +203,7 @@ def test_log_nondefault_logKeys_set(params_from_base_test_setup, sg_conf_name):
     # Remove generated conf file
     os.remove(temp_conf)
 
+
 @pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.logging

--- a/testsuites/syncgateway/functional/tests/test_log_rotation.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation.py
@@ -51,12 +51,12 @@ def test_log_rotation_default_values(params_from_base_test_setup, sg_conf_name):
             data = json.load(default_conf)
         else:
             template = Template(default_conf.read())
-            data = json.loads(template.render({
-                "couchbase_server_primary_node": utils.host_for_url(cluster_hosts["couchbase_servers"][0]),
-                "is_index_writer": False,
-            }, ))
-
-    log_info(data)
+            server_url = utils.host_for_url(cluster_hosts["couchbase_servers"][0])
+            temp = template.render(
+                couchbase_server_primary_node=server_url,
+                is_index_writer="false"
+            )
+            data = json.loads(temp)
 
     # delete rotation from sample config
     del data['logging']["default"]["rotation"]
@@ -111,9 +111,11 @@ def test_log_logKeys_string(params_from_base_test_setup, sg_conf_name):
 
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)
+
     # read sample sg_conf
     with open(sg_conf) as defaul_conf:
         data = json.load(defaul_conf)
+
     # set logKeys as string in config file
     data['logging']["default"]["logKeys"] = "http"
     # create temp config file in the same folder as sg_conf
@@ -156,9 +158,11 @@ def test_log_nondefault_logKeys_set(params_from_base_test_setup, sg_conf_name):
 
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)
+
     # read sample sg_conf
     with open(sg_conf) as defaul_conf:
         data = json.load(defaul_conf)
+
     # "FAKE" not valid area in logging
     data['logging']["default"]["logKeys"] = ["HTTP", "FAKE"]
     # create temp config file in the same folder as sg_conf
@@ -218,6 +222,7 @@ def test_log_maxage_10_timestamp_ignored(params_from_base_test_setup, sg_conf_na
     # read sample sg_conf
     with open(sg_conf) as defaul_conf:
         data = json.load(defaul_conf)
+
     # set maxage = 10 days
     data['logging']["default"]["rotation"]["maxage"] = 10
     # create temp config file in the same folder as sg_conf
@@ -315,15 +320,14 @@ def test_log_200mb(params_from_base_test_setup, sg_conf_name):
     sg_helper.stop_sync_gateway(cluster_config=cluster_conf, url=sg_one_url)
 
     remote_executor.execute("mkdir -p /tmp/sg_logs")
-
     remote_executor.execute("sudo rm -rf /tmp/sg_logs/sg_log_rotation*")
-
     remote_executor.execute("sudo dd if=/dev/zero of=/tmp/sg_logs/sg_log_rotation.log bs=204850000 count=100")
-
     remote_executor.execute("sudo chmod 777 -R /tmp/sg_logs")
+
     # read sample sg_conf
     with open(sg_conf) as defaul_conf:
         data = json.load(defaul_conf)
+
     # set maxsize by default
     data['logging']["default"]["rotation"]["maxsize"] = 200
     # create temp config file in the same folder as sg_conf
@@ -374,12 +378,11 @@ def test_log_number_backups(params_from_base_test_setup, sg_conf_name):
     sg_helper.stop_sync_gateway(cluster_config=cluster_conf, url=sg_one_url)
 
     remote_executor.execute("mkdir -p /tmp/sg_logs")
-
     remote_executor.execute("sudo rm -rf /tmp/sg_logs/sg_log_rotation*")
     # generate log file with almost 1MB
     remote_executor.execute("sudo dd if=/dev/zero of=/tmp/sg_logs/sg_log_rotation.log bs=1030000 count=1")
-
     remote_executor.execute("sudo chmod 777 -R /tmp/sg_logs")
+
     # iterate 5 times
     for i in xrange(5):
         sg_helper.start_sync_gateway(cluster_config=cluster_conf, url=sg_one_url, config=sg_conf)
@@ -420,9 +423,11 @@ def test_log_rotation_negative(params_from_base_test_setup, sg_conf_name):
 
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)
+
     # read sample sg_conf
     with open(sg_conf) as defaul_conf:
         data = json.load(defaul_conf)
+
     # set negative values for rotation section
     data['logging']["default"]["rotation"] = {
         "maxsize": -1,
@@ -530,6 +535,7 @@ def test_log_logLevel_invalid(params_from_base_test_setup, sg_conf_name):
     data['logging']["default"]["logLevel"] = "debugFake"
 
     temp_conf = "/".join(sg_conf.split('/')[:-2]) + '/temp_conf.json'
+
     # create temp config file in the same folder as sg_conf
     with open(temp_conf, 'w') as fp:
         json.dump(data, fp)


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`

#### Changes proposed in this pull request:

- Allow running log_rotation tests when Sync Gateway is operating in distributed index mode

