### PR TITLE
Feature/enable running races for sg tests

### DIFF
--- a/keywords/ClusterKeywords.py
+++ b/keywords/ClusterKeywords.py
@@ -153,7 +153,7 @@ class ClusterKeywords:
         cluster = Cluster(config=cluster_config)
         cluster.reset(sync_gateway_config)
 
-    def provision_cluster(self, cluster_config, server_version, sync_gateway_version, sync_gateway_config, races_enabled=False):
+    def provision_cluster(self, cluster_config, server_version, sync_gateway_version, sync_gateway_config, race_enabled=False):
 
         if server_version is None or sync_gateway_version is None or sync_gateway_version is None:
             raise ProvisioningError("Please make sure you have server_version, sync_gateway_version, and sync_gateway_config are set")
@@ -167,8 +167,8 @@ class ClusterKeywords:
 
         if version_is_binary(sync_gateway_version):
 
-            if races_enabled:
-                raise ProvisioningError("Races should only be enabled for source builds")
+            if race_enabled:
+                raise ProvisioningError("Race should only be enabled for source builds")
 
             version, build = version_and_build(sync_gateway_version)
             sg_config = SyncGatewayConfig(
@@ -182,8 +182,8 @@ class ClusterKeywords:
         else:
 
             build_flags = ""
-            if races_enabled:
-                build_flags = "-races"
+            if race_enabled:
+                build_flags = "-race"
 
             sg_config = SyncGatewayConfig(
                 commit=sync_gateway_version,

--- a/keywords/Logging.py
+++ b/keywords/Logging.py
@@ -4,6 +4,7 @@ import os.path
 import shutil
 import time
 
+from utilities import scan_logs
 from keywords.utils import log_info
 from keywords.exceptions import CollectionError
 from keywords.constants import RESULTS_DIR

--- a/keywords/Logging.py
+++ b/keywords/Logging.py
@@ -4,7 +4,6 @@ import os.path
 import shutil
 import time
 
-from utilities import scan_logs
 from keywords.utils import log_info
 from keywords.exceptions import CollectionError
 from keywords.constants import RESULTS_DIR

--- a/keywords/exceptions.py
+++ b/keywords/exceptions.py
@@ -44,3 +44,7 @@ class ClusterError(Error):
 
 class DocumentError(Error):
     pass
+
+
+class LogScanningError(Error):
+    pass

--- a/mobile_testkit_tests/test_data/mock_data_race_log.txt
+++ b/mobile_testkit_tests/test_data/mock_data_race_log.txt
@@ -1,0 +1,40 @@
+016-01-26T19:02:51.595-08:00 	BulkDocs: Doc "large-revisions_3" --> 503 Database server is over capacity (MCResponse status=TMPFAIL, opcode=GET, opaque=0, msg: Temporary failure)
+2016-01-26T19:02:51.595-08:00 	BulkDocs: Doc "large-revisions_4" --> 503 Database server is over capacity (MCResponse status=TMPFAIL, opcode=GET, opaque=0, msg: Temporary failure)
+2016-01-26T19:02:51.596-08:00 	BulkDocs: Doc "large-revisions_5" --> 503 Database server is over capacity (MCResponse status=TMPFAIL, opcode=GET, opaque=0, msg: Temporary failure)
+
+2016-01-26T19:02:51.612-08:00 	BulkDocs: Doc "large-revisions_6" --> 503 Database server is over capacity (MCResponse status=TMPFAIL, opcode=GET, opaque=0, msg: Temporary failure)
+
+2016-01-26T19:02:51.612-08:00 	BulkDocs: Doc "large-revisions_7" --> 503 Database server is over capacity (MCResponse status=TMPFAIL, opcode=GET, opaque=0, msg: Temporary failure)
+
+2016-01-26T19:02:51.630-08:00 HTTP:  #4463: POST /db/_revs_diff
+
+2016/01/26 19:02:51 planner: awakes, op: kick, msg: cfg changed, key: nodeDefs-wanted
+2016/01/26 19:02:51 planner: once, reason: cfg changed, key: nodeDefs-wanted
+2016/01/26 19:02:51 janitor: awakes, op: kick, msg: cfg changed, key: planPIndexes
+
+
+WARNING: DATA RACE
+Write at 0x00c423212378 by goroutine 1763:
+  github.com/couchbase/sync_gateway/base.(*SyncSequenceClock).SetMaxSequence()
+      /home/centos/godeps/src/github.com/couchbase/sync_gateway/base/sequence_clock.go:365 +0x159
+  github.com/couchbase/sync_gateway/db.(*Database).vectorChangesFeed.func1()
+      /home/centos/godeps/src/github.com/couchbase/sync_gateway/db/index_changes.go:736 +0x26e
+
+Previous read at 0x00c423212378 by goroutine 1764:
+  github.com/couchbase/sync_gateway/db.ClockMatches()
+      /home/centos/godeps/src/github.com/couchbase/sync_gateway/db/sequence_hasher.go:451 +0x91
+  github.com/couchbase/sync_gateway/db.(*storedClocks).Contains()
+      /home/centos/godeps/src/github.com/couchbase/sync_gateway/db/sequence_hasher.go:415 +0xb4
+  github.com/couchbase/sync_gateway/db.(*sequenceHasher).GetHash()
+      /home/centos/godeps/src/github.com/couchbase/sync_gateway/db/sequence_hasher.go:147 +0x23e
+  github.com/couchbase/sync_gateway/db.(*Database).vectorChangesFeed.func1()
+      /home/centos/godeps/src/github.com/couchbase/sync_gateway/db/index_changes.go:743 +0x41b
+
+
+016-01-26T19:02:51.595-08:00 	BulkDocs: Doc "large-revisions_3" --> 503 Database server is over capacity (MCResponse status=TMPFAIL, opcode=GET, opaque=0, msg: Temporary failure)
+2016-01-26T19:02:51.595-08:00 	BulkDocs: Doc "large-revisions_4" --> 503 Database server is over capacity (MCResponse status=TMPFAIL, opcode=GET, opaque=0, msg: Temporary failure)
+2016-01-26T19:02:51.596-08:00 	BulkDocs: Doc "large-revisions_5" --> 503 Database server is over capacity (MCResponse status=TMPFAIL, opcode=GET, opaque=0, msg: Temporary failure)
+
+2016-01-26T19:02:51.612-08:00 	BulkDocs: Doc "large-revisions_6" --> 503 Database server is over capacity (MCResponse status=TMPFAIL, opcode=GET, opaque=0, msg: Temporary failure)
+
+2016-01-26T19:02:51.612-08:00 	BulkDocs: Doc "large-revisions_7" --> 503 Database server is over capacity (MCResponse status=TMPFAIL, opcode=GET, opaque=0, msg: Temporary failure)

--- a/mobile_testkit_tests/test_scan_logs.py
+++ b/mobile_testkit_tests/test_scan_logs.py
@@ -1,4 +1,5 @@
 import pytest
+from keywords.exceptions import LogScanningError
 
 from utilities import scan_logs
 
@@ -11,10 +12,10 @@ def test_error_string_not_list():
     log_file_path = "mobile_testkit_tests/test_data/mock_panic_log.txt"
 
     with pytest.raises(ValueError) as e:
-        scan_logs.scan_for_errors('panic', log_file_path)
+        scan_logs.scan_for_errors(log_file_path, 'panic')
 
     error_message = str(e.value)
-    assert error_message.startswith("'error_strings must be a list'")
+    assert error_message.startswith("error_strings must be a list")
 
 
 def test_panic_in_log():
@@ -24,8 +25,8 @@ def test_panic_in_log():
 
     log_file_path = "mobile_testkit_tests/test_data/mock_panic_log.txt"
 
-    with pytest.raises(AssertionError) as e:
-        scan_logs.scan_for_errors(['panic'], log_file_path)
+    with pytest.raises(LogScanningError) as e:
+        scan_logs.scan_for_errors(log_file_path, ['panic'])
 
     error_message = str(e.value)
     assert error_message.startswith("panic found!!")
@@ -38,8 +39,8 @@ def test_warning_in_log():
 
     log_file_path = "mobile_testkit_tests/test_data/mock_panic_log.txt"
 
-    with pytest.raises(AssertionError) as e:
-        scan_logs.scan_for_errors(['warning'], log_file_path)
+    with pytest.raises(LogScanningError) as e:
+        scan_logs.scan_for_errors(log_file_path, ['warning'])
 
     error_message = str(e.value)
     assert error_message.startswith("warning found!!")
@@ -52,8 +53,8 @@ def test_cap_warning_in_log():
 
     log_file_path = "mobile_testkit_tests/test_data/mock_panic_log.txt"
 
-    with pytest.raises(AssertionError) as e:
-        scan_logs.scan_for_errors(['warning'], log_file_path)
+    with pytest.raises(LogScanningError) as e:
+        scan_logs.scan_for_errors(log_file_path, ['warning'])
 
     error_message = str(e.value)
     assert error_message.startswith("warning found!!")
@@ -66,8 +67,8 @@ def test_cap_panic_in_log():
 
     log_file_path = "mobile_testkit_tests/test_data/mock_panic_log.txt"
 
-    with pytest.raises(AssertionError) as e:
-        scan_logs.scan_for_errors(['Panic'], log_file_path)
+    with pytest.raises(LogScanningError) as e:
+        scan_logs.scan_for_errors(log_file_path, ['Panic'])
 
     error_message = str(e.value)
     assert error_message.startswith("Panic found!!")
@@ -80,8 +81,8 @@ def test_clean_log():
 
     log_file_path = "mobile_testkit_tests/test_data/mock_clean_log.txt"
 
-    scan_logs.scan_for_errors(['panic'], log_file_path)
-    scan_logs.scan_for_errors(['data race'], log_file_path)
+    scan_logs.scan_for_errors(log_file_path, ['panic'])
+    scan_logs.scan_for_errors(log_file_path, ['data race'])
 
 
 def test_data_race_log():
@@ -91,14 +92,14 @@ def test_data_race_log():
 
     log_file_path = "mobile_testkit_tests/test_data/mock_data_race_log.txt"
 
-    with pytest.raises(AssertionError) as e:
-        scan_logs.scan_for_errors(['data race'], log_file_path)
+    with pytest.raises(LogScanningError) as e:
+        scan_logs.scan_for_errors(log_file_path, ['data race'])
 
     error_message = str(e.value)
     assert error_message.startswith("data race found!!")
 
-    with pytest.raises(AssertionError) as e:
-        scan_logs.scan_for_errors(['DATA RACE'], log_file_path)
+    with pytest.raises(LogScanningError) as e:
+        scan_logs.scan_for_errors(log_file_path, ['DATA RACE'])
 
     error_message = str(e.value)
     assert error_message.startswith("DATA RACE found!!")

--- a/mobile_testkit_tests/test_scan_logs.py
+++ b/mobile_testkit_tests/test_scan_logs.py
@@ -81,3 +81,24 @@ def test_clean_log():
     log_file_path = "mobile_testkit_tests/test_data/mock_clean_log.txt"
 
     scan_logs.scan_for_errors(['panic'], log_file_path)
+    scan_logs.scan_for_errors(['data race'], log_file_path)
+
+
+def test_data_race_log():
+    """
+    Make sure scanner throws exception for found keyword
+    """
+
+    log_file_path = "mobile_testkit_tests/test_data/mock_data_race_log.txt"
+
+    with pytest.raises(AssertionError) as e:
+        scan_logs.scan_for_errors(['data race'], log_file_path)
+
+    error_message = str(e.value)
+    assert error_message.startswith("data race found!!")
+
+    with pytest.raises(AssertionError) as e:
+        scan_logs.scan_for_errors(['DATA RACE'], log_file_path)
+
+    error_message = str(e.value)
+    assert error_message.startswith("DATA RACE found!!")

--- a/testsuites/syncgateway/functional/tests/README.md
+++ b/testsuites/syncgateway/functional/tests/README.md
@@ -7,6 +7,7 @@
 | `--mode`  |  Channel cache mode ('cc') or using sg_accel in distributed index ('di') mode.  Determines which `CLUSTER_CONFIG` values are used during provisioning |
 | `-k`  |  Run a specific test rather than the entire sweet.  Supports substrings / regex? |
 | `--sync-gateway-version`  |  Sync Gateway version *or* commit hash |
+| `--race`  | If a Sync Gateway commit hash is provided and this flag is set, Sync Gateway will be built with -races |
 | `--server-version`  |  Couchbase Server version |
 
 ## Executing sync_gateway functional tests
@@ -32,6 +33,27 @@ pytest  -s \
         --mode=cc \
         --server-version=4.5.0 \
         --sync-gateway-version=1.3.1-16 \
+        testsuites/syncgateway/functional/tests/
+```
+
+### Run all the tests in channel cache mode with a source build
+
+```
+pytest  -s \
+        --mode=cc \
+        --server-version=4.5.0 \
+        --sync-gateway-version=5bb66efa523a2440642729ba5faebfef96fd2696 \
+        testsuites/syncgateway/functional/tests/
+```
+
+### Run all the tests in channel cache mode with a source build with -race
+
+```
+pytest  -s \
+        --mode=cc \
+        --server-version=4.5.0 \
+        --sync-gateway-version=5bb66efa523a2440642729ba5faebfef96fd2696 \
+        --race \
         testsuites/syncgateway/functional/tests/
 ```
 

--- a/testsuites/syncgateway/functional/tests/README.md
+++ b/testsuites/syncgateway/functional/tests/README.md
@@ -9,6 +9,7 @@
 | `--sync-gateway-version`  |  Sync Gateway version *or* commit hash |
 | `--race`  | If a Sync Gateway commit hash is provided and this flag is set, Sync Gateway will be built with -races |
 | `--server-version`  |  Couchbase Server version |
+| `--collect-logs`  |  Collect logs regardless of pass or fail state of test. Default is to collect logs only on failure |
 
 ## Executing sync_gateway functional tests
 

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -105,8 +105,6 @@ def params_from_base_suite_setup(request):
         "mode": mode
     }
 
-    # Scan logs for 'panic' and 'data races'
-    scan_logs(RESULTS_DIR)
     log_info("Tearing down 'params_from_base_suite_setup' ...")
 
 

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -1,16 +1,11 @@
 import pytest
 
 from keywords.constants import CLUSTER_CONFIGS_DIR
-from keywords.constants import RESULTS_DIR
 from keywords.utils import log_info
 from keywords.ClusterKeywords import ClusterKeywords
 from keywords.Logging import Logging
 from keywords.SyncGateway import validate_sync_gateway_mode
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
-
-
-from utilities.scan_logs import scan_logs
-
 from libraries.testkit import cluster
 
 from libraries.NetworkUtils import NetworkUtils
@@ -106,7 +101,6 @@ def params_from_base_suite_setup(request):
     }
 
     log_info("Tearing down 'params_from_base_suite_setup' ...")
-
 
 
 # This is called before each test and will yield the dictionary to each test that references the method

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -1,11 +1,15 @@
 import pytest
 
 from keywords.constants import CLUSTER_CONFIGS_DIR
+from keywords.constants import RESULTS_DIR
 from keywords.utils import log_info
 from keywords.ClusterKeywords import ClusterKeywords
 from keywords.Logging import Logging
 from keywords.SyncGateway import validate_sync_gateway_mode
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
+
+
+from utilities.scan_logs import scan_logs
 
 from libraries.testkit import cluster
 
@@ -101,7 +105,10 @@ def params_from_base_suite_setup(request):
         "mode": mode
     }
 
+    # Scan logs for 'panic' and 'data races'
+    scan_logs(RESULTS_DIR)
     log_info("Tearing down 'params_from_base_suite_setup' ...")
+
 
 
 # This is called before each test and will yield the dictionary to each test that references the method

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -36,6 +36,10 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="If set, will target larger cluster (3 backing servers instead of 1, 2 accels if in di mode)")
 
+    parser.addoption("--races",
+                     action="store_true",
+                     help="Enable -races for Sync Gateway build. IMPORTANT - This will only work with source builds at the moment")
+
 
 # This will be called once for the at the beggining of the execution in the 'tests/' directory
 # and will be torn down, (code after the yeild) when all the test session has completed.
@@ -51,6 +55,7 @@ def params_from_base_suite_setup(request):
     mode = request.config.getoption("--mode")
     skip_provisioning = request.config.getoption("--skip-provisioning")
     ci = request.config.getoption("--ci")
+    races_enabled = request.config.getoption("--races")
 
     log_info("server_version: {}".format(server_version))
     log_info("sync_gateway_version: {}".format(sync_gateway_version))
@@ -77,7 +82,8 @@ def params_from_base_suite_setup(request):
             cluster_config=cluster_config,
             server_version=server_version,
             sync_gateway_version=sync_gateway_version,
-            sync_gateway_config=sg_config
+            sync_gateway_config=sg_config,
+            races_enabled=races_enabled
         )
 
     # Load topology as a dictionary

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -36,7 +36,7 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="If set, will target larger cluster (3 backing servers instead of 1, 2 accels if in di mode)")
 
-    parser.addoption("--races",
+    parser.addoption("--race",
                      action="store_true",
                      help="Enable -races for Sync Gateway build. IMPORTANT - This will only work with source builds at the moment")
 
@@ -55,7 +55,7 @@ def params_from_base_suite_setup(request):
     mode = request.config.getoption("--mode")
     skip_provisioning = request.config.getoption("--skip-provisioning")
     ci = request.config.getoption("--ci")
-    races_enabled = request.config.getoption("--races")
+    race_enabled = request.config.getoption("--race")
 
     log_info("server_version: {}".format(server_version))
     log_info("sync_gateway_version: {}".format(sync_gateway_version))
@@ -83,7 +83,7 @@ def params_from_base_suite_setup(request):
             server_version=server_version,
             sync_gateway_version=sync_gateway_version,
             sync_gateway_config=sg_config,
-            races_enabled=races_enabled
+            race_enabled=race_enabled
         )
 
     # Load topology as a dictionary

--- a/testsuites/syncgateway/functional/topology_specific_tests/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/conftest.py
@@ -21,3 +21,7 @@ def pytest_addoption(parser):
     parser.addoption("--race",
                      action="store_true",
                      help="Enable -races for Sync Gateway build. IMPORTANT - This will only work with source builds at the moment")
+
+    parser.addoption("--collect-logs",
+                    action="store_true",
+                    help="Collect logs for every test. If this flag is not set, collection will only happen for test failures.")

--- a/testsuites/syncgateway/functional/topology_specific_tests/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/conftest.py
@@ -17,3 +17,7 @@ def pytest_addoption(parser):
     parser.addoption("--sync-gateway-version",
                      action="store",
                      help="sync-gateway-version: Sync Gateway version to install (ex. 1.3.1-16 or 590c1c31c7e83503eff304d8c0789bdd268d6291)")
+
+    parser.addoption("--race",
+                     action="store_true",
+                     help="Enable -races for Sync Gateway build. IMPORTANT - This will only work with source builds at the moment")

--- a/testsuites/syncgateway/functional/topology_specific_tests/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/conftest.py
@@ -23,5 +23,5 @@ def pytest_addoption(parser):
                      help="Enable -races for Sync Gateway build. IMPORTANT - This will only work with source builds at the moment")
 
     parser.addoption("--collect-logs",
-                    action="store_true",
-                    help="Collect logs for every test. If this flag is not set, collection will only happen for test failures.")
+                     action="store_true",
+                     help="Collect logs for every test. If this flag is not set, collection will only happen for test failures.")

--- a/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
@@ -17,6 +17,7 @@ from keywords.Logging import Logging
 def params_from_base_suite_setup(request):
     log_info("Setting up 'params_from_base_suite_setup' ...")
 
+    # pytest command line parameters
     server_version = request.config.getoption("--server-version")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
     mode = request.config.getoption("--mode")
@@ -80,9 +81,10 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     # Verify all sync_gateways and sg_accels are reachable
     c = cluster.Cluster(cluster_config)
     errors = c.verify_alive(mode)
-    assert len(errors) == 0
 
     # if the test failed pull logs
-    if collect_logs or request.node.rep_call.failed:
+    if collect_logs or request.node.rep_call.failed or len(errors) == 0:
         logging_helper = Logging()
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
+
+    assert len(errors) == 0

--- a/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
@@ -27,6 +27,7 @@ def params_from_base_suite_setup(request):
     log_info("sync_gateway_version: {}".format(sync_gateway_version))
     log_info("mode: {}".format(mode))
     log_info("skip_provisioning: {}".format(skip_provisioning))
+    log_info("race_enabled: {}".format(race_enabled))
 
     # Make sure mode for sync_gateway is supported ('cc' or 'di')
     validate_sync_gateway_mode(mode)

--- a/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
@@ -21,6 +21,7 @@ def params_from_base_suite_setup(request):
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
     mode = request.config.getoption("--mode")
     skip_provisioning = request.config.getoption("--skip-provisioning")
+    races_enabled = request.config.getoption("--races")
 
     log_info("server_version: {}".format(server_version))
     log_info("sync_gateway_version: {}".format(sync_gateway_version))
@@ -41,7 +42,8 @@ def params_from_base_suite_setup(request):
             cluster_config=cluster_config,
             server_version=server_version,
             sync_gateway_version=sync_gateway_version,
-            sync_gateway_config=sg_config
+            sync_gateway_config=sg_config,
+            races_enabled=races_enabled
         )
 
     yield {"cluster_config": cluster_config, "mode": mode}

--- a/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
@@ -57,6 +57,9 @@ def params_from_base_suite_setup(request):
 @pytest.fixture(scope="function")
 def params_from_base_test_setup(request, params_from_base_suite_setup):
 
+    # pytest command line parameters
+    collect_logs = request.config.getoption("--collect-logs")
+
     test_name = request.node.name
     log_info("Setting up test '{}'".format(test_name))
 
@@ -80,6 +83,6 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     assert len(errors) == 0
 
     # if the test failed pull logs
-    if request.node.rep_call.failed:
+    if collect_logs or request.node.rep_call.failed:
         logging_helper = Logging()
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)

--- a/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
@@ -21,7 +21,7 @@ def params_from_base_suite_setup(request):
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
     mode = request.config.getoption("--mode")
     skip_provisioning = request.config.getoption("--skip-provisioning")
-    races_enabled = request.config.getoption("--races")
+    race_enabled = request.config.getoption("--race")
 
     log_info("server_version: {}".format(server_version))
     log_info("sync_gateway_version: {}".format(sync_gateway_version))
@@ -43,7 +43,7 @@ def params_from_base_suite_setup(request):
             server_version=server_version,
             sync_gateway_version=sync_gateway_version,
             sync_gateway_config=sg_config,
-            races_enabled=races_enabled
+            race_enabled=race_enabled
         )
 
     yield {"cluster_config": cluster_config, "mode": mode}

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
@@ -21,7 +21,7 @@ def params_from_base_suite_setup(request):
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
     mode = request.config.getoption("--mode")
     skip_provisioning = request.config.getoption("--skip-provisioning")
-    races_enabled = request.config.getoption("--races")
+    race_enabled = request.config.getoption("--race")
 
     log_info("server_version: {}".format(server_version))
     log_info("sync_gateway_version: {}".format(sync_gateway_version))
@@ -47,7 +47,7 @@ def params_from_base_suite_setup(request):
             server_version=server_version,
             sync_gateway_version=sync_gateway_version,
             sync_gateway_config=sg_config,
-            races_enabled=races_enabled
+            race_enabled=race_enabled
         )
 
     yield {"cluster_config": cluster_config, "mode": mode}

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
@@ -27,6 +27,7 @@ def params_from_base_suite_setup(request):
     log_info("sync_gateway_version: {}".format(sync_gateway_version))
     log_info("mode: {}".format(mode))
     log_info("skip_provisioning: {}".format(skip_provisioning))
+    log_info("race_enabled: {}".format(race_enabled))
 
     # Make sure mode for sync_gateway is supported ('cc' or 'di')
     validate_sync_gateway_mode(mode)

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
@@ -21,6 +21,7 @@ def params_from_base_suite_setup(request):
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
     mode = request.config.getoption("--mode")
     skip_provisioning = request.config.getoption("--skip-provisioning")
+    races_enabled = request.config.getoption("--races")
 
     log_info("server_version: {}".format(server_version))
     log_info("sync_gateway_version: {}".format(sync_gateway_version))
@@ -45,7 +46,8 @@ def params_from_base_suite_setup(request):
             cluster_config=cluster_config,
             server_version=server_version,
             sync_gateway_version=sync_gateway_version,
-            sync_gateway_config=sg_config
+            sync_gateway_config=sg_config,
+            races_enabled=races_enabled
         )
 
     yield {"cluster_config": cluster_config, "mode": mode}

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
@@ -17,6 +17,7 @@ from keywords.Logging import Logging
 def params_from_base_suite_setup(request):
     log_info("Setting up 'params_from_base_suite_setup' ...")
 
+    # pytest command line parameters
     server_version = request.config.getoption("--server-version")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
     mode = request.config.getoption("--mode")
@@ -62,6 +63,9 @@ def params_from_base_suite_setup(request):
 def params_from_base_test_setup(request, params_from_base_suite_setup):
     # Code before the yeild will execute before each test starts
 
+    # pytest command line parameters
+    collect_logs = request.config.getoption("--collect-logs")
+
     cluster_config = params_from_base_suite_setup["cluster_config"]
     mode = params_from_base_suite_setup["mode"]
 
@@ -81,9 +85,10 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     # Verify all sync_gateways and sg_accels are reachable
     c = Cluster(cluster_config)
     errors = c.verify_alive(mode)
-    assert len(errors) == 0
 
     # if the test failed pull logs
-    if request.node.rep_call.failed:
+    if collect_logs or request.node.rep_call.failed or len(errors) != 0:
         logging_helper = Logging()
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
+
+    assert len(errors) == 0

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
@@ -22,6 +22,7 @@ def params_from_base_suite_setup(request):
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
     mode = request.config.getoption("--mode")
     skip_provisioning = request.config.getoption("--skip-provisioning")
+    races_enabled = request.config.getoption("--races")
 
     log_info("server_version: {}".format(server_version))
     log_info("sync_gateway_version: {}".format(sync_gateway_version))
@@ -42,7 +43,8 @@ def params_from_base_suite_setup(request):
             cluster_config=cluster_config,
             server_version=server_version,
             sync_gateway_version=sync_gateway_version,
-            sync_gateway_config=sg_config
+            sync_gateway_config=sg_config,
+            races_enabled=races_enabled
         )
 
     yield {"cluster_config": cluster_config, "mode": mode}

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
@@ -18,6 +18,7 @@ from libraries.testkit import cluster
 def params_from_base_suite_setup(request):
     log_info("Setting up 'params_from_base_suite_setup' ...")
 
+    # pytest command line parameters
     server_version = request.config.getoption("--server-version")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
     mode = request.config.getoption("--mode")
@@ -59,6 +60,9 @@ def params_from_base_suite_setup(request):
 def params_from_base_test_setup(request, params_from_base_suite_setup):
     # Code before the yeild will execute before each test starts
 
+    # pytest command line parameters
+    collect_logs = request.config.getoption("--collect-logs")
+
     cluster_config = params_from_base_suite_setup["cluster_config"]
     mode = params_from_base_suite_setup["mode"]
 
@@ -77,9 +81,10 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     # Verify all sync_gateways and sg_accels are reachable
     c = cluster.Cluster(cluster_config)
     errors = c.verify_alive(mode)
-    assert len(errors) == 0
 
     # if the test failed pull logs
-    if request.node.rep_call.failed:
+    if collect_logs or request.node.rep_call.failed or len(errors) == 0:
         logging_helper = Logging()
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
+
+    assert len(errors) == 0

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
@@ -28,6 +28,7 @@ def params_from_base_suite_setup(request):
     log_info("sync_gateway_version: {}".format(sync_gateway_version))
     log_info("mode: {}".format(mode))
     log_info("skip_provisioning: {}".format(skip_provisioning))
+    log_info("race_enabled: {}".format(race_enabled))
 
     # Make sure mode for sync_gateway is supported ('cc' or 'di')
     validate_sync_gateway_mode(mode)

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
@@ -22,7 +22,7 @@ def params_from_base_suite_setup(request):
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
     mode = request.config.getoption("--mode")
     skip_provisioning = request.config.getoption("--skip-provisioning")
-    races_enabled = request.config.getoption("--races")
+    race_enabled = request.config.getoption("--race")
 
     log_info("server_version: {}".format(server_version))
     log_info("sync_gateway_version: {}".format(sync_gateway_version))
@@ -44,7 +44,7 @@ def params_from_base_suite_setup(request):
             server_version=server_version,
             sync_gateway_version=sync_gateway_version,
             sync_gateway_config=sg_config,
-            races_enabled=races_enabled
+            race_enabled=race_enabled
         )
 
     yield {"cluster_config": cluster_config, "mode": mode}

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -22,6 +22,7 @@ def params_from_base_suite_setup(request):
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
     mode = request.config.getoption("--mode")
     skip_provisioning = request.config.getoption("--skip-provisioning")
+    races_enabled = request.config.getoption("--races")
 
     log_info("server_version: {}".format(server_version))
     log_info("sync_gateway_version: {}".format(sync_gateway_version))
@@ -42,7 +43,8 @@ def params_from_base_suite_setup(request):
             cluster_config=cluster_config,
             server_version=server_version,
             sync_gateway_version=sync_gateway_version,
-            sync_gateway_config=sg_config
+            sync_gateway_config=sg_config,
+            races_enabled=races_enabled
         )
 
     yield {"cluster_config": cluster_config, "mode": mode}

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -28,6 +28,7 @@ def params_from_base_suite_setup(request):
     log_info("sync_gateway_version: {}".format(sync_gateway_version))
     log_info("mode: {}".format(mode))
     log_info("skip_provisioning: {}".format(skip_provisioning))
+    log_info("race_enabled: {}".format(race_enabled))
 
     # Make sure mode for sync_gateway is supported ('cc' or 'di')
     validate_sync_gateway_mode(mode)

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -18,6 +18,7 @@ from libraries.testkit import cluster
 def params_from_base_suite_setup(request):
     log_info("Setting up 'params_from_base_suite_setup' ...")
 
+    # pytest command line parameters
     server_version = request.config.getoption("--server-version")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
     mode = request.config.getoption("--mode")
@@ -59,6 +60,9 @@ def params_from_base_suite_setup(request):
 def params_from_base_test_setup(request, params_from_base_suite_setup):
     # Code before the yeild will execute before each test starts
 
+    # pytest command line parameters
+    collect_logs = request.config.getoption("--collect-logs")
+
     cluster_config = params_from_base_suite_setup["cluster_config"]
     mode = params_from_base_suite_setup["mode"]
 
@@ -81,9 +85,10 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     # Verify all sync_gateways and sg_accels are reachable
     c = cluster.Cluster(cluster_config)
     errors = c.verify_alive(mode)
-    assert len(errors) == 0
 
     # if the test failed pull logs
-    if request.node.rep_call.failed:
+    if collect_logs or request.node.rep_call.failed or len(errors) == 0:
         logging_helper = Logging()
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
+
+    assert len(errors) == 0

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -22,7 +22,7 @@ def params_from_base_suite_setup(request):
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
     mode = request.config.getoption("--mode")
     skip_provisioning = request.config.getoption("--skip-provisioning")
-    races_enabled = request.config.getoption("--races")
+    race_enabled = request.config.getoption("--race")
 
     log_info("server_version: {}".format(server_version))
     log_info("sync_gateway_version: {}".format(sync_gateway_version))
@@ -44,7 +44,7 @@ def params_from_base_suite_setup(request):
             server_version=server_version,
             sync_gateway_version=sync_gateway_version,
             sync_gateway_config=sg_config,
-            races_enabled=races_enabled
+            race_enabled=race_enabled
         )
 
     yield {"cluster_config": cluster_config, "mode": mode}

--- a/utilities/scan_logs.py
+++ b/utilities/scan_logs.py
@@ -8,7 +8,7 @@ def scan_for_errors(error_strings, log_file_path):
     We use this to look for errors, so we expect that no words will be found
     If any of the words are found, we raise an exception.
 
-    'error_strings' should be a list. Example ['panic', 'error']
+    'error_strings' should be a list. Example ['panic', 'error', 'data race']
     """
 
     if type(error_strings) != list:

--- a/utilities/scan_logs.py
+++ b/utilities/scan_logs.py
@@ -1,10 +1,8 @@
 import argparse
 import os
 import zipfile
-import glob
 
 from keywords.utils import log_info
-from keywords.utils import log_error
 from keywords.exceptions import LogScanningError
 
 
@@ -31,10 +29,12 @@ def unzip_log_files(directory):
             zf.extractall(zip_file_extract_dir)
 
 
-def scan_logfiles(directory):
-    """ Scan directory recursively for .log files and scan them for error key words.
+def scan_logs(directory):
+    """ Unzips .zip files and scans directory recursively for .log files and scan them for error key words.
     Raise an exception if any of the error keywords are found.
     """
+    # Unzip logs
+    unzip_log_files(directory)
 
     log_file_paths = get_file_paths_with_extension(directory, '.log')
 
@@ -78,8 +78,5 @@ if __name__ == '__main__':
     parser.add_argument('--path-to-log-dir', help='Directory containing the log files', required=True)
     args = parser.parse_args()
 
-    # Unzip files
-    unzip_log_files(args.path_to_log_dir)
-
     # Scan all log files in the directory for 'panic' and 'data races'
-    scan_logfiles(args.path_to_log_dir)
+    scan_logs(args.path_to_log_dir)

--- a/utilities/scan_logs.py
+++ b/utilities/scan_logs.py
@@ -29,7 +29,6 @@ def unzip_log_files(directory):
         log_info('Unzipping: {}'.format(zip_file))
         with zipfile.ZipFile(zip_file) as zf:
             zf.extractall(zip_file_extract_dir)
-            os.remove(zip_file)
 
 
 def scan_logfiles(directory):

--- a/utilities/scan_logs.py
+++ b/utilities/scan_logs.py
@@ -1,8 +1,59 @@
+import argparse
+import os
+import zipfile
+
 from keywords.utils import log_info
 from keywords.utils import log_error
+from keywords.exceptions import LogScanningError
 
 
-def scan_for_errors(error_strings, log_file_path):
+def gather_logs(directory):
+    """ 
+    1. Look for .zip files and unzip
+    2. Scan for sync gateway / accel logs
+    """
+
+    log_info('Looking in {} for sync_gateway / accel logs ...'.format(directory))
+
+    # Walk directory to get list of files
+    file_names = []
+    for root, dirs, files in os.walk(directory, topdown=True):
+        for f in files:
+            file_names.append(os.path.join(root, f))
+
+    # Extract / remove any .zip files
+    zip_files = [file_name for file_name in file_names if file_name.endswith('.zip')]
+    for zip_file in zip_files:
+        zip_file_extract_dir = zip_file.replace('.zip', '')
+        log_info('Unzipping: {}'.format(zip_file))
+        with zipfile.ZipFile(zip_file) as zf:
+            zf.extractall(zip_file_extract_dir)
+            os.remove(zip_file)
+
+    # Walk directory again to get list of files now that everything has been extracted
+    file_names = []
+    for root, dirs, files in os.walk(directory, topdown=True):
+        for f in files:
+            file_names.append(os.path.join(root, f))
+
+    # Get log files we would like to scan
+    log_files = [file_name for file_name in file_names if file_name.endswith('.log')]
+
+    # Scan the logs for panics and data races
+    log_info('Scanning logs {} logs ...'.format(len(log_files)))
+    issues_found = False
+    for log_file in log_files:
+        try:
+            scan_for_errors(log_file, ['panic', 'data race'])
+        except LogScanningError as lse:
+            log_info(lse.message)
+            issues_found = True
+
+    if issues_found:
+        raise LogScanningError('ERROR!!! Found panics or data races!!')
+
+
+def scan_for_errors(log_file_path, error_strings):
     """
     Scans a log file line by line for a provided array of words.
     We use this to look for errors, so we expect that no words will be found
@@ -12,9 +63,7 @@ def scan_for_errors(error_strings, log_file_path):
     """
 
     if type(error_strings) != list:
-        raise ValueError("'error_strings must be a list'")
-
-    log_info("Looking for {} in {} ...".format(error_strings, log_file_path))
+        raise ValueError('error_strings must be a list')
 
     # Scan each line in the log file for the words to search for
     with open(log_file_path) as f:
@@ -24,7 +73,13 @@ def scan_for_errors(error_strings, log_file_path):
                 # which handles the case where 'warning' will catch 'WARNING' and 'Warning', etc
                 if word.lower() in line.lower():
                     log_error(line)
-                    raise AssertionError("{} found!! Please review: {} ".format(word, log_file_path))
+                    raise LogScanningError('{} found!! Please review: {} '.format(word, log_file_path))
 
-    # No errors found
-    log_info("Scan complete. Did not find any error strings.")
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--path-to-log-dir', help='Directory containing the log files', required=True)
+    args = parser.parse_args()
+
+    gather_logs(args.path_to_log_dir)


### PR DESCRIPTION
#### Updating log collection on every run.

- [x] Ran `flake8`

#### Changes proposed in this pull request:

- Allow sync gateway functional test to run with `--race` flag. When this is enabled with a commit as the version, Sync Gateway will be built with -race. 

- Allow sync gateway functional test to run with `--collect-logs` flag. When this is enabled, every test will pull logs regardless of pass / fail. 

