### PR TITLE
Feature/issue 973 validate di mode

### DIFF
--- a/libraries/provision/provision_cluster.py
+++ b/libraries/provision/provision_cluster.py
@@ -15,6 +15,7 @@ from libraries.testkit.config import Config
 
 from keywords.utils import log_info
 from keywords.utils import version_and_build
+from keywords.exceptions import ProvisioningError
 from libraries.testkit.cluster import validate_cluster
 from libraries.testkit.cluster import Cluster
 
@@ -43,7 +44,7 @@ def provision_cluster(cluster_config, couchbase_server_config, sync_gateway_conf
         config,
     )
     if not is_valid:
-        raise RuntimeError(reason)
+        raise ProvisioningError(reason)
 
     log_info(">>> Provisioning cluster...")
 

--- a/libraries/provision/provision_cluster.py
+++ b/libraries/provision/provision_cluster.py
@@ -14,7 +14,7 @@ from libraries.provision.install_deps import install_deps
 
 from keywords.utils import log_info
 from keywords.utils import version_and_build
-
+from libraries.testkit.cluster import validate_cluster
 
 def provision_cluster(cluster_config, couchbase_server_config, sync_gateway_config):
 
@@ -29,6 +29,12 @@ def provision_cluster(cluster_config, couchbase_server_config, sync_gateway_conf
     if not sync_gateway_config.is_valid():
         log_info("Invalid sync_gateway provisioning configuration. Exiting ...")
         sys.exit(1)
+
+    validate_cluster(
+        cluster_config.sync_gateways, 
+        cluster_config.sg_accels,
+        sync_gateway_config,
+    )
 
     log_info(">>> Provisioning cluster...")
 

--- a/libraries/provision/provision_cluster.py
+++ b/libraries/provision/provision_cluster.py
@@ -11,10 +11,13 @@ from install_sync_gateway import SyncGatewayConfig
 from install_nginx import install_nginx
 
 from libraries.provision.install_deps import install_deps
+from libraries.testkit.config import Config
 
 from keywords.utils import log_info
 from keywords.utils import version_and_build
 from libraries.testkit.cluster import validate_cluster
+from libraries.testkit.cluster import Cluster
+
 
 def provision_cluster(cluster_config, couchbase_server_config, sync_gateway_config):
 
@@ -30,11 +33,17 @@ def provision_cluster(cluster_config, couchbase_server_config, sync_gateway_conf
         log_info("Invalid sync_gateway provisioning configuration. Exiting ...")
         sys.exit(1)
 
-    validate_cluster(
-        cluster_config.sync_gateways, 
-        cluster_config.sg_accels,
-        sync_gateway_config,
+    cluster = Cluster(config=cluster_config)
+    config_path_full = os.path.abspath(sync_gateway_config.config_path)
+    config = Config(config_path_full)
+
+    is_valid, reason = validate_cluster(
+        cluster.sync_gateways,
+        cluster.sg_accels,
+        config,
     )
+    if not is_valid:
+        raise RuntimeError(reason)
 
     log_info(">>> Provisioning cluster...")
 

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -57,7 +57,6 @@ class Cluster:
         # for integrating keywords
         self.cb_server = couchbaseserver.CouchbaseServer(self.servers[0].url)
 
-
     def reset(self, sg_config_path):
 
         ansible_runner = AnsibleRunner(self._cluster_config)
@@ -141,7 +140,6 @@ class Cluster:
             log_info(">>> Running in channel cache")
 
         return mode
-
 
     def save_cbgt_diagnostics(self):
 

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -15,6 +15,7 @@ from keywords import couchbaseserver
 from keywords import utils
 
 import keywords.exceptions
+from keywords.exceptions import ProvisioningError
 
 from keywords.utils import log_info
 
@@ -95,7 +96,7 @@ class Cluster:
 
         is_valid, reason = validate_cluster(self.sync_gateways, self.sg_accels, config)
         if not is_valid:
-            raise RuntimeError(reason)
+            raise ProvisioningError(reason)
 
         log_info(">>> Creating buckets on: {}".format(self.cb_server.url))
         log_info(">>> Creating buckets {}".format(bucket_name_set))

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -282,6 +282,6 @@ def validate_cluster(sync_gateways, sg_accels, config):
 
     # If we are using a Distributed Index config, make sure that we have sg-accels
     if config.mode == "di" and len(sg_accels) == 0:
-        return False, "INVALID CONFIG: Running in Distributed Index mode but no sg_accels are defined.  Config: {}".format(config)
+        return False, "INVALID CONFIG: Running in Distributed Index mode but no sg_accels are defined."
 
     return True, ""

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -57,15 +57,8 @@ class Cluster:
         # for integrating keywords
         self.cb_server = couchbaseserver.CouchbaseServer(self.servers[0].url)
 
-    def validate_cluster(self):
-
-        # Validate sync gateways
-        if len(self.sync_gateways) == 0:
-            raise Exception("Functional tests require at least 1 index reader")
 
     def reset(self, sg_config_path):
-
-        self.validate_cluster()
 
         ansible_runner = AnsibleRunner(self._cluster_config)
 
@@ -100,6 +93,10 @@ class Cluster:
         bucket_name_set = config.get_bucket_name_set()
 
         self.sync_gateway_config = config
+
+        is_valid, reason = validate_cluster(self.sync_gateways, self.sg_accels, config)
+        if not is_valid:
+            raise RuntimeError(reason)
 
         log_info(">>> Creating buckets on: {}".format(self.cb_server.url))
         log_info(">>> Creating buckets {}".format(bucket_name_set))
@@ -144,6 +141,7 @@ class Cluster:
             log_info(">>> Running in channel cache")
 
         return mode
+
 
     def save_cbgt_diagnostics(self):
 
@@ -276,3 +274,16 @@ class Cluster:
             s += str(server)
         s += "\n"
         return s
+
+
+def validate_cluster(sync_gateways, sg_accels, config):
+
+    # Validate sync gateways
+    if len(sync_gateways) == 0:
+        return False, "Functional tests require at least 1 index reader"
+
+    # If we are using a Distributed Index config, make sure that we have sg-accels
+    if config.mode == "di" and len(sg_accels) == 0:
+        return False, "INVALID CONFIG: Running in Distributed Index mode but no sg_accels are defined.  Config: {}".format(config)
+
+    return True, ""

--- a/libraries/testkit/config.py
+++ b/libraries/testkit/config.py
@@ -15,9 +15,6 @@ class Config:
         self.mode = None
         self.bucket_name_set = []
 
-        if not conf_path:
-            return
-
         with open(conf_path, "r") as config:
 
             data = config.read()

--- a/libraries/testkit/config.py
+++ b/libraries/testkit/config.py
@@ -15,6 +15,9 @@ class Config:
         self.mode = None
         self.bucket_name_set = []
 
+        if not conf_path:
+            return
+
         with open(conf_path, "r") as config:
 
             data = config.read()

--- a/mobile_testkit_tests/test_cluster.py
+++ b/mobile_testkit_tests/test_cluster.py
@@ -1,10 +1,5 @@
-
 from libraries.testkit.cluster import validate_cluster
 from libraries.testkit.config import Config
-
-import pytest
-
-from utilities import scan_logs
 
 
 def test_validate_cluster():
@@ -17,8 +12,8 @@ def test_validate_cluster():
     config.mode = "di"
 
     is_valid, _ = validate_cluster(sync_gateways, sg_accels, config)
-    assert is_valid == False
+    assert is_valid is False
 
     sg_accels.append("sga1")
     is_valid, _ = validate_cluster(sync_gateways, sg_accels, config)
-    assert is_valid == True
+    assert is_valid is True

--- a/mobile_testkit_tests/test_cluster.py
+++ b/mobile_testkit_tests/test_cluster.py
@@ -1,0 +1,24 @@
+
+from libraries.testkit.cluster import validate_cluster
+from libraries.testkit.config import Config
+
+import pytest
+
+from utilities import scan_logs
+
+
+def test_validate_cluster():
+    """
+    Make sure validate cluster catches invalid clusters
+    """
+    sync_gateways = ["sg1"]
+    sg_accels = []
+    config = Config(conf_path=None)
+    config.mode = "di"
+
+    is_valid, _ = validate_cluster(sync_gateways, sg_accels, config)
+    assert is_valid == False
+
+    sg_accels.append("sga1")
+    is_valid, _ = validate_cluster(sync_gateways, sg_accels, config)
+    assert is_valid == True

--- a/mobile_testkit_tests/test_cluster.py
+++ b/mobile_testkit_tests/test_cluster.py
@@ -8,8 +8,12 @@ def test_validate_cluster():
     """
     sync_gateways = ["sg1"]
     sg_accels = []
-    config = Config(conf_path=None)
-    config.mode = "di"
+
+    class MockConfig:
+        def __init__(self, mode):
+            self.mode = mode
+
+    config = MockConfig(mode="di")
 
     is_valid, _ = validate_cluster(sync_gateways, sg_accels, config)
     assert is_valid is False


### PR DESCRIPTION
#### Fixes #973 .

- [x] Ran `flake8`, twice

#### Changes proposed in this pull request:

- Validates that if distributed index config is used, then there must be sync gw accels present 

This job failed due to validation failure:

http://uberjenkins.sc.couchbase.com/view/Performance/job/sync-gateway-perf-test-copy-ro/116/console

These jobs passed validation:

http://uberjenkins.sc.couchbase.com/view/Performance/job/sync-gateway-perf-test-copy-ro/118/

http://uberjenkins.sc.couchbase.com/view/Performance/job/sync-gateway-perf-test-copy-ro/117/
