### PR TITLE
Refactor out cpu profile collection from gateload script

### DIFF
--- a/libraries/provision/ansible/playbooks/start-gateload.yml
+++ b/libraries/provision/ansible/playbooks/start-gateload.yml
@@ -11,52 +11,6 @@
     shell: screen -X -S gateload_expvars kill
     ignore_errors: yes
 
-- hosts: sync_gateways
-  any_errors_fatal: true
-  sudo: true
-
-  # Copy machine stat collection script to sync_gateways
-  tasks:
-  - name: copy the machine collection script
-    copy: src=files/log_machine_stats.py dest=/home/sync_gateway/ owner=sync_gateway group=sync_gateway mode=755
-  # Start collecting machine stats, no polling and a 24 hour timeout
-  - name: start stat collection
-    shell: ./log_machine_stats.py chdir=/home/sync_gateway/
-    async: 86400
-    poll: 0
-
-  # Copy profile collection script to sync_gateways
-  - name: copy the profile collection script
-    copy: src=files/sync_gateway_collect_profile.py dest=/home/sync_gateway/ owner=sync_gateway group=sync_gateway mode=755
-  # Start collecting profile, no polling and a 24 hour timeout
-  - name: start profile collection
-    shell: ./sync_gateway_collect_profile.py --sg-binary /opt/couchbase-sync-gateway/bin/sync_gateway --format-type-pdf --format-type-text --profile-type-heap --profile-type-cpu --profile-type-goroutine --heap-alloc-space --heap-inuse-space --delay-secs 540 chdir=/home/sync_gateway/
-    async: 86400
-    poll: 0
-
-- hosts: sg_accels
-  any_errors_fatal: true
-  sudo: true
-
-  # Copy machine stat collection script to sg_accels
-  tasks:
-  - name: copy the machine collection script
-    copy: src=files/log_machine_stats.py dest=/home/sg_accel/ owner=sg_accel group=sg_accel mode=755
-  # Start collecting machine stats, no polling and a 24 hour timeout
-  - name: start stat collection
-    shell: ./log_machine_stats.py chdir=/home/sg_accel/
-    async: 86400
-    poll: 0
-
-  # Copy profile collection script to sg_accels
-  - name: copy the profile collection script
-    copy: src=files/sync_gateway_collect_profile.py dest=/home/sg_accel/ owner=sg_accel group=sg_accel mode=755
-  # Start collecting profile, no polling and a 24 hour timeout
-  - name: start profile collection
-    shell: ./sync_gateway_collect_profile.py --sg-binary /opt/couchbase-sg-accel/bin/sg_accel --format-type-pdf --format-type-text --profile-type-heap --profile-type-cpu --profile-type-goroutine --heap-alloc-space --heap-inuse-space --delay-secs 540 chdir=/home/sg_accel/
-    async: 86400
-    poll: 0
-
 - hosts: load_generators
   any_errors_fatal: true
 

--- a/libraries/provision/ansible/playbooks/start-profile-collection.yml
+++ b/libraries/provision/ansible/playbooks/start-profile-collection.yml
@@ -1,0 +1,45 @@
+- hosts: sync_gateways
+  any_errors_fatal: true
+  sudo: true
+
+  # Copy machine stat collection script to sync_gateways
+  tasks:
+  - name: copy the machine collection script
+    copy: src=files/log_machine_stats.py dest=/home/sync_gateway/ owner=sync_gateway group=sync_gateway mode=755
+  # Start collecting machine stats, no polling and a 24 hour timeout
+  - name: start stat collection
+    shell: ./log_machine_stats.py chdir=/home/sync_gateway/
+    async: 86400
+    poll: 0
+
+  # Copy profile collection script to sync_gateways
+  - name: copy the profile collection script
+    copy: src=files/sync_gateway_collect_profile.py dest=/home/sync_gateway/ owner=sync_gateway group=sync_gateway mode=755
+  # Start collecting profile, no polling and a 24 hour timeout
+  - name: start profile collection
+    shell: ./sync_gateway_collect_profile.py --sg-binary /opt/couchbase-sync-gateway/bin/sync_gateway --format-type-pdf --format-type-text --profile-type-heap --profile-type-cpu --profile-type-goroutine --heap-alloc-space --heap-inuse-space --delay-secs 540 chdir=/home/sync_gateway/
+    async: 86400
+    poll: 0
+
+- hosts: sg_accels
+  any_errors_fatal: true
+  sudo: true
+
+  # Copy machine stat collection script to sg_accels
+  tasks:
+  - name: copy the machine collection script
+    copy: src=files/log_machine_stats.py dest=/home/sg_accel/ owner=sg_accel group=sg_accel mode=755
+  # Start collecting machine stats, no polling and a 24 hour timeout
+  - name: start stat collection
+    shell: ./log_machine_stats.py chdir=/home/sg_accel/
+    async: 86400
+    poll: 0
+
+  # Copy profile collection script to sg_accels
+  - name: copy the profile collection script
+    copy: src=files/sync_gateway_collect_profile.py dest=/home/sg_accel/ owner=sg_accel group=sg_accel mode=755
+  # Start collecting profile, no polling and a 24 hour timeout
+  - name: start profile collection
+    shell: ./sync_gateway_collect_profile.py --sg-binary /opt/couchbase-sg-accel/bin/sg_accel --format-type-pdf --format-type-text --profile-type-heap --profile-type-cpu --profile-type-goroutine --heap-alloc-space --heap-inuse-space --delay-secs 540 chdir=/home/sg_accel/
+    async: 86400
+    poll: 0

--- a/libraries/utilities/fetch_sync_gateway_profile.py
+++ b/libraries/utilities/fetch_sync_gateway_profile.py
@@ -3,6 +3,7 @@ import shutil
 import time
 from libraries.provision.ansible_runner import AnsibleRunner
 from keywords.utils import log_info
+import sys
 
 
 def fetch_sync_gateway_profile(cluster_config, folder_name):
@@ -41,3 +42,16 @@ def fetch_sync_gateway_profile(cluster_config, folder_name):
                 log_info("Exhausted attempts.  Giving up")
 
         attempt_number += 1
+
+
+if __name__ == "__main__":
+
+    try:
+        cluster_config = os.environ["CLUSTER_CONFIG"]
+    except KeyError:
+        print ("Make sure CLUSTER_CONFIG is defined and pointing to the configuration you would like to provision")
+        sys.exit(1)
+
+    folder_name = "profile"  # TODO: not really sure what to use here..
+
+    fetch_sync_gateway_profile(cluster_config, folder_name)

--- a/testsuites/syncgateway/performance/run_gateload_perf_test.py
+++ b/testsuites/syncgateway/performance/run_gateload_perf_test.py
@@ -72,6 +72,13 @@ def run_gateload_perf_test(gen_gateload_config, test_id, gateload_params):
             gateload_params=gateload_params
         )
 
+    print(">>> Starting profile collection scripts")
+    status = ansible_runner.run_ansible_playbook(
+        "start-profile-collection.yml",
+        extra_vars={},
+    )
+    assert status == 0, "Could not start profiling collection scripts"
+
     # Start gateload
     print(">>> Starting gateload with {0} pullers and {1} pushers".format(
         gateload_params.number_pullers, gateload_params.number_pushers

--- a/testsuites/syncgateway/performance/run_sgload_perf_test.py
+++ b/testsuites/syncgateway/performance/run_sgload_perf_test.py
@@ -10,6 +10,7 @@ from libraries.provision.ansible_runner import AnsibleRunner
 from keywords.exceptions import ProvisioningError
 
 from libraries.utilities.provisioning_config_parser import hosts_for_tag
+from libraries.utilities.fetch_sync_gateway_profile import fetch_sync_gateway_profile
 
 from keywords.utils import log_info
 from keywords.remoteexecutor import RemoteExecutor
@@ -96,6 +97,13 @@ def run_sgload_perf_test(cluster_config, sgload_arg_list_main, skip_build_sgload
     print("Running sgload perf test against cluster: {}".format(cluster_config))
     main_ansible_runner = AnsibleRunner(cluster_config)
 
+    print(">>> Starting profile collection scripts")
+    status = main_ansible_runner.run_ansible_playbook(
+        "start-profile-collection.yml",
+        extra_vars={},
+    )
+    assert status == 0, "Could not start profiling collection scripts"
+
     # Install + configure telegraf
     status = main_ansible_runner.run_ansible_playbook("install-telegraf.yml")
     if status != 0:
@@ -147,3 +155,7 @@ if __name__ == "__main__":
         sgload_arg_list_main,
         known_args.skip_build_sgload,
     )
+
+    folder_name = "profile"  # TODO: not really sure what to use here..
+
+    fetch_sync_gateway_profile(main_cluster_config, folder_name)


### PR DESCRIPTION
Makes it easy to run from sgload script

Rework https://github.com/couchbaselabs/mobile-testkit/pull/910

#### Fixes #.

- [x] Ran `flake8`

#### Changes proposed in this pull request:

- When running sgload based perftest, it fetches cpu/mem profiles (was not doing so before)
- Refactor out the yml playbook for setting up the profile collection
- This is a rebase/rework of https://github.com/couchbaselabs/mobile-testkit/pull/910

Validation run in progress:

http://uberjenkins.sc.couchbase.com/view/Performance/job/sync-gateway-perf-test/534/

