### PR TITLE
Fix the URL to delete user

### DIFF
--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -92,7 +92,7 @@ def delete_internal_rbac_bucket_user(url, bucketname):
 
     log_info("Deleting RBAC user {}".format(bucketname))
 
-    rbac_url = "{}/settings/rbac/users/{}".format(url, bucketname)
+    rbac_url = "{}/settings/rbac/users/builtin/{}".format(url, bucketname)
 
     resp = ""
     try:


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:
- Fixes a typo in the URL for deleting the user 

