### PR TITLE
Catch HTTP Error specifically

### DIFF
--- a/testsuites/listener/shared/client_sg/conftest.py
+++ b/testsuites/listener/shared/client_sg/conftest.py
@@ -129,7 +129,7 @@ def setup_client_syncgateway_test(request, setup_client_syncgateway_suite):
     except HTTPError as h:
         liteserv.stop()
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
-        raise Exception(h)
+        raise HTTPError(h)
     except:
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
         raise Exception("Something went wrong trying to delete the database", sys.exc_info()[0])

--- a/testsuites/listener/shared/client_sg/conftest.py
+++ b/testsuites/listener/shared/client_sg/conftest.py
@@ -127,9 +127,11 @@ def setup_client_syncgateway_test(request, setup_client_syncgateway_suite):
         client.delete_databases(ls_url)
         liteserv.stop()
     except HTTPError as h:
+        # Stop liteserv, save the logs and Rethrow the exception caught
         liteserv.stop()
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
-        raise HTTPError(h)
+        raise
     except:
+        # Save the logs and Rethrow the exception caught
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
-        raise Exception("Something went wrong trying to delete the database", sys.exc_info()[0])
+        raise

--- a/testsuites/listener/shared/client_sg/conftest.py
+++ b/testsuites/listener/shared/client_sg/conftest.py
@@ -10,6 +10,7 @@ from keywords.MobileRestClient import MobileRestClient
 from keywords.ClusterKeywords import ClusterKeywords
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
 from keywords.Logging import Logging
+from requests.models import HTTPError
 
 
 # Add custom arguments for executing tests in this directory
@@ -125,7 +126,10 @@ def setup_client_syncgateway_test(request, setup_client_syncgateway_suite):
     try:
         client.delete_databases(ls_url)
         liteserv.stop()
-    except:
+    except HTTPError as h:
         liteserv.stop()
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
-        raise Exception(sys.exc_info()[0])
+        raise Exception(h)
+    except:
+        logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
+        raise Exception("Something went wrong trying to delete the database", sys.exc_info()[0])


### PR DESCRIPTION
#### Fixes #.
LiteServ was being stopped upon an exception when it was already stopped. Now we only try to stop it if the exception thrown is an HTTPError.

- [ ] Ran `flake8`

#### Changes proposed in this pull request:
LiteServ was being stopped upon an exception when it was already stopped. Now we only try to stop it if the exception thrown is an HTTPError.
