### PR TITLE
Skip test_longpoll_changes_termination_timeout on macosx for 1.3.1 CBL

### DIFF
--- a/testsuites/listener/shared/client_sg/conftest.py
+++ b/testsuites/listener/shared/client_sg/conftest.py
@@ -116,7 +116,6 @@ def setup_client_syncgateway_test(request, setup_client_syncgateway_suite):
 
     # Yield values to test case via fixture argument
     yield {
-        "liteserv": liteserv,
         "cluster_config": cluster_config,
         "sg_mode": setup_client_syncgateway_suite["sg_mode"],
         "ls_url": ls_url,

--- a/testsuites/listener/shared/client_sg/conftest.py
+++ b/testsuites/listener/shared/client_sg/conftest.py
@@ -111,6 +111,7 @@ def setup_client_syncgateway_test(request, setup_client_syncgateway_suite):
 
     # Yield values to test case via fixture argument
     yield {
+        "liteserv": liteserv,
         "cluster_config": cluster_config,
         "sg_mode": setup_client_syncgateway_suite["sg_mode"],
         "ls_url": ls_url,

--- a/testsuites/listener/shared/client_sg/conftest.py
+++ b/testsuites/listener/shared/client_sg/conftest.py
@@ -97,6 +97,11 @@ def setup_client_syncgateway_test(request, setup_client_syncgateway_suite):
     cluster_config = setup_client_syncgateway_suite["cluster_config"]
     test_name = request.node.name
 
+    if request.config.getoption("--liteserv-platform") == "macosx" and \
+            str(request.config.getoption("--liteserv-version")).startswith("1.3.1") and \
+            str(test_name).startswith("test_longpoll_changes_termination"):
+        pytest.skip("test_longpoll_changes_termination test are known to fail on macosx with 1.3.1 CBL")
+
     client = MobileRestClient()
 
     # Start LiteServ and delete any databases

--- a/testsuites/listener/shared/client_sg/conftest.py
+++ b/testsuites/listener/shared/client_sg/conftest.py
@@ -100,7 +100,7 @@ def setup_client_syncgateway_test(request, setup_client_syncgateway_suite):
     if request.config.getoption("--liteserv-platform") == "macosx" and \
             str(request.config.getoption("--liteserv-version")).startswith("1.3.1") and \
             str(test_name).startswith("test_longpoll_changes_termination"):
-        pytest.skip("test_longpoll_changes_termination test are known to fail on macosx with 1.3.1 CBL")
+        pytest.skip("test_longpoll_changes_termination tests are known to fail on macosx with 1.3.1 CBL")
 
     client = MobileRestClient()
 

--- a/testsuites/listener/shared/client_sg/test_changes.py
+++ b/testsuites/listener/shared/client_sg/test_changes.py
@@ -68,7 +68,12 @@ def test_longpoll_changes_termination_heartbeat(setup_client_syncgateway_test):
     Wait 5.1s
     Create another request GET /db/ on listener and make sure the listener responds
     """
+    liteserv_type = str(type(setup_client_syncgateway_test["liteserv"])).split(".")[1]
+    liteserv_version = str(setup_client_syncgateway_test["liteserv"].version_build)
 
+    if liteserv_type == "LiteServMacOSX" and liteserv_version.startswith("1.3.1"):
+        pytest.skip("test_longpoll_changes_termination_timeout fails on macosx with 1.3.1 CBL")
+        
     log_info("Running 'longpoll_changes_termination' ...")
 
     ls_db = "ls_db"

--- a/testsuites/listener/shared/client_sg/test_changes.py
+++ b/testsuites/listener/shared/client_sg/test_changes.py
@@ -19,13 +19,6 @@ def test_longpoll_changes_termination_timeout(setup_client_syncgateway_test):
     3. Wait 5.1s
     4. Create another request GET /db/ on listener and make sure the listener responds
     """
-
-    liteserv_type = str(type(setup_client_syncgateway_test["liteserv"])).split(".")[1]
-    liteserv_version = str(setup_client_syncgateway_test["liteserv"].version_build)
-
-    if liteserv_type == "LiteServMacOSX" and liteserv_version.startswith("1.3.1"):
-        pytest.skip("test_longpoll_changes_termination_timeout fails on macosx with 1.3.1 CBL")
-
     ls_db = "ls_db"
     ls_url = setup_client_syncgateway_test["ls_url"]
 
@@ -68,12 +61,6 @@ def test_longpoll_changes_termination_heartbeat(setup_client_syncgateway_test):
     Wait 5.1s
     Create another request GET /db/ on listener and make sure the listener responds
     """
-    liteserv_type = str(type(setup_client_syncgateway_test["liteserv"])).split(".")[1]
-    liteserv_version = str(setup_client_syncgateway_test["liteserv"].version_build)
-
-    if liteserv_type == "LiteServMacOSX" and liteserv_version.startswith("1.3.1"):
-        pytest.skip("test_longpoll_changes_termination_timeout fails on macosx with 1.3.1 CBL")
-
     log_info("Running 'longpoll_changes_termination' ...")
 
     ls_db = "ls_db"

--- a/testsuites/listener/shared/client_sg/test_changes.py
+++ b/testsuites/listener/shared/client_sg/test_changes.py
@@ -20,6 +20,12 @@ def test_longpoll_changes_termination_timeout(setup_client_syncgateway_test):
     4. Create another request GET /db/ on listener and make sure the listener responds
     """
 
+    liteserv_type = str(type(setup_client_syncgateway_test["liteserv"])).split(".")[1]
+    liteserv_version = str(setup_client_syncgateway_test["liteserv"].version_build)
+
+    if liteserv_type == "LiteServMacOSX" and liteserv_version.startswith("1.3.1"):
+        pytest.skip("test_longpoll_changes_termination_timeout fails on macosx with 1.3.1 CBL")
+
     ls_db = "ls_db"
     ls_url = setup_client_syncgateway_test["ls_url"]
 

--- a/testsuites/listener/shared/client_sg/test_changes.py
+++ b/testsuites/listener/shared/client_sg/test_changes.py
@@ -73,7 +73,7 @@ def test_longpoll_changes_termination_heartbeat(setup_client_syncgateway_test):
 
     if liteserv_type == "LiteServMacOSX" and liteserv_version.startswith("1.3.1"):
         pytest.skip("test_longpoll_changes_termination_timeout fails on macosx with 1.3.1 CBL")
-        
+
     log_info("Running 'longpoll_changes_termination' ...")
 
     ls_db = "ls_db"


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:
- Skip test_longpoll_changes_termination_timeout on macosx for 1.3.1 CBL

