### PR TITLE
Feature/channel grant to role scenarios

### DIFF
--- a/keywords/utils.py
+++ b/keywords/utils.py
@@ -78,7 +78,7 @@ def host_for_url(url):
 
     host = url.replace("http://", "")
     host = host.split(":")[0]
-    log_info("Extracted host () from url ()".format(host, url))
+    log_info("Extracted host ({}) from url ({})".format(host, url))
 
     return host
 

--- a/resources/sync_gateway_configs/custom_sync/access_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/access_cc.json
@@ -18,6 +18,8 @@
                     access(doc.users, doc.channels);
                 } else if(doc._id == "role_access") {
                     role(doc.users, doc.roles);
+                } else if(doc._id == "channel_grant_to_role") {
+                    access(doc.roles, doc.channels);
                 } else {
                     channel(doc, doc.channels);
                 }

--- a/resources/sync_gateway_configs/custom_sync/access_di.json
+++ b/resources/sync_gateway_configs/custom_sync/access_di.json
@@ -32,6 +32,8 @@
                     access(doc.users, doc.channels);
                 } else if(doc._id == "role_access") {
                     role(doc.users, doc.roles);
+                } else if(doc._id == "channel_grant_to_role") {
+                    access(doc.roles, doc.channels);
                 } else {
                     channel(doc.channels);
                 }

--- a/testsuites/syncgateway/functional/tests/test_changes_backfill.py
+++ b/testsuites/syncgateway/functional/tests/test_changes_backfill.py
@@ -805,6 +805,6 @@ def test_backfill_channel_grant_to_role_longpoll(params_from_base_test_setup, sg
             db=sg_db,
             since=grantee_changes_post_grant["last_seq"],
             auth=grantee_session,
-            feed="longpoll"
+            feed="normal"
         )
         assert len(grantee_changes_post_post_grant["results"]) == 0

--- a/testsuites/syncgateway/functional/tests/test_changes_backfill.py
+++ b/testsuites/syncgateway/functional/tests/test_changes_backfill.py
@@ -19,9 +19,21 @@ from keywords import exceptions
     ("custom_sync/access", "CHANNEL-REST"),
     ("custom_sync/access", "CHANNEL-SYNC"),
     ("custom_sync/access", "ROLE-REST"),
-    ("custom_sync/access", "ROLE-SYNC")
+    ("custom_sync/access", "ROLE-SYNC"),
+    ("custom_sync/access", "CHANNEL-TO-ROLE-REST"),
+    ("custom_sync/access", "CHANNEL-TO-ROLE-SYNC")
 ])
 def test_backfill_channels_oneshot_changes(params_from_base_test_setup, sg_conf_name, grant_type):
+    """
+    Test that checks that docs are backfilled for one shot changes for a access grant (via REST or SYNC)
+
+    CHANNEL-REST = Channel is granted to user via REST
+    CHANNEL-SYNC = Channel is granted to user via sync function access()
+    ROLE-REST = Role is granted to user via REST
+    ROLE-SYNC = Role is granted to user via sync function role()
+    CHANNEL-TO-ROLE-REST = Channel is added to existing role via REST
+    CHANNEL-TO-ROLE-SYNC = Channel is added to existing role via sync access()
+    """
 
     cluster_config = params_from_base_test_setup["cluster_config"]
     topology = params_from_base_test_setup["cluster_topology"]
@@ -41,17 +53,42 @@ def test_backfill_channels_oneshot_changes(params_from_base_test_setup, sg_conf_
     client = MobileRestClient()
 
     admin_user_info = userinfo.UserInfo("admin", "pass", channels=["A"], roles=[])
-    user_b_user_info = userinfo.UserInfo("USER_B", "pass", channels=["B"], roles=[])
+
+    if grant_type == "CHANNEL-TO-ROLE-REST" or grant_type == "CHANNEL-TO-ROLE-SYNC":
+        user_b_user_info = userinfo.UserInfo("USER_B", "pass", channels=["B"], roles=["empty_role"])
+    else:
+        user_b_user_info = userinfo.UserInfo("USER_B", "pass", channels=["B"], roles=[])
 
     # Create users / sessions
-    client.create_user(url=sg_admin_url, db=sg_db,
-                       name=admin_user_info.name, password=admin_user_info.password, channels=admin_user_info.channels)
+    client.create_user(
+        url=sg_admin_url,
+        db=sg_db,
+        name=admin_user_info.name,
+        password=admin_user_info.password,
+        channels=admin_user_info.channels
+    )
 
-    client.create_user(url=sg_admin_url, db=sg_db,
-                       name=user_b_user_info.name, password=user_b_user_info.password, channels=user_b_user_info.channels)
+    client.create_user(
+        url=sg_admin_url,
+        db=sg_db,
+        name=user_b_user_info.name,
+        password=user_b_user_info.password,
+        channels=user_b_user_info.channels,
+        roles=user_b_user_info.roles
+    )
 
-    admin_session = client.create_session(url=sg_admin_url, db=sg_db, name=admin_user_info.name, password=admin_user_info.password)
-    user_b_session = client.create_session(url=sg_admin_url, db=sg_db, name=user_b_user_info.name, password=user_b_user_info.password)
+    admin_session = client.create_session(
+        url=sg_admin_url,
+        db=sg_db,
+        name=admin_user_info.name,
+        password=admin_user_info.password
+    )
+    user_b_session = client.create_session(
+        url=sg_admin_url,
+        db=sg_db,
+        name=user_b_user_info.name,
+        password=user_b_user_info.password
+    )
 
     # Create 50 "A" channel docs
     a_docs = client.add_docs(url=sg_url, db=sg_db, number=50, id_prefix=None, auth=admin_session, channels=["A"])
@@ -73,8 +110,7 @@ def test_backfill_channels_oneshot_changes(params_from_base_test_setup, sg_conf_
     if grant_type == "CHANNEL-REST":
         log_info("Granting user access to channel A via Admin REST user update")
         # Grant via update to user in Admin API
-        client.update_user(url=sg_admin_url, db=sg_db,
-                           name=user_b_user_info.name, channels=["A", "B"])
+        client.update_user(url=sg_admin_url, db=sg_db, name=user_b_user_info.name, channels=["A", "B"])
 
     elif grant_type == "CHANNEL-SYNC":
         log_info("Granting user access to channel A sync function access()")
@@ -99,6 +135,18 @@ def test_backfill_channels_oneshot_changes(params_from_base_test_setup, sg_conf_
         role_access_doc["users"] = ["USER_B"]
         role_access_doc["roles"] = ["role:channel-A-role"]
         client.add_doc(sg_url, db=sg_db, doc=role_access_doc, auth=admin_session)
+
+    elif grant_type == "CHANNEL-TO-ROLE-REST":
+        # Update the empty_role to have channel "A"
+        client.update_role(url=sg_admin_url, db=sg_db, name="empty_role", channels=["A"])
+
+    elif grant_type == "CHANNEL-TO-ROLE-SYNC":
+        # Grant empty_role access to channel "A" via sync function
+        # Grant channel access to role via sync function
+        access_doc = document.create_doc("channel_grant_to_role")
+        access_doc["roles"] = ["role:empty_role"]
+        access_doc["channels"] = ["A"]
+        client.add_doc(url=sg_url, db=sg_db, doc=access_doc, auth=admin_session, use_post=True)
 
     else:
         pytest.fail("Unsupported grant_type!!!!")
@@ -159,9 +207,21 @@ def test_backfill_channels_oneshot_changes(params_from_base_test_setup, sg_conf_
     ("custom_sync/access", "CHANNEL-REST"),
     ("custom_sync/access", "CHANNEL-SYNC"),
     ("custom_sync/access", "ROLE-REST"),
-    ("custom_sync/access", "ROLE-SYNC")
+    ("custom_sync/access", "ROLE-SYNC"),
+    ("custom_sync/access", "CHANNEL-TO-ROLE-REST"),
+    ("custom_sync/access", "CHANNEL-TO-ROLE-SYNC")
 ])
 def test_backfill_channels_oneshot_limit_changes(params_from_base_test_setup, sg_conf_name, grant_type):
+    """
+    Test that checks that docs are backfilled for one shot changes with limit for a access grant (via REST or SYNC)
+
+    CHANNEL-REST = Channel is granted to user via REST
+    CHANNEL-SYNC = Channel is granted to user via sync function access()
+    ROLE-REST = Role is granted to user via REST
+    ROLE-SYNC = Role is granted to user via sync function role()
+    CHANNEL-TO-ROLE-REST = Channel is added to existing role via REST
+    CHANNEL-TO-ROLE-SYNC = Channel is added to existing role via sync access()
+    """
 
     cluster_config = params_from_base_test_setup["cluster_config"]
     topology = params_from_base_test_setup["cluster_topology"]
@@ -181,7 +241,11 @@ def test_backfill_channels_oneshot_limit_changes(params_from_base_test_setup, sg
     client = MobileRestClient()
 
     admin_user_info = userinfo.UserInfo("admin", "pass", channels=["A"], roles=[])
-    user_b_user_info = userinfo.UserInfo("USER_B", "pass", channels=["B"], roles=[])
+
+    if grant_type == "CHANNEL-TO-ROLE-REST" or grant_type == "CHANNEL-TO-ROLE-SYNC":
+        user_b_user_info = userinfo.UserInfo("USER_B", "pass", channels=["B"], roles=["empty_role"])
+    else:
+        user_b_user_info = userinfo.UserInfo("USER_B", "pass", channels=["B"], roles=[])
 
     # Create users / sessions
     client.create_user(url=sg_admin_url, db=sg_db,
@@ -239,6 +303,18 @@ def test_backfill_channels_oneshot_limit_changes(params_from_base_test_setup, sg
         role_access_doc["users"] = ["USER_B"]
         role_access_doc["roles"] = ["role:channel-A-role"]
         client.add_doc(sg_url, db=sg_db, doc=role_access_doc, auth=admin_session)
+
+    elif grant_type == "CHANNEL-TO-ROLE-REST":
+        # Update the empty_role to have channel "A"
+        client.update_role(url=sg_admin_url, db=sg_db, name="empty_role", channels=["A"])
+
+    elif grant_type == "CHANNEL-TO-ROLE-SYNC":
+        # Grant empty_role access to channel "A" via sync function
+        # Grant channel access to role via sync function
+        access_doc = document.create_doc("channel_grant_to_role")
+        access_doc["roles"] = ["role:empty_role"]
+        access_doc["channels"] = ["A"]
+        client.add_doc(url=sg_url, db=sg_db, doc=access_doc, auth=admin_session, use_post=True)
 
     else:
         pytest.fail("Unsupported grant_type!!!!")
@@ -335,9 +411,21 @@ def test_backfill_channels_oneshot_limit_changes(params_from_base_test_setup, sg
     ("custom_sync/access", "CHANNEL-REST"),
     ("custom_sync/access", "CHANNEL-SYNC"),
     ("custom_sync/access", "ROLE-REST"),
-    ("custom_sync/access", "ROLE-SYNC")
+    ("custom_sync/access", "ROLE-SYNC"),
+    ("custom_sync/access", "CHANNEL-TO-ROLE-REST"),
+    ("custom_sync/access", "CHANNEL-TO-ROLE-SYNC")
 ])
-def test_backfill_channels_looping_longpoll_changes(params_from_base_test_setup, sg_conf_name, grant_type):
+def test_backfill_channels_longpoll_changes_with_limit(params_from_base_test_setup, sg_conf_name, grant_type):
+    """
+    Test that checks that docs are backfilled for logpoll changes with limit for a access grant (via REST or SYNC)
+
+    CHANNEL-REST = Channel is granted to user via REST
+    CHANNEL-SYNC = Channel is granted to user via sync function access()
+    ROLE-REST = Role is granted to user via REST
+    ROLE-SYNC = Role is granted to user via sync function role()
+    CHANNEL-TO-ROLE-REST = Channel is added to existing role via REST
+    CHANNEL-TO-ROLE-SYNC = Channel is added to existing role via sync access()
+    """
 
     cluster_config = params_from_base_test_setup["cluster_config"]
     topology = params_from_base_test_setup["cluster_topology"]
@@ -357,7 +445,11 @@ def test_backfill_channels_looping_longpoll_changes(params_from_base_test_setup,
     client = MobileRestClient()
 
     admin_user_info = userinfo.UserInfo("admin", "pass", channels=["A"], roles=[])
-    user_b_user_info = userinfo.UserInfo("USER_B", "pass", channels=["B"], roles=[])
+
+    if grant_type == "CHANNEL-TO-ROLE-REST" or grant_type == "CHANNEL-TO-ROLE-SYNC":
+        user_b_user_info = userinfo.UserInfo("USER_B", "pass", channels=["B"], roles=["empty_role"])
+    else:
+        user_b_user_info = userinfo.UserInfo("USER_B", "pass", channels=["B"], roles=[])
 
     # Create users / sessions
     client.create_user(url=sg_admin_url, db=sg_db,
@@ -426,6 +518,18 @@ def test_backfill_channels_looping_longpoll_changes(params_from_base_test_setup,
             role_access_doc["roles"] = ["role:channel-A-role"]
             client.add_doc(sg_url, db=sg_db, doc=role_access_doc, auth=admin_session)
 
+        elif grant_type == "CHANNEL-TO-ROLE-REST":
+            # Update the empty_role to have channel "A"
+            client.update_role(url=sg_admin_url, db=sg_db, name="empty_role", channels=["A"])
+
+        elif grant_type == "CHANNEL-TO-ROLE-SYNC":
+            # Grant empty_role access to channel "A" via sync function
+            # Grant channel access to role via sync function
+            access_doc = document.create_doc("channel_grant_to_role")
+            access_doc["roles"] = ["role:empty_role"]
+            access_doc["channels"] = ["A"]
+            client.add_doc(url=sg_url, db=sg_db, doc=access_doc, auth=admin_session, use_post=True)
+
         else:
             pytest.fail("Unsupported grant_type!!!!")
 
@@ -478,179 +582,179 @@ def test_backfill_channels_looping_longpoll_changes(params_from_base_test_setup,
     assert len(zero_results["results"]) == 0
 
 
-@pytest.mark.sanity
-@pytest.mark.syncgateway
-@pytest.mark.changes
-@pytest.mark.role
-@pytest.mark.parametrize("sg_conf_name, grant_type, channels_to_grant", [
-    ("custom_sync/access", "CHANNEL-REST", ["A"]),
-    ("custom_sync/access", "CHANNEL-REST", ["A", "B", "C"]),
-    ("custom_sync/access", "CHANNEL-SYNC", ["A"]),
-    ("custom_sync/access", "CHANNEL-SYNC", ["A", "B", "C"])
-])
-def test_backfill_channel_grant_to_role(params_from_base_test_setup, sg_conf_name, grant_type, channels_to_grant):
-    """
-    Test that check that docs are backfilled for a channel grant (via REST or SYNC) to existing role
+# @pytest.mark.sanity
+# @pytest.mark.syncgateway
+# @pytest.mark.changes
+# @pytest.mark.role
+# @pytest.mark.parametrize("sg_conf_name, grant_type, channels_to_grant", [
+#     ("custom_sync/access", "CHANNEL-REST", ["A"]),
+#     ("custom_sync/access", "CHANNEL-REST", ["A", "B", "C"]),
+#     ("custom_sync/access", "CHANNEL-SYNC", ["A"]),
+#     ("custom_sync/access", "CHANNEL-SYNC", ["A", "B", "C"])
+# ])
+# def test_backfill_channel_grant_to_role(params_from_base_test_setup, sg_conf_name, grant_type, channels_to_grant):
+#     """
+#     Test that check that docs are backfilled for a channel grant (via REST or SYNC) to existing role
+#
+#     1. Create a 'grantee' user with an empty role
+#     2. 'pusher' user adds docs with channel(s) that will later be granted to 'grantee'
+#     3. Verify that the 'pusher' sees the docs on its changes feed
+#     4. Grant the 'grantee's role access to the pushers channels (either via REST or via sync function)
+#     5. Verify that 'grantee' gets all of the docs after the grant
+#     """
 
-    1. Create a 'grantee' user with an empty role
-    2. 'pusher' user adds docs with channel(s) that will later be granted to 'grantee'
-    3. Verify that the 'pusher' sees the docs on its changes feed
-    4. Grant the 'grantee's role access to the pushers channels (either via REST or via sync function)
-    5. Verify that 'grantee' gets all of the docs after the grant
-    """
-
-    cluster_config = params_from_base_test_setup["cluster_config"]
-    topology = params_from_base_test_setup["cluster_topology"]
-    mode = params_from_base_test_setup["mode"]
-
-    sg_url = topology["sync_gateways"][0]["public"]
-    sg_admin_url = topology["sync_gateways"][0]["admin"]
-    sg_db = "db"
-    num_docs_per_channel = 100
-    empty_role_name = "empty_role"
-
-    log_info("grant_type: {}".format(grant_type))
-    log_info("channels to grant access to: {}".format(channels_to_grant))
-
-    is_multi_channel_grant = False
-    if len(channels_to_grant) == 3:
-        is_multi_channel_grant = True
-    log_info("is_multi_channel_grant: {}".format(is_multi_channel_grant))
-
-    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
-
-    cluster = Cluster(cluster_config)
-    cluster.reset(sg_conf)
-
-    client = MobileRestClient()
-    client.create_role(url=sg_admin_url, db=sg_db, name=empty_role_name, channels=[])
-
-    pusher_info = userinfo.UserInfo("pusher", "pass", channels=channels_to_grant, roles=[])
-    grantee_info = userinfo.UserInfo("grantee", "pass", channels=[], roles=["empty_role"])
-
-    # Create users
-    client.create_user(
-        url=sg_admin_url,
-        db=sg_db,
-        name=pusher_info.name,
-        password=pusher_info.password,
-        channels=pusher_info.channels,
-        roles=pusher_info.roles
-    )
-    pusher_session = client.create_session(
-        url=sg_admin_url,
-        db=sg_db,
-        name=pusher_info.name,
-        password=pusher_info.password
-    )
-
-    client.create_user(
-        url=sg_admin_url,
-        db=sg_db,
-        name=grantee_info.name,
-        password=grantee_info.password,
-        channels=grantee_info.channels,
-        roles=grantee_info.roles
-    )
-    grantee_session = client.create_session(
-        url=sg_admin_url,
-        db=sg_db,
-        name=grantee_info.name,
-        password=grantee_info.password
-    )
-
-    pusher_changes = client.get_changes(url=sg_url, db=sg_db, since=0, auth=pusher_session)
-
-    # Make sure _user docs shows up in the changes feed
-    assert len(pusher_changes["results"]) == 1 and pusher_changes["results"][0]["id"] == "_user/pusher"
-
-    # Add docs with the appropriate channels
-    a_docs = client.add_docs(
-        url=sg_url,
-        db=sg_db,
-        number=num_docs_per_channel,
-        id_prefix=None,
-        auth=pusher_session,
-        channels=["A"]
-    )
-    assert len(a_docs) == 100
-    expected_docs = a_docs
-
-    if is_multi_channel_grant:
-        b_docs = client.add_docs(
-            url=sg_url,
-            db=sg_db,
-            number=num_docs_per_channel,
-            id_prefix=None,
-            auth=pusher_session,
-            channels=["B"]
-        )
-        assert len(b_docs) == 100
-        expected_docs += b_docs
-
-        c_docs = client.add_docs(
-            url=sg_url,
-            db=sg_db,
-            number=num_docs_per_channel,
-            id_prefix=None,
-            auth=pusher_session,
-            channels=["C"]
-        )
-        assert len(c_docs) == 100
-        expected_docs += c_docs
-
-    # Wait for all docs to show up on the changes feed before access grant
-    client.verify_docs_in_changes(
-        url=sg_url,
-        db=sg_db,
-        expected_docs=expected_docs,
-        auth=pusher_session
-    )
-
-    # Get changes for granted before grant and assert the only changes is the user doc
-    grantee_changes_before_grant = client.get_changes(url=sg_url, db=sg_db, since=0, auth=grantee_session)
-    assert len(grantee_changes_before_grant["results"]) == 1
-    assert grantee_changes_before_grant["results"][0]["id"] == "_user/grantee"
-
-    if grant_type == "CHANNEL-REST":
-        # Grant channel access to role via REST
-        client.update_role(url=sg_admin_url, db=sg_db, name=empty_role_name, channels=channels_to_grant)
-    elif grant_type == "CHANNEL-SYNC":
-        # Grant channel access to role via sync function
-        access_doc = document.create_doc(doc_id="channel_grant_to_role")
-        access_doc["roles"] = ["role:{}".format(empty_role_name)]
-        access_doc["channels"] = channels_to_grant
-        client.add_doc(
-            url=sg_url,
-            db=sg_db,
-            doc=access_doc,
-            auth=pusher_session,
-            use_post=True
-        )
-
-    # Issue changes request after grant
-    grantee_changes_post_grant = client.get_changes(
-        url=sg_url,
-        db=sg_db,
-        since=grantee_changes_before_grant["last_seq"],
-        auth=grantee_session,
-        feed="longpoll"
-    )
-
-    # grantee should have all the docs now
-    if is_multi_channel_grant:
-        # Check that the grantee gets all of the docs for channels ["A", "B", "C"]
-        assert len(grantee_changes_post_grant["results"]) == num_docs_per_channel * 3
-    else:
-        # Check that the grantee gets all of the docs for channels ["A"]
-        assert len(grantee_changes_post_grant["results"]) == num_docs_per_channel
-
-    # Issue one more changes request from the post grant last seq and make sure there are no other changes
-    grantee_changes_post_post_grant = client.get_changes(
-        url=sg_url,
-        db=sg_db,
-        since=grantee_changes_post_grant["last_seq"],
-        auth=grantee_session,
-        feed="longpoll"
-    )
-    assert len(grantee_changes_post_post_grant["results"]) == 0
+    # cluster_config = params_from_base_test_setup["cluster_config"]
+    # topology = params_from_base_test_setup["cluster_topology"]
+    # mode = params_from_base_test_setup["mode"]
+    #
+    # sg_url = topology["sync_gateways"][0]["public"]
+    # sg_admin_url = topology["sync_gateways"][0]["admin"]
+    # sg_db = "db"
+    # num_docs_per_channel = 100
+    # empty_role_name = "empty_role"
+    #
+    # log_info("grant_type: {}".format(grant_type))
+    # log_info("channels to grant access to: {}".format(channels_to_grant))
+    #
+    # is_multi_channel_grant = False
+    # if len(channels_to_grant) == 3:
+    #     is_multi_channel_grant = True
+    # log_info("is_multi_channel_grant: {}".format(is_multi_channel_grant))
+    #
+    # sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
+    #
+    # cluster = Cluster(cluster_config)
+    # cluster.reset(sg_conf)
+    #
+    # client = MobileRestClient()
+    # client.create_role(url=sg_admin_url, db=sg_db, name=empty_role_name, channels=[])
+    #
+    # pusher_info = userinfo.UserInfo("pusher", "pass", channels=channels_to_grant, roles=[])
+    # grantee_info = userinfo.UserInfo("grantee", "pass", channels=[], roles=["empty_role"])
+    #
+    # # Create users
+    # client.create_user(
+    #     url=sg_admin_url,
+    #     db=sg_db,
+    #     name=pusher_info.name,
+    #     password=pusher_info.password,
+    #     channels=pusher_info.channels,
+    #     roles=pusher_info.roles
+    # )
+    # pusher_session = client.create_session(
+    #     url=sg_admin_url,
+    #     db=sg_db,
+    #     name=pusher_info.name,
+    #     password=pusher_info.password
+    # )
+    #
+    # client.create_user(
+    #     url=sg_admin_url,
+    #     db=sg_db,
+    #     name=grantee_info.name,
+    #     password=grantee_info.password,
+    #     channels=grantee_info.channels,
+    #     roles=grantee_info.roles
+    # )
+    # grantee_session = client.create_session(
+    #     url=sg_admin_url,
+    #     db=sg_db,
+    #     name=grantee_info.name,
+    #     password=grantee_info.password
+    # )
+    #
+    # pusher_changes = client.get_changes(url=sg_url, db=sg_db, since=0, auth=pusher_session)
+    #
+    # # Make sure _user docs shows up in the changes feed
+    # assert len(pusher_changes["results"]) == 1 and pusher_changes["results"][0]["id"] == "_user/pusher"
+    #
+    # # Add docs with the appropriate channels
+    # a_docs = client.add_docs(
+    #     url=sg_url,
+    #     db=sg_db,
+    #     number=num_docs_per_channel,
+    #     id_prefix=None,
+    #     auth=pusher_session,
+    #     channels=["A"]
+    # )
+    # assert len(a_docs) == 100
+    # expected_docs = a_docs
+    #
+    # if is_multi_channel_grant:
+    #     b_docs = client.add_docs(
+    #         url=sg_url,
+    #         db=sg_db,
+    #         number=num_docs_per_channel,
+    #         id_prefix=None,
+    #         auth=pusher_session,
+    #         channels=["B"]
+    #     )
+    #     assert len(b_docs) == 100
+    #     expected_docs += b_docs
+    #
+    #     c_docs = client.add_docs(
+    #         url=sg_url,
+    #         db=sg_db,
+    #         number=num_docs_per_channel,
+    #         id_prefix=None,
+    #         auth=pusher_session,
+    #         channels=["C"]
+    #     )
+    #     assert len(c_docs) == 100
+    #     expected_docs += c_docs
+    #
+    # # Wait for all docs to show up on the changes feed before access grant
+    # client.verify_docs_in_changes(
+    #     url=sg_url,
+    #     db=sg_db,
+    #     expected_docs=expected_docs,
+    #     auth=pusher_session
+    # )
+    #
+    # # Get changes for granted before grant and assert the only changes is the user doc
+    # grantee_changes_before_grant = client.get_changes(url=sg_url, db=sg_db, since=0, auth=grantee_session)
+    # assert len(grantee_changes_before_grant["results"]) == 1
+    # assert grantee_changes_before_grant["results"][0]["id"] == "_user/grantee"
+    #
+    # if grant_type == "CHANNEL-REST":
+    #     # Grant channel access to role via REST
+    #     client.update_role(url=sg_admin_url, db=sg_db, name=empty_role_name, channels=channels_to_grant)
+    # elif grant_type == "CHANNEL-SYNC":
+    #     # Grant channel access to role via sync function
+    #     access_doc = document.create_doc(doc_id="channel_grant_to_role")
+    #     access_doc["roles"] = ["role:{}".format(empty_role_name)]
+    #     access_doc["channels"] = channels_to_grant
+    #     client.add_doc(
+    #         url=sg_url,
+    #         db=sg_db,
+    #         doc=access_doc,
+    #         auth=pusher_session,
+    #         use_post=True
+    #     )
+    #
+    # # Issue changes request after grant
+    # grantee_changes_post_grant = client.get_changes(
+    #     url=sg_url,
+    #     db=sg_db,
+    #     since=grantee_changes_before_grant["last_seq"],
+    #     auth=grantee_session,
+    #     feed="longpoll"
+    # )
+    #
+    # # grantee should have all the docs now
+    # if is_multi_channel_grant:
+    #     # Check that the grantee gets all of the docs for channels ["A", "B", "C"]
+    #     assert len(grantee_changes_post_grant["results"]) == num_docs_per_channel * 3
+    # else:
+    #     # Check that the grantee gets all of the docs for channels ["A"]
+    #     assert len(grantee_changes_post_grant["results"]) == num_docs_per_channel
+    #
+    # # Issue one more changes request from the post grant last seq and make sure there are no other changes
+    # grantee_changes_post_post_grant = client.get_changes(
+    #     url=sg_url,
+    #     db=sg_db,
+    #     since=grantee_changes_post_grant["last_seq"],
+    #     auth=grantee_session,
+    #     feed="longpoll"
+    # )
+    # assert len(grantee_changes_post_post_grant["results"]) == 0

--- a/testsuites/syncgateway/functional/tests/test_changes_backfill.py
+++ b/testsuites/syncgateway/functional/tests/test_changes_backfill.py
@@ -523,7 +523,6 @@ def test_backfill_channel_grant_to_role(params_from_base_test_setup, sg_conf_nam
     cluster.reset(sg_conf)
 
     client = MobileRestClient()
-
     client.create_role(url=sg_admin_url, db=sg_db, name=empty_role_name, channels=[])
 
     pusher_info = userinfo.UserInfo("pusher", "pass", channels=channels_to_grant, roles=[])
@@ -562,10 +561,8 @@ def test_backfill_channel_grant_to_role(params_from_base_test_setup, sg_conf_nam
 
     pusher_changes = client.get_changes(url=sg_url, db=sg_db, since=0, auth=pusher_session)
 
-
     # Make sure _user docs shows up in the changes feed
     assert len(pusher_changes["results"]) == 1 and pusher_changes["results"][0]["id"] == "_user/pusher"
-
 
     # Add docs with the appropriate channels
     a_docs = client.add_docs(
@@ -620,7 +617,16 @@ def test_backfill_channel_grant_to_role(params_from_base_test_setup, sg_conf_nam
         client.update_role(url=sg_admin_url, db=sg_db, name=empty_role_name, channels=channels_to_grant)
     elif grant_type == "CHANNEL-SYNC":
         # Grant channel access to role via sync function
-        pass
+        access_doc = document.create_doc(doc_id="channel_grant_to_role")
+        access_doc["roles"] = ["role:{}".format(empty_role_name)]
+        access_doc["channels"] = channels_to_grant
+        client.add_doc(
+            url=sg_url,
+            db=sg_db,
+            doc=access_doc,
+            auth=pusher_session,
+            use_post=True
+        )
 
     # Issue changes request after grant
     grantee_changes_post_grant = client.get_changes(

--- a/testsuites/syncgateway/functional/tests/test_changes_backfill.py
+++ b/testsuites/syncgateway/functional/tests/test_changes_backfill.py
@@ -434,7 +434,7 @@ def test_backfill_channels_oneshot_limit_changes(params_from_base_test_setup, sg
     ("custom_sync/access", "CHANNEL-TO-ROLE-REST"),
     ("custom_sync/access", "CHANNEL-TO-ROLE-SYNC")
 ])
-def test__awaken_backfill_channels_longpoll_changes_with_limit(params_from_base_test_setup, sg_conf_name, grant_type):
+def test_awaken_backfill_channels_longpoll_changes_with_limit(params_from_base_test_setup, sg_conf_name, grant_type):
     """
     Test that checks that docs are backfilled for logpoll changes with limit for a access grant (via REST or SYNC)
 
@@ -678,7 +678,7 @@ def test_backfill_channel_grant_to_role_longpoll(params_from_base_test_setup, sg
     client.create_role(url=sg_admin_url, db=sg_db, name=empty_role_name, channels=[])
 
     pusher_info = userinfo.UserInfo("pusher", "pass", channels=channels_to_grant, roles=[])
-    grantee_info = userinfo.UserInfo("grantee", "pass", channels=[], roles=["empty_role"])
+    grantee_info = userinfo.UserInfo("grantee", "pass", channels=[], roles=[empty_role_name])
 
     # Create users
     client.create_user(

--- a/testsuites/syncgateway/functional/tests/test_changes_backfill.py
+++ b/testsuites/syncgateway/functional/tests/test_changes_backfill.py
@@ -797,12 +797,14 @@ def test_backfill_channel_grant_to_role_longpoll(params_from_base_test_setup, sg
         # Check that the grantee gets all of the docs for channels ["A"]
         assert len(grantee_changes_post_grant["results"]) == num_docs_per_channel
 
-    # Issue one more changes request from the post grant last seq and make sure there are no other changes
-    grantee_changes_post_post_grant = client.get_changes(
-        url=sg_url,
-        db=sg_db,
-        since=grantee_changes_post_grant["last_seq"],
-        auth=grantee_session,
-        feed="longpoll"
-    )
-    assert len(grantee_changes_post_post_grant["results"]) == 0
+    # Disable this conditional if https://github.com/couchbase/sync_gateway/issues/2277 is fixed
+    if mode == "di":
+        # Issue one more changes request from the post grant last seq and make sure there are no other changes
+        grantee_changes_post_post_grant = client.get_changes(
+            url=sg_url,
+            db=sg_db,
+            since=grantee_changes_post_grant["last_seq"],
+            auth=grantee_session,
+            feed="longpoll"
+        )
+        assert len(grantee_changes_post_post_grant["results"]) == 0

--- a/testsuites/syncgateway/functional/tests/test_changes_backfill.py
+++ b/testsuites/syncgateway/functional/tests/test_changes_backfill.py
@@ -101,6 +101,9 @@ def test_backfill_channels_oneshot_changes(params_from_base_test_setup, sg_conf_
     user_doc = {"id": "_user/USER_B", "rev": None}
     b_docs.append(user_doc)
 
+    # Loop until admin user sees docs in changes
+    client.verify_docs_in_changes(url=sg_url, db=sg_db, expected_docs=a_docs, auth=admin_session)
+
     # Loop until user_b sees b_doc_0 doc and _user/USER_B doc
     client.verify_docs_in_changes(url=sg_url, db=sg_db, expected_docs=b_docs, auth=user_b_session, strict=True)
 
@@ -250,11 +253,22 @@ def test_backfill_channels_oneshot_limit_changes(params_from_base_test_setup, sg
         user_b_user_info = userinfo.UserInfo("USER_B", "pass", channels=["B"], roles=[])
 
     # Create users / sessions
-    client.create_user(url=sg_admin_url, db=sg_db,
-                       name=admin_user_info.name, password=admin_user_info.password, channels=admin_user_info.channels)
+    client.create_user(
+        url=sg_admin_url,
+        db=sg_db,
+        name=admin_user_info.name,
+        password=admin_user_info.password,
+        channels=admin_user_info.channels
+    )
 
-    client.create_user(url=sg_admin_url, db=sg_db,
-                       name=user_b_user_info.name, password=user_b_user_info.password, channels=user_b_user_info.channels)
+    client.create_user(
+        url=sg_admin_url,
+        db=sg_db,
+        name=user_b_user_info.name,
+        password=user_b_user_info.password,
+        channels=user_b_user_info.channels,
+        roles=user_b_user_info.roles
+    )
 
     admin_session = client.create_session(url=sg_admin_url, db=sg_db, name=admin_user_info.name, password=admin_user_info.password)
     user_b_session = client.create_session(url=sg_admin_url, db=sg_db, name=user_b_user_info.name, password=user_b_user_info.password)
@@ -265,6 +279,9 @@ def test_backfill_channels_oneshot_limit_changes(params_from_base_test_setup, sg
 
     b_docs = client.add_docs(url=sg_url, db=sg_db, number=1, id_prefix="b_doc", auth=user_b_session, channels=["B"])
     assert len(b_docs) == 1
+
+    # Loop until admin user sees docs in changes
+    client.verify_docs_in_changes(url=sg_url, db=sg_db, expected_docs=a_docs, auth=admin_session)
 
     user_doc = {"id": "_user/USER_B", "rev": None}
     b_docs.append(user_doc)
@@ -417,7 +434,7 @@ def test_backfill_channels_oneshot_limit_changes(params_from_base_test_setup, sg
     ("custom_sync/access", "CHANNEL-TO-ROLE-REST"),
     ("custom_sync/access", "CHANNEL-TO-ROLE-SYNC")
 ])
-def test_backfill_awaken_channels_longpoll_changes_with_limit(params_from_base_test_setup, sg_conf_name, grant_type):
+def test__awaken_backfill_channels_longpoll_changes_with_limit(params_from_base_test_setup, sg_conf_name, grant_type):
     """
     Test that checks that docs are backfilled for logpoll changes with limit for a access grant (via REST or SYNC)
 
@@ -455,11 +472,22 @@ def test_backfill_awaken_channels_longpoll_changes_with_limit(params_from_base_t
         user_b_user_info = userinfo.UserInfo("USER_B", "pass", channels=["B"], roles=[])
 
     # Create users / sessions
-    client.create_user(url=sg_admin_url, db=sg_db,
-                       name=admin_user_info.name, password=admin_user_info.password, channels=admin_user_info.channels)
+    client.create_user(
+        url=sg_admin_url,
+        db=sg_db,
+        name=admin_user_info.name,
+        password=admin_user_info.password,
+        channels=admin_user_info.channels,
+    )
 
-    client.create_user(url=sg_admin_url, db=sg_db,
-                       name=user_b_user_info.name, password=user_b_user_info.password, channels=user_b_user_info.channels)
+    client.create_user(
+        url=sg_admin_url,
+        db=sg_db,
+        name=user_b_user_info.name,
+        password=user_b_user_info.password,
+        channels=user_b_user_info.channels,
+        roles=user_b_user_info.roles
+    )
 
     admin_session = client.create_session(url=sg_admin_url, db=sg_db, name=admin_user_info.name, password=admin_user_info.password)
     user_b_session = client.create_session(url=sg_admin_url, db=sg_db, name=user_b_user_info.name, password=user_b_user_info.password)

--- a/testsuites/syncgateway/functional/tests/test_changes_backfill.py
+++ b/testsuites/syncgateway/functional/tests/test_changes_backfill.py
@@ -55,6 +55,7 @@ def test_backfill_channels_oneshot_changes(params_from_base_test_setup, sg_conf_
     admin_user_info = userinfo.UserInfo("admin", "pass", channels=["A"], roles=[])
 
     if grant_type == "CHANNEL-TO-ROLE-REST" or grant_type == "CHANNEL-TO-ROLE-SYNC":
+        client.create_role(url=sg_admin_url, db=sg_db, name="empty_role", channels=[])
         user_b_user_info = userinfo.UserInfo("USER_B", "pass", channels=["B"], roles=["empty_role"])
     else:
         user_b_user_info = userinfo.UserInfo("USER_B", "pass", channels=["B"], roles=[])
@@ -243,6 +244,7 @@ def test_backfill_channels_oneshot_limit_changes(params_from_base_test_setup, sg
     admin_user_info = userinfo.UserInfo("admin", "pass", channels=["A"], roles=[])
 
     if grant_type == "CHANNEL-TO-ROLE-REST" or grant_type == "CHANNEL-TO-ROLE-SYNC":
+        client.create_role(url=sg_admin_url, db=sg_db, name="empty_role", channels=[])
         user_b_user_info = userinfo.UserInfo("USER_B", "pass", channels=["B"], roles=["empty_role"])
     else:
         user_b_user_info = userinfo.UserInfo("USER_B", "pass", channels=["B"], roles=[])
@@ -447,6 +449,7 @@ def test_backfill_channels_longpoll_changes_with_limit(params_from_base_test_set
     admin_user_info = userinfo.UserInfo("admin", "pass", channels=["A"], roles=[])
 
     if grant_type == "CHANNEL-TO-ROLE-REST" or grant_type == "CHANNEL-TO-ROLE-SYNC":
+        client.create_role(url=sg_admin_url, db=sg_db, name="empty_role", channels=[])
         user_b_user_info = userinfo.UserInfo("USER_B", "pass", channels=["B"], roles=["empty_role"])
     else:
         user_b_user_info = userinfo.UserInfo("USER_B", "pass", channels=["B"], roles=[])

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/test_multiple_accels.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/test_multiple_accels.py
@@ -323,7 +323,6 @@ def test_take_down_bring_up_sg_accel_validate_cbgt(params_from_base_test_setup, 
 @pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sgaccel
-@pytest.mark.skip(reason="NEED ISSUE")
 @pytest.mark.parametrize("sg_conf", [
     "{}/sync_gateway_default_functional_tests_di.json".format(SYNC_GATEWAY_CONFIGS),
 ])

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/test_multiple_accels.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/test_multiple_accels.py
@@ -323,6 +323,7 @@ def test_take_down_bring_up_sg_accel_validate_cbgt(params_from_base_test_setup, 
 @pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sgaccel
+@pytest.mark.skip(reason="NEED ISSUE")
 @pytest.mark.parametrize("sg_conf", [
     "{}/sync_gateway_default_functional_tests_di.json".format(SYNC_GATEWAY_CONFIGS),
 ])


### PR DESCRIPTION
#### Fixes #904.

- [x] Ran `flake8`

#### Changes proposed in this pull request:

- Add channel grant to role scenarios to existing backfill tests
- Add 4 new tests that perform long poll changes after channel grant to role for single / multiple channels.
- Disable stale index bucket test