### PR TITLE
Fix liteserv stop

### DIFF
--- a/keywords/LiteServNetMsft.py
+++ b/keywords/LiteServNetMsft.py
@@ -177,7 +177,11 @@ class LiteServNetMsft(LiteServBase):
         Stops a .NET listener on a remote windows machine via ansible and pulls logs.
         """
 
-        binary_path = "couchbase-lite-net-msft-{}-liteserv/LiteServ.exe".format(self.version_build)
+        # The package structure for LiteServ is different pre 1.4. Handle for this case
+        if has_dot_net4_dot_5(self.version_build):
+            binary_path = "couchbase-lite-net-msft-{}-liteserv/net45/LiteServ.exe".format(self.version_build)
+        else:
+            binary_path = "couchbase-lite-net-msft-{}-liteserv/LiteServ.exe".format(self.version_build)
 
         log_full_path = "{}/{}".format(os.getcwd(), self.logfile)
 


### PR DESCRIPTION
#### Fixes #.
https://github.com/couchbaselabs/mobile-testkit/issues/1094

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:
- The stop method adopts the binary path

