### PR TITLE
Add 1.4.0 to the LiteServ path check

### DIFF
--- a/keywords/LiteServNetMono.py
+++ b/keywords/LiteServNetMono.py
@@ -14,6 +14,7 @@ from keywords.constants import REGISTERED_CLIENT_DBS
 from keywords.exceptions import LiteServError
 from keywords.utils import version_and_build
 from keywords.utils import log_info
+from keywords.utils import hasDotNet4Dot5
 
 
 class LiteServNetMono(LiteServBase):
@@ -26,10 +27,10 @@ class LiteServNetMono(LiteServBase):
         """
 
         # Skip download if packages is already downloaded
-        if self.version_build.startswith("1.2") or self.version_build.startswith("1.3") or self.version_build.startswith("1.4.0"):
-            expected_binary = "{}/couchbase-lite-net-mono-{}-liteserv/LiteServ.exe".format(BINARY_DIR, self.version_build)
-        else:
+        if hasDotNet4Dot5(self.version_build):
             expected_binary = "{}/couchbase-lite-net-mono-{}-liteserv/net45/LiteServ.exe".format(BINARY_DIR, self.version_build)
+        else:
+            expected_binary = "{}/couchbase-lite-net-mono-{}-liteserv/LiteServ.exe".format(BINARY_DIR, self.version_build)
 
         if os.path.isfile(expected_binary):
             log_info("Package already downloaded: {}".format(expected_binary))

--- a/keywords/LiteServNetMono.py
+++ b/keywords/LiteServNetMono.py
@@ -14,7 +14,7 @@ from keywords.constants import REGISTERED_CLIENT_DBS
 from keywords.exceptions import LiteServError
 from keywords.utils import version_and_build
 from keywords.utils import log_info
-from keywords.utils import hasDotNet4Dot5
+from keywords.utils import has_dot_net4_dot_5
 
 
 class LiteServNetMono(LiteServBase):
@@ -27,7 +27,7 @@ class LiteServNetMono(LiteServBase):
         """
 
         # Skip download if packages is already downloaded
-        if hasDotNet4Dot5(self.version_build):
+        if has_dot_net4_dot_5(self.version_build):
             expected_binary = "{}/couchbase-lite-net-mono-{}-liteserv/net45/LiteServ.exe".format(BINARY_DIR, self.version_build)
         else:
             expected_binary = "{}/couchbase-lite-net-mono-{}-liteserv/LiteServ.exe".format(BINARY_DIR, self.version_build)
@@ -85,10 +85,10 @@ class LiteServNetMono(LiteServBase):
         self._verify_not_running()
 
         # The package structure for LiteServ is different pre 1.4. Handle for this case
-        if self.version_build.startswith("1.2") or self.version_build.startswith("1.3") or self.version_build.startswith("1.4.0"):
-            binary_path = "{}/couchbase-lite-net-mono-{}-liteserv/LiteServ.exe".format(BINARY_DIR, self.version_build)
-        else:
+        if has_dot_net4_dot_5(self.version_build):
             binary_path = "{}/couchbase-lite-net-mono-{}-liteserv/net45/LiteServ.exe".format(BINARY_DIR, self.version_build)
+        else:
+            binary_path = "{}/couchbase-lite-net-mono-{}-liteserv/LiteServ.exe".format(BINARY_DIR, self.version_build)
 
         process_args = [
             "mono",

--- a/keywords/LiteServNetMono.py
+++ b/keywords/LiteServNetMono.py
@@ -26,7 +26,11 @@ class LiteServNetMono(LiteServBase):
         """
 
         # Skip download if packages is already downloaded
-        expected_binary = "{}/couchbase-lite-net-mono-{}-liteserv/net45/LiteServ.exe".format(BINARY_DIR, self.version_build)
+        if self.version_build.startswith("1.2") or self.version_build.startswith("1.3") or self.version_build.startswith("1.4.0"):
+            expected_binary = "{}/couchbase-lite-net-mono-{}-liteserv/LiteServ.exe".format(BINARY_DIR, self.version_build)
+        else:
+            expected_binary = "{}/couchbase-lite-net-mono-{}-liteserv/net45/LiteServ.exe".format(BINARY_DIR, self.version_build)
+
         if os.path.isfile(expected_binary):
             log_info("Package already downloaded: {}".format(expected_binary))
             return
@@ -80,7 +84,7 @@ class LiteServNetMono(LiteServBase):
         self._verify_not_running()
 
         # The package structure for LiteServ is different pre 1.4. Handle for this case
-        if self.version_build.startswith("1.2") or self.version_build.startswith("1.3"):
+        if self.version_build.startswith("1.2") or self.version_build.startswith("1.3") or self.version_build.startswith("1.4.0"):
             binary_path = "{}/couchbase-lite-net-mono-{}-liteserv/LiteServ.exe".format(BINARY_DIR, self.version_build)
         else:
             binary_path = "{}/couchbase-lite-net-mono-{}-liteserv/net45/LiteServ.exe".format(BINARY_DIR, self.version_build)

--- a/keywords/LiteServNetMsft.py
+++ b/keywords/LiteServNetMsft.py
@@ -69,8 +69,12 @@ class LiteServNetMsft(LiteServBase):
         """
         Installs needed packages on Windows host and removes any existing service wrappers for LiteServ
         """
+        # The package structure for LiteServ is different pre 1.4. Handle for this case
+        if self.version_build.startswith("1.2") or self.version_build.startswith("1.3") or self.version_build.startswith("1.4.0"):
+            directory_path = "couchbase-lite-net-msft-{}-liteserv/LiteServ.exe".format(self.version_build)
+        else:
+            directory_path = "couchbase-lite-net-msft-{}-liteserv/net45/LiteServ.exe".format(self.version_build)
 
-        directory_path = "couchbase-lite-net-msft-{}-liteserv/net45/LiteServ.exe".format(self.version_build)
         status = self.ansible_runner.run_ansible_playbook("install-liteserv-windows.yml", extra_vars={
             "directory_path": directory_path
         })
@@ -118,7 +122,7 @@ class LiteServNetMsft(LiteServBase):
             process_args.extend(db_flags)
 
         # The package structure for LiteServ is different pre 1.4. Handle for this case
-        if self.version_build.startswith("1.2") or self.version_build.startswith("1.3"):
+        if self.version_build.startswith("1.2") or self.version_build.startswith("1.3") or self.version_build.startswith("1.4.0"):
             binary_path = "couchbase-lite-net-msft-{}-liteserv/LiteServ.exe".format(self.version_build)
         else:
             binary_path = "couchbase-lite-net-msft-{}-liteserv/net45/LiteServ.exe".format(self.version_build)

--- a/keywords/LiteServNetMsft.py
+++ b/keywords/LiteServNetMsft.py
@@ -7,6 +7,7 @@ from keywords.constants import REGISTERED_CLIENT_DBS
 from keywords.exceptions import LiteServError
 from keywords.utils import version_and_build
 from keywords.utils import log_info
+from keywords.utils import hasDotNet4Dot5
 
 from libraries.provision.ansible_runner import AnsibleRunner
 
@@ -70,10 +71,10 @@ class LiteServNetMsft(LiteServBase):
         Installs needed packages on Windows host and removes any existing service wrappers for LiteServ
         """
         # The package structure for LiteServ is different pre 1.4. Handle for this case
-        if self.version_build.startswith("1.2") or self.version_build.startswith("1.3") or self.version_build.startswith("1.4.0"):
-            directory_path = "couchbase-lite-net-msft-{}-liteserv/LiteServ.exe".format(self.version_build)
-        else:
+        if hasDotNet4Dot5(self.version_build):
             directory_path = "couchbase-lite-net-msft-{}-liteserv/net45/LiteServ.exe".format(self.version_build)
+        else:
+            directory_path = "couchbase-lite-net-msft-{}-liteserv/LiteServ.exe".format(self.version_build)
 
         status = self.ansible_runner.run_ansible_playbook("install-liteserv-windows.yml", extra_vars={
             "directory_path": directory_path
@@ -122,10 +123,10 @@ class LiteServNetMsft(LiteServBase):
             process_args.extend(db_flags)
 
         # The package structure for LiteServ is different pre 1.4. Handle for this case
-        if self.version_build.startswith("1.2") or self.version_build.startswith("1.3") or self.version_build.startswith("1.4.0"):
-            binary_path = "couchbase-lite-net-msft-{}-liteserv/LiteServ.exe".format(self.version_build)
-        else:
+        if hasDotNet4Dot5(self.version_build):
             binary_path = "couchbase-lite-net-msft-{}-liteserv/net45/LiteServ.exe".format(self.version_build)
+        else:
+            binary_path = "couchbase-lite-net-msft-{}-liteserv/LiteServ.exe".format(self.version_build)
 
         joined_args = " ".join(process_args)
         log_info("Starting LiteServ {} with: {}".format(binary_path, joined_args))

--- a/keywords/LiteServNetMsft.py
+++ b/keywords/LiteServNetMsft.py
@@ -7,7 +7,7 @@ from keywords.constants import REGISTERED_CLIENT_DBS
 from keywords.exceptions import LiteServError
 from keywords.utils import version_and_build
 from keywords.utils import log_info
-from keywords.utils import hasDotNet4Dot5
+from keywords.utils import has_dot_net4_dot_5
 
 from libraries.provision.ansible_runner import AnsibleRunner
 
@@ -71,7 +71,7 @@ class LiteServNetMsft(LiteServBase):
         Installs needed packages on Windows host and removes any existing service wrappers for LiteServ
         """
         # The package structure for LiteServ is different pre 1.4. Handle for this case
-        if hasDotNet4Dot5(self.version_build):
+        if has_dot_net4_dot_5(self.version_build):
             directory_path = "couchbase-lite-net-msft-{}-liteserv/net45/LiteServ.exe".format(self.version_build)
         else:
             directory_path = "couchbase-lite-net-msft-{}-liteserv/LiteServ.exe".format(self.version_build)
@@ -123,7 +123,7 @@ class LiteServNetMsft(LiteServBase):
             process_args.extend(db_flags)
 
         # The package structure for LiteServ is different pre 1.4. Handle for this case
-        if hasDotNet4Dot5(self.version_build):
+        if has_dot_net4_dot_5(self.version_build):
             binary_path = "couchbase-lite-net-msft-{}-liteserv/net45/LiteServ.exe".format(self.version_build)
         else:
             binary_path = "couchbase-lite-net-msft-{}-liteserv/LiteServ.exe".format(self.version_build)

--- a/keywords/utils.py
+++ b/keywords/utils.py
@@ -117,3 +117,17 @@ def dump_file_contents_to_logs(filename):
         log_info("Contents of {}: {}".format(filename, open(filename).read()))
     except Exception as e:
         log_info("Error reading {}: {}".format(filename, e))
+
+# Check if this version has net45
+def hasDotNet4Dot5(version):
+    version_prefixes = [
+         "1.2",
+         "1.3",
+         "1.4.0"  # For 1.4, the path is net45/LiteServ.exe, for 1.4.0, there is no net45
+    ]
+
+    for i in version_prefixes:
+        if version.startswith(i) :
+            return False
+
+    return True

--- a/keywords/utils.py
+++ b/keywords/utils.py
@@ -118,8 +118,9 @@ def dump_file_contents_to_logs(filename):
     except Exception as e:
         log_info("Error reading {}: {}".format(filename, e))
 
+
 # Check if this version has net45
-def hasDotNet4Dot5(version):
+def has_dot_net4_dot_5(version):
     version_prefixes = [
          "1.2",
          "1.3",


### PR DESCRIPTION
- [ ] Ran `flake8`

#### Changes proposed in this pull request:
1.4.0 does not have android, net45, ios folders. This change adds a check to select the right path for LiteServ.exe