### PR TITLE
Change bucket shadow tests to use TAP feed

### DIFF
--- a/resources/sync_gateway_configs/sync_gateway_bucketshadow_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_bucketshadow_cc.json
@@ -11,6 +11,7 @@
         "db":{
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
+            "feed_type":"tap",
             "password": "password",
         	    "shadow": {
 		          "server": "{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",

--- a/resources/sync_gateway_configs/sync_gateway_bucketshadow_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_bucketshadow_cc.json
@@ -17,7 +17,8 @@
 		          "server": "{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
 		          "bucket": "source-bucket",
                   "username": "source-bucket",
-                  "password": "password"
+                  "password": "password",
+                  "feed_type": "tap"
 	      }
         }
     }

--- a/resources/sync_gateway_configs/sync_gateway_bucketshadow_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_bucketshadow_di.json
@@ -31,7 +31,8 @@
         "server": "{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "bucket": "source-bucket",
         "username": "source-bucket",
-        "password": "password"
+        "password": "password",
+        "feed_type":"tap"
       }
     }
   }

--- a/resources/sync_gateway_configs/sync_gateway_bucketshadow_low_revs_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_bucketshadow_low_revs_cc.json
@@ -12,12 +12,14 @@
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "password": "password",
+            "feed_type":"tap",
     	    "revs_limit":5,
     	    "shadow": {
 		        "server": "{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
 		        "bucket": "source-bucket",
                 "username": "source-bucket",
-                "password": "password"
+                "password": "password",
+                "feed_type":"tap"
             }
         }
     }

--- a/resources/sync_gateway_configs/sync_gateway_bucketshadow_low_revs_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_bucketshadow_low_revs_di.json
@@ -32,7 +32,8 @@
         "server": "{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "bucket": "source-bucket",
         "username": "source-bucket",
-        "password": "password"
+        "password": "password",
+        "feed_type":"tap"
       }
     }
   }

--- a/resources/sync_gateway_configs/sync_gateway_default_low_revs_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_low_revs_cc.json
@@ -12,7 +12,8 @@
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "password": "password",
-	        "revs_limit":5
+	        "revs_limit":5,
+            "feed_type":"tap"
         }
     }
 }


### PR DESCRIPTION
Until https://github.com/couchbase/sync_gateway/issues/2502 is resolved

# Conflicts:
#	resources/sync_gateway_configs/sync_gateway_bucketshadow_cc.json
#	resources/sync_gateway_configs/sync_gateway_bucketshadow_low_revs_cc.json
#	resources/sync_gateway_configs/sync_gateway_default_low_revs_cc.json

#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- See commit message


