### PR TITLE
Add a test case for replication with short ttl

### DIFF
--- a/testsuites/listener/shared/client_sg/test_replication.py
+++ b/testsuites/listener/shared/client_sg/test_replication.py
@@ -1104,6 +1104,7 @@ def test_replication_with_session_cookie_short_ttl(setup_client_syncgateway_test
 
     # session_header: SyncGatewaySession=a483be3248f740d810c09eb2c1b1f9198141bb15; Path=/db; Expires=Fri, 14 Apr 2017 03:54:46 GMT
     session_header = "{}={}".format(cookie_name, session_id)
+    assert session_header.startswith("SyncGatewaySession")
 
     log_info("session_header: {}".format(session_header))
 
@@ -1137,11 +1138,10 @@ def test_replication_with_session_cookie_short_ttl(setup_client_syncgateway_test
         # Sleep for 5 seconds after every add so as to expire the ttl
         time.sleep(5)
 
-    all_docs = client.merge(ls_docs)
-    log_info(all_docs)
+    log_info(ls_docs)
 
-    client.verify_docs_present(url=sg_admin_url, db=sg_db, expected_docs=all_docs)
-    client.verify_docs_present(url=ls_url, db=ls_db, expected_docs=all_docs)
+    client.verify_docs_present(url=sg_admin_url, db=sg_db, expected_docs=ls_docs)
+    client.verify_docs_present(url=ls_url, db=ls_db, expected_docs=ls_docs)
 
     # Cancel the replications
     # Stop repl_one
@@ -1166,10 +1166,13 @@ def test_replication_with_session_cookie_short_ttl(setup_client_syncgateway_test
 
     # session_header: SyncGatewaySession=a483be3248f740d810c09eb2c1b1f9198141bb15; Path=/db; Expires=Fri, 14 Apr 2017 03:54:46 GMT
     session_header = "{}={}".format(cookie_name, session_id)
+    assert session_header.startswith("SyncGatewaySession")
 
     log_info("session_header: {}".format(session_header))
 
     # Start authenticated push replication
+    # The bug was that the CBL replication here will use the previous
+    # session's cookie and get a 401 error
     repl_one = client.start_replication(
         url=ls_url,
         continuous=True,
@@ -1199,11 +1202,10 @@ def test_replication_with_session_cookie_short_ttl(setup_client_syncgateway_test
         # Sleep for 5 seconds after every add so as to expire the ttl
         time.sleep(5)
 
-    all_docs = client.merge(ls_docs)
-    log_info(all_docs)
+    log_info(ls_docs)
 
-    client.verify_docs_present(url=sg_admin_url, db=sg_db, expected_docs=all_docs)
-    client.verify_docs_present(url=ls_url, db=ls_db, expected_docs=all_docs)
+    client.verify_docs_present(url=sg_admin_url, db=sg_db, expected_docs=ls_docs)
+    client.verify_docs_present(url=ls_url, db=ls_db, expected_docs=ls_docs)
 
     # Cancel the replications
     # Stop repl_one

--- a/testsuites/listener/shared/client_sg/test_replication.py
+++ b/testsuites/listener/shared/client_sg/test_replication.py
@@ -1099,7 +1099,7 @@ def test_replication_with_session_cookie_short_ttl(setup_client_syncgateway_test
     client.create_database(url=ls_url, name=ls_db)
 
     # Get session header for user_1
-    cookie_name, session_id = client.create_session(url=sg_admin_url, db=sg_db, name="user_1", password="foo", ttl=1)
+    cookie_name, session_id = client.create_session(url=sg_admin_url, db=sg_db, name="user_1", password="foo", ttl=3)
 
     # session_header: SyncGatewaySession=a483be3248f740d810c09eb2c1b1f9198141bb15; Path=/db; Expires=Fri, 14 Apr 2017 03:54:46 GMT
     session_header = "{}={}".format(cookie_name, session_id)
@@ -1147,7 +1147,7 @@ def test_replication_with_session_cookie_short_ttl(setup_client_syncgateway_test
         assert len(sg_docs) == num_docs_pushed
 
         num_docs_pushed -= 1
-        time.sleep(2)
+        time.sleep(5)
 
     all_docs = client.merge(ls_docs, sg_docs)
     log_info(all_docs)

--- a/testsuites/listener/shared/client_sg/test_replication.py
+++ b/testsuites/listener/shared/client_sg/test_replication.py
@@ -1066,7 +1066,7 @@ def test_verify_open_revs_with_revs_limit_push_conflict(setup_client_syncgateway
 @pytest.mark.replication
 @pytest.mark.session
 def test_replication_with_session_cookie_short_ttl(setup_client_syncgateway_test):
-    """Regression test for https://issues.couchbase.com/browse/CBSE-3606
+    """Regression test for https://github.com/couchbaselabs/mobile-testkit/issues/1110
     1. SyncGateway Config with guest disabled = true and One user added (e.g. user1 / 1234)
     2. Create a new session on SGW for the user1 by using POST /_session.
        Capture the SyncGatewaySession cookie from the set-cookie in the response header.

--- a/testsuites/listener/shared/client_sg/test_replication.py
+++ b/testsuites/listener/shared/client_sg/test_replication.py
@@ -1072,6 +1072,7 @@ def test_replication_with_session_cookie_short_ttl(setup_client_syncgateway_test
        Capture the SyncGatewaySession cookie from the set-cookie in the response header.
     3. Start continuous push replicator on the LiteServ with SyncGatewaySession cookie.
        Make sure that the replicators start correctly
+       Let the replicator run for more than 10% of the session expiry time specified when the session was created in step 2
     4. Cancel both push and pull replicator on the LiteServ
     5. Delete the session from SGW by sending DELETE /_sessions/ to SGW
     6. Repeat steps 2 through 6

--- a/testsuites/listener/shared/client_sg/test_replication.py
+++ b/testsuites/listener/shared/client_sg/test_replication.py
@@ -1101,8 +1101,8 @@ def test_replication_with_session_cookie_short_ttl(setup_client_syncgateway_test
     # Get session header for user_1
     cookie_name, session_id = client.create_session(url=sg_admin_url, db=sg_db, name="user_1", password="foo", ttl=1)
 
-    # session_header: SyncGatewaySession = a483be3248f740d810c09eb2c1b1f9198141bb15; Path=/db; Expires=Fri, 14 Apr 2017 03:54:46 GMT
-    session_header = "{}={}; Path=/{}".format(cookie_name, session_id, sg_db)
+    # session_header: SyncGatewaySession=a483be3248f740d810c09eb2c1b1f9198141bb15; Path=/db; Expires=Fri, 14 Apr 2017 03:54:46 GMT
+    session_header = "{}={}".format(cookie_name, session_id)
 
     log_info("session_header: {}".format(session_header))
     session = (cookie_name, session_id)


### PR DESCRIPTION
#### Fixes #.
https://github.com/couchbaselabs/mobile-testkit/issues/1110

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:
    1. SyncGateway Config with guest disabled = true and One user added (e.g. user1 / 1234)
    2. Create a new session on SGW for the user1 by using POST /_session.
       Capture the SyncGatewaySession cookie from the set-cookie in the response header.
    3. Start continuous push replicator on the LiteServ with SyncGatewaySession cookie.
       Make sure that the replicators start correctly
       Let the replicator run for more than 10% of the session expiry time specified when the session was created in step 2
    4. Cancel both push and pull replicator on the LiteServ
    5. Delete the session from SGW by sending DELETE /_sessions/ to SGW
    6. Repeat steps 2 through 6
