### PR TITLE
Fix the sync gateway config parser

### DIFF
--- a/libraries/provision/install_sync_gateway.py
+++ b/libraries/provision/install_sync_gateway.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import re
 
 from keywords.couchbaseserver import CouchbaseServer
 from keywords.ClusterKeywords import ClusterKeywords
@@ -170,10 +171,41 @@ def create_server_buckets(cluster_config, sync_gateway_config):
 
 
 def get_buckets_from_sync_gateway_config(sync_gateway_config_path):
+    # Remove the sync function before trying to extract the bucket names
 
-    config_path_full = os.path.abspath(sync_gateway_config_path)
+    with open(sync_gateway_config_path) as fp:
+        conf_data = fp.read()
+
+    fp.close()
+    temp_config_path = ""
+    temp_config = ""
+
+    # Check if a sync function id defined between ` `
+    if re.search('`', conf_data):
+        log_info("Ignoring the sync function to extract bucket names")
+        conf = re.split('`', conf_data)
+        split_len = len(conf)
+
+        # Replace the sync function with a string "function"
+        for i in range(0, split_len, 2):
+            if i == split_len - 1:
+                temp_config += conf[i]
+            else:
+                temp_config += conf[i] + " \"function\" "
+
+        temp_config_path = "/".join(sync_gateway_config_path.split('/')[:-2]) + '/temp_conf.json'
+
+        with open(temp_config_path, 'w') as fp:
+            fp.write(temp_config)
+
+        config_path_full = os.path.abspath(temp_config_path)
+    else:
+        config_path_full = os.path.abspath(sync_gateway_config_path)
+
     config = Config(config_path_full)
     bucket_name_set = config.get_bucket_name_set()
+    if os.path.exists(temp_config_path):
+        os.remove(temp_config_path)
     return bucket_name_set
 
 

--- a/mobile_testkit_tests/test_get_buckets_from_sync_gateway_config.py
+++ b/mobile_testkit_tests/test_get_buckets_from_sync_gateway_config.py
@@ -1,0 +1,66 @@
+# This is to test the get_buckets_from_sync_gateway_config
+# method in install_sync_gateway.py
+# to ensure that the expected buckets are returned
+
+import os
+import pytest
+
+from libraries.provision.install_sync_gateway import get_buckets_from_sync_gateway_config
+
+
+@pytest.mark.parametrize("sync_gateway_path, buckets", [
+    ("testfest_todo_di.json", ['data-bucket', 'index-bucket']),
+    ("default.json", []),
+    ("dist_index_config_local.json", ['data-bucket', 'cbgt-bucket', 'index-bucket']),
+    ("grocery_sync_conf.json", []),
+    ("log_rotation_cc.json", ['data-bucket']),
+    ("log_rotation_di.json", ['data-bucket', 'index-bucket']),
+    ("missing_num_shards_di.json", ['data-bucket', 'index-bucket']),
+    ("multiple_dbs_shared_data_shared_index_cc.json", ['data-bucket']),
+    ("multiple_dbs_shared_data_shared_index_di.json", ['data-bucket', 'index-bucket']),
+    ("multiple_dbs_unique_data_unique_index_cc.json", ['data-bucket', 'data-bucket-2']),
+    ("multiple_dbs_unique_data_unique_index_di.json", ['index-bucket-2', 'index-bucket', 'data-bucket', 'data-bucket-2']),
+    ("reject_all_cc.json", ['data-bucket']),
+    ("reject_all_di.json", ['data-bucket', 'index-bucket']),
+    ("sync_gateway_bucketshadow_cc.json", ['data-bucket', 'source-bucket']),
+    ("sync_gateway_bucketshadow_di.json", ['source-bucket', 'data-bucket', 'index-bucket']),
+    ("sync_gateway_bucketshadow_low_revs_cc.json", ['data-bucket', 'source-bucket']),
+    ("sync_gateway_bucketshadow_low_revs_di.json", ['source-bucket', 'data-bucket', 'index-bucket']),
+    ("sync_gateway_channel_cache_cc.json", ['data-bucket']),
+    ("sync_gateway_channel_cache_di.json", ['data-bucket', 'index-bucket']),
+    ("sync_gateway_default_cc.json", ['data-bucket']),
+    ("sync_gateway_default_di.json", ['data-bucket', 'index-bucket']),
+    ("sync_gateway_default_functional_tests_cc.json", ['data-bucket']),
+    ("sync_gateway_default_functional_tests_di.json", ['data-bucket', 'index-bucket']),
+    ("sync_gateway_default_functional_tests_revslimit50_cc.json", ['data-bucket']),
+    ("sync_gateway_default_functional_tests_revslimit50_di.json", ['data-bucket', 'index-bucket']),
+    ("sync_gateway_default_low_revs_cc.json", ['data-bucket']),
+    ("sync_gateway_default_low_revs_di.json", ['data-bucket', 'index-bucket']),
+    ("sync_gateway_gzip_cc.json", ['data-bucket']),
+    ("sync_gateway_gzip_di.json", ['data-bucket', 'index-bucket']),
+    ("sync_gateway_openid_connect_cc.json", ['data-bucket']),
+    ("sync_gateway_openid_connect_di.json", ['data-bucket', 'index-bucket']),
+    ("sync_gateway_openid_connect_unsigned_cc.json", ['data-bucket']),
+    ("sync_gateway_openid_connect_unsigned_di.json", ['data-bucket', 'index-bucket']),
+    ("sync_gateway_sg_replicate_cc.json", ['data-bucket-1', 'data-bucket-2']),
+    ("sync_gateway_sg_replicate_continuous_cc.json", ['data-bucket-1', 'data-bucket-2']),
+    ("sync_gateway_sg_replicate_continuous_di.json", ['index-bucket-2', 'data-bucket-1', 'index-bucket-1', 'data-bucket', 'data-bucket-2']),
+    ("sync_gateway_sg_replicate_di.json", ['index-bucket-2', 'data-bucket-1', 'index-bucket-1', 'data-bucket', 'data-bucket-2']),
+    ("sync_gateway_todolite.json", ['data-bucket', 'cbgt-bucket', 'index-bucket']),
+    ("sync_gateway_webhook_cc.json", ['data-bucket']),
+    ("sync_gateway_webhook_di.json", ['data-bucket', 'index-bucket']),
+    ("testfest_todo_di.json", ['data-bucket', 'index-bucket']),
+    ("todolite.json", ['data-bucket']),
+])
+def test_get_buckets_from_sync_gateway_config(sync_gateway_path, buckets):
+    cwd = os.getcwd()
+    sync_gateway_configs_folder = cwd + "/resources/sync_gateway_configs/"
+
+    # Run tests with mock_pool_ips.json for backward compatibility
+    bucket_list = get_buckets_from_sync_gateway_config(sync_gateway_configs_folder + sync_gateway_path)
+
+    # Verification
+    # mock_pool_ips.json will generate 22 files ansible+json
+    print bucket_list
+    print buckets
+    assert bucket_list == buckets


### PR DESCRIPTION
#### Fixes #.
https://github.com/couchbaselabs/mobile-testkit/issues/804

- [x] Ran `flake8`

#### Changes proposed in this pull request:
- Ignore the sync function in the sync gateway configs to get the bucket names
- Added a unit test for get_buckets_from_sync_gateway_config method - 100% pass

