### PR TITLE
Change to stop liteserv and pull logs in case DB delete fails

### DIFF
--- a/testsuites/listener/shared/client_sg/conftest.py
+++ b/testsuites/listener/shared/client_sg/conftest.py
@@ -10,7 +10,6 @@ from keywords.MobileRestClient import MobileRestClient
 from keywords.ClusterKeywords import ClusterKeywords
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
 from keywords.Logging import Logging
-from requests.models import HTTPError
 
 
 # Add custom arguments for executing tests in this directory

--- a/testsuites/listener/shared/client_sg/conftest.py
+++ b/testsuites/listener/shared/client_sg/conftest.py
@@ -124,6 +124,7 @@ def setup_client_syncgateway_test(request, setup_client_syncgateway_suite):
 
     try:
         client.delete_databases(ls_url)
+        liteserv.stop()
     except:
         liteserv.stop()
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)

--- a/testsuites/listener/shared/client_sg/conftest.py
+++ b/testsuites/listener/shared/client_sg/conftest.py
@@ -121,17 +121,11 @@ def setup_client_syncgateway_test(request, setup_client_syncgateway_suite):
     }
 
     log_info("Tearing down test")
+    logging_helper = Logging()
 
     try:
         client.delete_databases(ls_url)
-    except HTTPError as he:
-        liteserv.stop()
-        raise HTTPError(he)
     except:
         liteserv.stop()
+        logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
         raise Exception(sys.exc_info()[0])
-    finally:
-        # if the test failed pull logs
-        if request.node.rep_call.failed:
-            logging_helper = Logging()
-            logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)

--- a/testsuites/listener/shared/client_sg/conftest.py
+++ b/testsuites/listener/shared/client_sg/conftest.py
@@ -124,6 +124,9 @@ def setup_client_syncgateway_test(request, setup_client_syncgateway_suite):
 
     try:
         client.delete_databases(ls_url)
+    except HTTPError as he:
+        liteserv.stop()
+        raise HTTPError(he)
     except:
         liteserv.stop()
         raise HTTPError(sys.exc_info()[0])

--- a/testsuites/listener/shared/client_sg/conftest.py
+++ b/testsuites/listener/shared/client_sg/conftest.py
@@ -129,7 +129,7 @@ def setup_client_syncgateway_test(request, setup_client_syncgateway_suite):
         raise HTTPError(he)
     except:
         liteserv.stop()
-        raise HTTPError(sys.exc_info()[0])
+        raise Exception(sys.exc_info()[0])
     finally:
         # if the test failed pull logs
         if request.node.rep_call.failed:


### PR DESCRIPTION
- [x] Ran `flake8`

#### Changes proposed in this pull request:
- If client.delete_databases fails, catch the exception
- stop liteserv and fetch logs.

