### PR TITLE
Add redeploy_local_sg_builld script for faster local sg redeploys

### DIFF
--- a/libraries/provision/ansible/playbooks/redeploy-local-sg-build.yml
+++ b/libraries/provision/ansible/playbooks/redeploy-local-sg-build.yml
@@ -1,0 +1,41 @@
+---
+
+- hosts: sync_gateways
+  any_errors_fatal: true
+  become: yes
+  vars:
+    sync_gateway_config_filepath:
+
+  tasks:
+  - include: tasks/stop-sync-gateway.yml
+    when: ansible_distribution == "CentOS"
+
+  - include: tasks/stop-sync-gateway-windows.yml
+    when: ansible_os_family == "Windows"
+
+  - name: copy the sync gateway binary
+    copy: src={{ local_sg_binary }} dest=/opt/couchbase-sync-gateway/bin/
+
+  - include: tasks/start-sync-gateway.yml
+    when: ansible_distribution == "CentOS"
+
+  - include: tasks/start-sync-gateway-windows.yml
+    when: ansible_os_family == "Windows"
+
+
+- hosts: sg_accels
+  any_errors_fatal: true
+  become: yes
+
+  tasks:
+  - include: tasks/stop-sg-accel.yml
+    when: ansible_distribution == "CentOS"
+
+  - include: tasks/stop-sg-accel-windows.yml
+    when: ansible_os_family == "Windows"
+
+  - name: copy the sync gateway accel binary
+    copy: src={{ local_sga_binary }} dest=/opt/sync-gateway-accel/bin/
+
+  - include: tasks/start-sg-accel.yml
+    when: ansible_distribution == "CentOS"

--- a/redeploy_local_sg_build.sh
+++ b/redeploy_local_sg_build.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+if [ -z "$CLUSTER_CONFIG" ]; then
+    echo "Need to set CLUSTER_CONFIG"
+    exit 1
+fi
+
+parseOptions () {
+
+
+    while getopts "b:h" opt; do
+	case $opt in
+	    b)
+		BINARY_DIRECTORY=$OPTARG
+		echo "Looking for sync gateway / accel binaries in : $BINARY_DIRECTORY"
+		;;
+	    h)
+		echo "./redeploy_local_sg_build.sh -b /Users/tleyden/Development/sync_gateway/godeps/bin/linux_amd64/"
+		echo "-b <binary_directory> the path where the linux binaries for sync_gateway and sync-gateway-accel"
+		exit 0
+		;;
+	    \?)
+		echo "Invalid option: -$OPTARG.  Aborting" >&2
+		exit 1
+		;;
+	esac
+    done
+
+}
+
+# Parse the getopt options and set variables
+parseOptions "$@"
+
+if [ -z "$BINARY_DIRECTORY" ]; then
+    echo "Need to pass in -b flag to specify the directory which contains the Sync Gateway / Accel binaries.  Run with -h for help"
+    exit 1
+fi
+
+SG_BINARY="$BINARY_DIRECTORY/sync_gateway"
+SGA_BINARY="$BINARY_DIRECTORY/sync-gateway-accel"
+
+ansible-playbook -i $CLUSTER_CONFIG libraries/provision/ansible/playbooks/redeploy-local-sg-build.yml --extra-vars "local_sg_binary=$SG_BINARY local_sga_binary=$SGA_BINARY"
+


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- - Add script to make it easy to deploy local sg linux builds (built via`GOOS=linux GOARCH=amd64 ./build.sh`) 

