### PR TITLE
Feature/fix install keys script take 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ In order to use Ansible, the controller needs to have it's SSH keys in all the h
 Follow the instructions in [Docker container SSH key instructions](https://github.com/couchbaselabs/mobile-testkit/wiki/Docker-Container---SSH-Keys) to setup keys in Docker
 
 ```
-python libraries/utilities/install_keys.py --key-name=sample_key.pub --ssh-user=root
+python libraries/utilities/install_keys.py --public-key-path=~/.ssh/id_rsa.pub --ssh-user=root
 ```
 - Generate the necessary cluster topologies to run the tests
 ```
@@ -340,7 +340,7 @@ Do the same for rests of the hosts in the `Vagrantfile`
 1. Install the ssh key into the machines via 
 
 ```
-python libraries/utilities/install_keys.py --key-name=id_rsa.pub --ssh-user=vagrant
+python libraries/utilities/install_keys.py --public-key-path=~/.ssh/id_rsa.pub --ssh-user=vagrant --ssh-password=vagrant
 ```
 
 use the password `vagrant`. 

--- a/libraries/utilities/generate_clusters_from_pool.py
+++ b/libraries/utilities/generate_clusters_from_pool.py
@@ -29,7 +29,7 @@ class ClusterDef:
 
 
 def write_config(config, pool_file):
-    ips, ip_to_node_type = get_ips(pool_file)
+    ips, ip_to_node_type = get_hosts(pool_file)
     ip_to_node_type_len = len(ip_to_node_type)
     ip_to_node_type_defined = False
 
@@ -372,7 +372,7 @@ def write_config(config, pool_file):
             f_json.write(json.dumps(cluster_dict, indent=4))
 
 
-def get_ips(pool_file="resources/pool.json"):
+def get_hosts(pool_file="resources/pool.json"):
     with open(pool_file) as f:
         pool_dict = json.loads(f.read())
         ips = pool_dict["ips"]
@@ -461,7 +461,7 @@ def generate_clusters_from_pool(pool_file):
         sys.exit(1)
 
     print("Using the following machines to run functional tests ... ")
-    for host in get_ips(pool_file):
+    for host in get_hosts(pool_file):
         print(host)
 
     print("Generating 'resources/cluster_configs/'")

--- a/libraries/utilities/install-gh-deploy-keys.py
+++ b/libraries/utilities/install-gh-deploy-keys.py
@@ -19,12 +19,12 @@ import sys
 
 from optparse import OptionParser
 
-from generate_clusters_from_pool import get_ips
+from generate_clusters_from_pool import get_hosts
 
 
 def install_gh_deploy_keys(key_path, user_name):
 
-    ips, _ = get_ips()
+    ips, _ = get_hosts()
 
     for ip in ips:
 

--- a/libraries/utilities/install_keys.py
+++ b/libraries/utilities/install_keys.py
@@ -49,7 +49,7 @@ def deploy_key(public_key, server, username, password):
 
 if __name__ == "__main__":
 
-    usage = "usage: install-keys.py --public-key-path=<name_of_public_key> --ssh-user=<user>"
+    usage = "usage: install-keys.py --public-key-path=<path_of_public_key> --ssh-user=<user> --ssh-password=<>"
     parser = OptionParser(usage=usage)
 
     parser.add_option(


### PR DESCRIPTION
#### Fixes #885 

- [x] Ran `flake8`

#### Changes proposed in this pull request:

- Makes it easier to put ssh keys to hosts 
- Works on Vagrant (password based auth) and AWS ec2 instances (passwordless auth)
- Rework of https://github.com/couchbaselabs/mobile-testkit/pull/900
