### PR TITLE
Feature/unit test source builds

### DIFF
--- a/libraries/provision/ansible/playbooks/install-sync-gateway-source.yml
+++ b/libraries/provision/ansible/playbooks/install-sync-gateway-source.yml
@@ -54,6 +54,9 @@
     build_flags:
 
   tasks:
+
+  - debug: msg=Building Sync Gateway commit {{ commit }} with build flags {{ build_flags }}
+
   - name: SYNC GATEWAY & SG ACCEL | Create .git email to use bootstrap.sh script
     shell: git config --global user.email "foo@couchbase.com"
 

--- a/libraries/provision/ansible/playbooks/install-sync-gateway-source.yml
+++ b/libraries/provision/ansible/playbooks/install-sync-gateway-source.yml
@@ -80,6 +80,9 @@
   - name: SYNC GATEWAY & SG ACCEL | Build
     shell: ./build.sh {{ build_flags }} chdir=/home/centos/
 
+  - name: SYNC GATEWAY & SG ACCEL | Unit Tests
+    shell: ./test.sh chdir=/home/centos/
+
 - hosts: sync_gateways
   any_errors_fatal: true
   become: yes

--- a/libraries/provision/ansible/playbooks/install-sync-gateway-source.yml
+++ b/libraries/provision/ansible/playbooks/install-sync-gateway-source.yml
@@ -54,9 +54,6 @@
     build_flags:
 
   tasks:
-
-  - debug: msg=Building Sync Gateway commit {{ commit }} with build flags {{ build_flags }}
-
   - name: SYNC GATEWAY & SG ACCEL | Create .git email to use bootstrap.sh script
     shell: git config --global user.email "foo@couchbase.com"
 

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -65,6 +65,7 @@ def params_from_base_suite_setup(request):
     log_info("sync_gateway_version: {}".format(sync_gateway_version))
     log_info("mode: {}".format(mode))
     log_info("skip_provisioning: {}".format(skip_provisioning))
+    log_info("race_enabled: {}".format(race_enabled))
 
     # Make sure mode for sync_gateway is supported ('cc' or 'di')
     validate_sync_gateway_mode(mode)


### PR DESCRIPTION
#### Fixes #.

- [x] No need to run `flake8` 
- [x] No need to run `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Run sg unit tests on source builds

#### Passing functional tests

This got past the build/test phase: 

http://uberjenkins.sc.couchbase.com/job/cen7-sync-gateway-functional-tests-topology-specific-di/278/console

Logs:

```
TASK [SG ACCEL | Run bootstrap.sh script] **************************************
skipping: [sg1]
skipping: [sg2]
changed: [ac1]

TASK [SYNC GATEWAY & SG ACCEL | Build] *****************************************
changed: [sg1]
changed: [sg2]
changed: [ac1]

TASK [SYNC GATEWAY & SG ACCEL | Unit Tests] ************************************
changed: [sg2]
changed: [sg1]
changed: [ac1]
```
