### PR TITLE
Disable strict host key checking by default

### DIFF
--- a/ansible.cfg.example
+++ b/ansible.cfg.example
@@ -1,10 +1,13 @@
 [defaults]
 remote_user = vagrant
 
+; Get rid of "Are you sure you want to continue connecting (yes/no)?" warnings
+host_key_checking = False
+
 ; http://docs.ansible.com/ansible/intro_configuration.html#control-path
 ; prevent socket names that may be too long with (AWS host names)
 [ssh_connection]
 control_path = %(directory)s/%%h-%%r
 
-; Increase number of concurrent ssh connections that ansible uses. 
+; Increase number of concurrent ssh connections that ansible uses.
 forks = 100


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`

#### Changes proposed in this pull request:

- Disable host key checking by default for ansible 

