### PR TITLE
Bump ssh timeout to 60 seconds

### DIFF
--- a/keywords/constants.py
+++ b/keywords/constants.py
@@ -12,7 +12,7 @@ MAX_RETRIES = 5
 
 CLIENT_REQUEST_TIMEOUT = 120
 REBALANCE_TIMEOUT_SECS = 600
-REMOTE_EXECUTOR_TIMEOUT = 30
+REMOTE_EXECUTOR_TIMEOUT = 60
 
 # Required to make sure that these are created with encryption
 # Use to build the command line flags for encryption


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`

#### Changes proposed in this pull request:

- Still seeing occasional timeouts in log rotation tests (ex. http://uberjenkins.sc.couchbase.com/job/cen7-sync-gateway-functional-tests-base-cc/226/)

