### PR TITLE
Timeout requests to get expvars, which can block jenkins jobs

### DIFF
--- a/libraries/utilities/log_expvars.py
+++ b/libraries/utilities/log_expvars.py
@@ -3,6 +3,7 @@ import datetime
 import requests
 import json
 from keywords.utils import log_info
+from libraries.testkit import settings
 
 from collections import OrderedDict
 
@@ -25,7 +26,7 @@ def dump_results(test_folder, gateload_results, sync_gateway_results):
 
 def write_expvars(results_obj, endpoint):
 
-        resp = requests.get("http://{}".format(endpoint))
+        resp = requests.get("http://{}".format(endpoint), timeout=settings.HTTP_REQ_TIMEOUT)
         resp.raise_for_status()
         expvars = resp.json()
 
@@ -103,7 +104,7 @@ def wait_for_endpoints_alive_or_raise(endpoints, num_attempts=5):
 
             try:
                 log_info("Checking if endpoint is up: {}".format(endpoint_url))
-                resp = requests.get(endpoint_url)
+                resp = requests.get(endpoint_url, timeout=settings.HTTP_REQ_TIMEOUT)
                 resp.raise_for_status()
                 log_info("Endpoint is up")
             except Exception as e:


### PR DESCRIPTION
# Conflicts:
#	libraries/utilities/log_expvars.py

#### Fixes #.

- [x] Ran `flake8`

#### Changes proposed in this pull request:

- [sync-gateway-perf-test-copy-ro/60](http://uberjenkins.sc.couchbase.com/view/Performance/job/sync-gateway-perf-test-copy-ro/60) is completely stuck on the expvar collection, and I think it's because the request somehow got into a stuck state.  Per [requests docs](http://docs.python-requests.org/en/master/user/quickstart/#timeouts) without a timeout, this can block forever in certain cases.

