### PR TITLE
Add method to wait until a db is in the online state

### DIFF
--- a/libraries/testkit/user.py
+++ b/libraries/testkit/user.py
@@ -143,6 +143,20 @@ class User:
 
         return doc_id
 
+    def wait_until_db_online(self):
+        db_url = self.target.url + "/" + self.db + "/"
+        while True:
+            log.debug("DB [{}] waiting until online".format(self.db))
+            resp = self._session.get(db_url, timeout=settings.HTTP_REQ_TIMEOUT)
+            resp.raise_for_status()
+            resp_json = resp.json()
+            if resp_json["state"] == "Offline":
+                log.info("DB [{}] offline, waiting a few seconds and will retry.  Response: {}".format(self.db, resp_json))
+                time.sleep(10)
+            else:
+                log.debug("DB [{}] is online. Response: {}".format(self.db, resp_json))
+                return
+
     # POST /{db}/_bulk_docs
     def add_bulk_docs(self, doc_ids, retries=False):
 


### PR DESCRIPTION
I wrote and tested this while debugging https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-297576701 and it works.  Seems like a useful addition

#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Add method to wait until a db is in the online state