### PR TITLE
Add additional perf cluster configs

### DIFF
--- a/libraries/utilities/generate_clusters_from_pool.py
+++ b/libraries/utilities/generate_clusters_from_pool.py
@@ -426,15 +426,22 @@ def generate_clusters_from_pool(pool_file):
         ClusterDef("2sg_8ac_6cbs_2lgs", num_sgs=2, num_acs=8, num_cbs=6, num_lgs=2, num_lbs=0),
         # 4 sync_gateways
         ClusterDef("4sg_2ac_3cbs_4lgs", num_sgs=4, num_acs=2, num_cbs=3, num_lgs=4, num_lbs=0),
+        ClusterDef("4sg_2ac_6cbs_4lgs", num_sgs=4, num_acs=2, num_cbs=3, num_lgs=4, num_lbs=0),
         ClusterDef("4sg_4ac_3cbs_4lgs", num_sgs=4, num_acs=4, num_cbs=3, num_lgs=4, num_lbs=0),
+        ClusterDef("4sg_4ac_6cbs_4lgs", num_sgs=4, num_acs=4, num_cbs=3, num_lgs=4, num_lbs=0),
         ClusterDef("4sg_8ac_3cbs_4lgs", num_sgs=4, num_acs=8, num_cbs=3, num_lgs=4, num_lbs=0),
         ClusterDef("4sg_8ac_6cbs_4lgs", num_sgs=4, num_acs=8, num_cbs=6, num_lgs=4, num_lbs=0),
         # 8 sync_gateways
         ClusterDef("8sg_4ac_3cbs_8lgs", num_sgs=8, num_acs=4, num_cbs=3, num_lgs=8, num_lbs=0),
+        ClusterDef("8sg_4ac_6cbs_8lgs", num_sgs=8, num_acs=4, num_cbs=3, num_lgs=8, num_lbs=0),
         ClusterDef("8sg_8ac_3cbs_8lgs", num_sgs=8, num_acs=8, num_cbs=3, num_lgs=8, num_lbs=0),
+        ClusterDef("8sg_8ac_6cbs_8lgs", num_sgs=8, num_acs=8, num_cbs=3, num_lgs=8, num_lbs=0),
         ClusterDef("8sg_12ac_3cbs_8lgs", num_sgs=8, num_acs=12, num_cbs=3, num_lgs=8, num_lbs=0),
         # 16 sync_gateways
+        ClusterDef("16sg_4ac_3cbs_16lgs", num_sgs=16, num_acs=8, num_cbs=3, num_lgs=16, num_lbs=0),
+        ClusterDef("16sg_4ac_6cbs_16lgs", num_sgs=16, num_acs=8, num_cbs=3, num_lgs=16, num_lbs=0),
         ClusterDef("16sg_8ac_3cbs_16lgs", num_sgs=16, num_acs=8, num_cbs=3, num_lgs=16, num_lbs=0),
+        ClusterDef("16sg_8ac_6cbs_16lgs", num_sgs=16, num_acs=8, num_cbs=3, num_lgs=16, num_lbs=0),
 
         # End Perf Mini Matrix
 

--- a/libraries/utilities/generate_clusters_from_pool.py
+++ b/libraries/utilities/generate_clusters_from_pool.py
@@ -426,22 +426,22 @@ def generate_clusters_from_pool(pool_file):
         ClusterDef("2sg_8ac_6cbs_2lgs", num_sgs=2, num_acs=8, num_cbs=6, num_lgs=2, num_lbs=0),
         # 4 sync_gateways
         ClusterDef("4sg_2ac_3cbs_4lgs", num_sgs=4, num_acs=2, num_cbs=3, num_lgs=4, num_lbs=0),
-        ClusterDef("4sg_2ac_6cbs_4lgs", num_sgs=4, num_acs=2, num_cbs=3, num_lgs=4, num_lbs=0),
+        ClusterDef("4sg_2ac_6cbs_4lgs", num_sgs=4, num_acs=2, num_cbs=6, num_lgs=4, num_lbs=0),
         ClusterDef("4sg_4ac_3cbs_4lgs", num_sgs=4, num_acs=4, num_cbs=3, num_lgs=4, num_lbs=0),
-        ClusterDef("4sg_4ac_6cbs_4lgs", num_sgs=4, num_acs=4, num_cbs=3, num_lgs=4, num_lbs=0),
+        ClusterDef("4sg_4ac_6cbs_4lgs", num_sgs=4, num_acs=4, num_cbs=6, num_lgs=4, num_lbs=0),
         ClusterDef("4sg_8ac_3cbs_4lgs", num_sgs=4, num_acs=8, num_cbs=3, num_lgs=4, num_lbs=0),
         ClusterDef("4sg_8ac_6cbs_4lgs", num_sgs=4, num_acs=8, num_cbs=6, num_lgs=4, num_lbs=0),
         # 8 sync_gateways
         ClusterDef("8sg_4ac_3cbs_8lgs", num_sgs=8, num_acs=4, num_cbs=3, num_lgs=8, num_lbs=0),
-        ClusterDef("8sg_4ac_6cbs_8lgs", num_sgs=8, num_acs=4, num_cbs=3, num_lgs=8, num_lbs=0),
+        ClusterDef("8sg_4ac_6cbs_8lgs", num_sgs=8, num_acs=4, num_cbs=6, num_lgs=8, num_lbs=0),
         ClusterDef("8sg_8ac_3cbs_8lgs", num_sgs=8, num_acs=8, num_cbs=3, num_lgs=8, num_lbs=0),
-        ClusterDef("8sg_8ac_6cbs_8lgs", num_sgs=8, num_acs=8, num_cbs=3, num_lgs=8, num_lbs=0),
+        ClusterDef("8sg_8ac_6cbs_8lgs", num_sgs=8, num_acs=8, num_cbs=6, num_lgs=8, num_lbs=0),
         ClusterDef("8sg_12ac_3cbs_8lgs", num_sgs=8, num_acs=12, num_cbs=3, num_lgs=8, num_lbs=0),
         # 16 sync_gateways
-        ClusterDef("16sg_4ac_3cbs_16lgs", num_sgs=16, num_acs=8, num_cbs=3, num_lgs=16, num_lbs=0),
-        ClusterDef("16sg_4ac_6cbs_16lgs", num_sgs=16, num_acs=8, num_cbs=3, num_lgs=16, num_lbs=0),
+        ClusterDef("16sg_4ac_3cbs_16lgs", num_sgs=16, num_acs=4, num_cbs=3, num_lgs=16, num_lbs=0),
+        ClusterDef("16sg_4ac_6cbs_16lgs", num_sgs=16, num_acs=4, num_cbs=6, num_lgs=16, num_lbs=0),
         ClusterDef("16sg_8ac_3cbs_16lgs", num_sgs=16, num_acs=8, num_cbs=3, num_lgs=16, num_lbs=0),
-        ClusterDef("16sg_8ac_6cbs_16lgs", num_sgs=16, num_acs=8, num_cbs=3, num_lgs=16, num_lbs=0),
+        ClusterDef("16sg_8ac_6cbs_16lgs", num_sgs=16, num_acs=8, num_cbs=6, num_lgs=16, num_lbs=0),
 
         # End Perf Mini Matrix
 

--- a/mobile_testkit_tests/test_generate_clusters_from_pool.py
+++ b/mobile_testkit_tests/test_generate_clusters_from_pool.py
@@ -91,8 +91,8 @@ def test_generate_clusters_from_pool_ip_to_node(cleanup_folder, cluster_conf, nu
     generate_clusters_from_pool(ip_to_node_type_pool_file)
 
     # Verification
-    # mock_pool_ip_to_node_type.json will generate 42 ansible+json
-    assert len([name for name in os.listdir(cluster_config_dir)]) == 42
+    # mock_pool_ip_to_node_type.json will generate 44 ansible+json
+    assert len([name for name in os.listdir(cluster_config_dir)]) == 44
 
     # We will check 2 files for content 1cbs/1cbs.json
     config = configparser.ConfigParser()


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`

#### Changes proposed in this pull request:

Adds cluster configs for running with 6 CBS nodes in several more sg/ac combinations, and adds 16/4 sg/ac.

