### PR TITLE
Bump EBS volume size to 300 GB for each type of node

### DIFF
--- a/libraries/provision/cloudformation_template.py
+++ b/libraries/provision/cloudformation_template.py
@@ -190,7 +190,7 @@ def gen_template(config):
                 DeviceName="/dev/sda1",
                 Ebs=ec2.EBSBlockDevice(
                     DeleteOnTermination=True,
-                    VolumeSize=100,
+                    VolumeSize=300,
                     VolumeType="gp2"
                 )
             )
@@ -220,7 +220,7 @@ def gen_template(config):
                 DeviceName="/dev/sda1",
                 Ebs=ec2.EBSBlockDevice(
                     DeleteOnTermination=True,
-                    VolumeSize=20,
+                    VolumeSize=300,
                     VolumeType="gp2"
                 )
             )
@@ -243,7 +243,7 @@ def gen_template(config):
                 DeviceName="/dev/sda1",
                 Ebs=ec2.EBSBlockDevice(
                     DeleteOnTermination=True,
-                    VolumeSize=20,
+                    VolumeSize=300,
                     VolumeType="gp2"
                 )
             )


### PR DESCRIPTION
Until https://github.com/couchbaselabs/mobile-testkit/issues/846 is done, I think this is the only way to avoid ending up with a Couchbase Server that has a 20GB EBS storage

#### Fixes #.

- [ X ] Ran `flake8`

#### Changes proposed in this pull request:

- Bump EBS volume size to 300 GB for each type of node


