### PR TITLE
Feature/rework test overloaded channel cache

### DIFF
--- a/resources/sync_gateway_configs/sync_gateway_channel_cache_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_channel_cache_cc.json
@@ -1,15 +1,16 @@
 {
     "interface":":4984",
     "adminInterface": "0.0.0.0:4985",
-    "log": ["CRUD+", "Cache+", "HTTP+", "Changes+"],
+    "compressResponses": false,
+    "log": ["*"],
     "databases":{
         "db": {
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "password": "password",
             "cache": {
-                "channel_cache_max_length": 5000,
-                "channel_cache_min_length": 5000,
+                "channel_cache_max_length": 750,
+                "channel_cache_min_length": 750,
                 "channel_cache_expiry": 90
             }
         }

--- a/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
+++ b/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
@@ -61,7 +61,8 @@ def test_overloaded_channel_cache(params_from_base_test_setup, sg_conf_name, num
 
     start = time.time()
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=100) as executor:
+    # This uses a ProcessPoolExecutor due to https://github.com/couchbaselabs/mobile-testkit/issues/1142
+    with concurrent.futures.ProcessPoolExecutor(max_workers=100) as executor:
 
         changes_requests = []
         errors = []

--- a/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
+++ b/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
@@ -27,6 +27,22 @@ from keywords.SyncGateway import sync_gateway_config_path_for_mode
 ])
 def test_overloaded_channel_cache(params_from_base_test_setup, sg_conf_name, num_docs, user_channels, filter, limit):
 
+    """
+    The purpose of this test is to verify that channel cache backfill via view queries is working properly.
+    It works by doing the following:
+
+    - Set channel cache size in Sync Gateway config to a small number, eg, 750.  This means that only 750 docs fit in the channel cache
+    - Add a large number of docs, eg, 1000.  
+    - Issue a _changes request that will return all 1000 docs
+
+    Expected behavior / Verification:
+
+    - Since 1000 docs requested from changes feed, but only 750 docs fit in channel cache, then it will need to do a view query 
+      to get the remaining 250 changes
+    - Verify that the changes feed returns all 1000 expected docs
+    - Check the expvar statistics to verify that view queries were made
+    """
+
     cluster_conf = params_from_base_test_setup["cluster_config"]
     mode = params_from_base_test_setup["mode"]
 
@@ -106,9 +122,9 @@ def test_overloaded_channel_cache(params_from_base_test_setup, sg_conf_name, num
         resp.raise_for_status()
         resp_obj = resp.json()
 
-        if user_channels == "*" and num_docs == 5000:
-            # "*" channel includes _user docs so the verify_changes will result in 10 view queries
-            assert resp_obj["syncGateway_changeCache"]["view_queries"] == 10
-        else:
-            # If number of view queries == 0 the key will not exist in the expvars
-            assert "view_queries" not in resp_obj["syncGateway_changeCache"]
+
+        # Since Sync Gateway will need to issue view queries to handle _changes requests that don't
+        # fit in the channel cache, we expect there to be several view queries
+        assert resp_obj["syncGateway_changeCache"]["view_queries"] > 0
+
+        

--- a/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
+++ b/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
@@ -32,12 +32,12 @@ def test_overloaded_channel_cache(params_from_base_test_setup, sg_conf_name, num
     It works by doing the following:
 
     - Set channel cache size in Sync Gateway config to a small number, eg, 750.  This means that only 750 docs fit in the channel cache
-    - Add a large number of docs, eg, 1000.  
+    - Add a large number of docs, eg, 1000.
     - Issue a _changes request that will return all 1000 docs
 
     Expected behavior / Verification:
 
-    - Since 1000 docs requested from changes feed, but only 750 docs fit in channel cache, then it will need to do a view query 
+    - Since 1000 docs requested from changes feed, but only 750 docs fit in channel cache, then it will need to do a view query
       to get the remaining 250 changes
     - Verify that the changes feed returns all 1000 expected docs
     - Check the expvar statistics to verify that view queries were made
@@ -122,9 +122,6 @@ def test_overloaded_channel_cache(params_from_base_test_setup, sg_conf_name, num
         resp.raise_for_status()
         resp_obj = resp.json()
 
-
         # Since Sync Gateway will need to issue view queries to handle _changes requests that don't
         # fit in the channel cache, we expect there to be several view queries
         assert resp_obj["syncGateway_changeCache"]["view_queries"] > 0
-
-        


### PR DESCRIPTION
#### Fixes #1142.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`
- [x] Passes [functional test](http://uberjenkins.sc.couchbase.com/job/cen7-sync-gateway-functional-tests-base-cc/507/) (queued up) 

#### Changes proposed in this pull request:

- Fixes test overloaded channel cache on https://github.com/couchbase/sync_gateway/issues/2423 feature branch.  (See commit comments for details)