### PR TITLE
Emit private dns names into pools.json file

### DIFF
--- a/libraries/provision/generate_pools_json_from_aws.py
+++ b/libraries/provision/generate_pools_json_from_aws.py
@@ -156,6 +156,9 @@ def wait_until_stack_create_complete(stackname):
             if stack_event.resource_type == "AWS::CloudFormation::Stack" and stack_event.resource_status == "CREATE_COMPLETE":
                 print("Stack {} has successfully been created".format(stackname))
                 return
+            elif stack_event.resource_type == "AWS::CloudFormation::Stack" and stack_event.resource_status == "UPDATE_COMPLETE":
+                print("Stack {} has successfully been created".format(stackname))
+                return
 
         # didn't find it, lets wait and try again
         time.sleep(5)

--- a/libraries/utilities/generate_clusters_from_pool.py
+++ b/libraries/utilities/generate_clusters_from_pool.py
@@ -412,6 +412,7 @@ def generate_clusters_from_pool(pool_file):
         # 1 sync_gateway
         ClusterDef("1sg_1ac_3cbs_1lgs", num_sgs=1, num_acs=1, num_cbs=3, num_lgs=1, num_lbs=0),
         ClusterDef("1sg_2ac_3cbs_1lgs", num_sgs=1, num_acs=2, num_cbs=3, num_lgs=1, num_lbs=0),
+        ClusterDef("1sg_1ac_3cbs_1lgs", num_sgs=1, num_acs=1, num_cbs=3, num_lgs=1, num_lbs=0),
         # 2 sync_gateways
         ClusterDef("2sg_1cbs_1lgs", num_sgs=2, num_acs=0, num_cbs=1, num_lgs=1, num_lbs=0),
         ClusterDef("2sg_3cbs_2lgs", num_sgs=2, num_acs=0, num_cbs=3, num_lgs=2, num_lbs=0),


### PR DESCRIPTION
In order to make it easier to find relevant logs in cloudwatch logs, which can only use private ip address in the name of the logstream, this will add the private ip addresses into our pools.json file which ends up in the jenkins logs.

Still not ideal, but should be a usable workaround until we figure out a better way

#### Fixes #.

- [x] Ran `flake8`

#### Changes proposed in this pull request:

- Emit private dns names into pools.json file


