### PR TITLE
Disable noisy server goes down test

### DIFF
--- a/resources/sync_gateway_configs/custom_sync/access_di.json
+++ b/resources/sync_gateway_configs/custom_sync/access_di.json
@@ -33,7 +33,7 @@
                 } else if(doc._id == "role_access") {
                     role(doc.users, doc.roles);
                 } else {
-                    channel(doc, doc.channels);
+                    channel(doc.channels);
                 }
             }`
         }

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/test_multiple_servers.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/test_multiple_servers.py
@@ -95,6 +95,7 @@ def test_rebalance_sanity(params_from_base_test_setup):
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.failover
+@pytest.mark.skip(reason="Failing due to - https://github.com/couchbase/sync_gateway/issues/2197")
 def test_server_goes_down_sanity(params_from_base_test_setup):
     """
     1. Start with a two node couchbase server cluster


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`

#### Changes proposed in this pull request:

- Minor sync function fix
- Disable noisy tests until - https://github.com/couchbase/sync_gateway/issues/2197 is resolved

