### PR TITLE
There’s no need to restart Sync Gateway or accel when redploying a lo…

### DIFF
--- a/libraries/provision/ansible/playbooks/redeploy-local-sg-build.yml
+++ b/libraries/provision/ansible/playbooks/redeploy-local-sg-build.yml
@@ -16,12 +16,6 @@
   - name: copy the sync gateway binary
     copy: src={{ local_sg_binary }} dest=/opt/couchbase-sync-gateway/bin/
 
-  - include: tasks/start-sync-gateway.yml
-    when: ansible_distribution == "CentOS"
-
-  - include: tasks/start-sync-gateway-windows.yml
-    when: ansible_os_family == "Windows"
-
 
 - hosts: sg_accels
   any_errors_fatal: true
@@ -37,5 +31,4 @@
   - name: copy the sync gateway accel binary
     copy: src={{ local_sga_binary }} dest=/opt/sync-gateway-accel/bin/
 
-  - include: tasks/start-sg-accel.yml
-    when: ansible_distribution == "CentOS"
+

--- a/libraries/provision/ansible/playbooks/redeploy-local-sg-build.yml
+++ b/libraries/provision/ansible/playbooks/redeploy-local-sg-build.yml
@@ -14,7 +14,7 @@
     when: ansible_os_family == "Windows"
 
   - name: copy the sync gateway binary
-    copy: src={{ local_sg_binary }} dest=/opt/couchbase-sync-gateway/bin/
+    copy: src={{ local_sg_binary }} dest=/opt/couchbase-sync-gateway/bin/sync_gateway
 
 
 - hosts: sg_accels

--- a/libraries/provision/ansible/playbooks/redeploy-local-sg-build.yml
+++ b/libraries/provision/ansible/playbooks/redeploy-local-sg-build.yml
@@ -29,6 +29,7 @@
     when: ansible_os_family == "Windows"
 
   - name: copy the sync gateway accel binary
-    copy: src={{ local_sga_binary }} dest=/opt/sync-gateway-accel/bin/
+    copy: src={{ local_sga_binary }} dest=/opt/couchbase-sg-accel/bin/sg_accel
+
 
 

--- a/redeploy_local_sg_build.sh
+++ b/redeploy_local_sg_build.sh
@@ -39,5 +39,8 @@ fi
 SG_BINARY="$BINARY_DIRECTORY/sync_gateway"
 SGA_BINARY="$BINARY_DIRECTORY/sync-gateway-accel"
 
+echo "Redeploying to machine specified $CLUSTER_CONFIG"
+cat $CLUSTER_CONFIG
+
 ansible-playbook -i $CLUSTER_CONFIG libraries/provision/ansible/playbooks/redeploy-local-sg-build.yml --extra-vars "local_sg_binary=$SG_BINARY local_sga_binary=$SGA_BINARY"
 

--- a/testsuites/syncgateway/functional/tests/README.md
+++ b/testsuites/syncgateway/functional/tests/README.md
@@ -92,3 +92,16 @@ pytest  -s \
         -k "test_online_to_offline_check_503" \
         testsuites/syncgateway/functional/tests/
 ```
+
+
+## Locally redeploy Linux binaries
+
+To speed up local development, you can build Sync Gateway + Accel locally on your OSX machine and cross-compile for Linux, and then deploy the binaries to your Vagrant / AWS / Data Center VM machines using a script.
+
+Steps:
+
+1. `GOOS=linux GOARCH=amd64 ./build.sh`
+1. `export CLUSTER_CONFIG=path/to/your/cluster_config`
+1. `./redeploy_local_sg_build.sh -b path/to/your/sync_gw/linux/binaries`  
+
+An example path to your Sync Gateway linux binaries is `~/code/sync_gateway/godeps/bin/linux_amd64/` 


### PR DESCRIPTION
…cal cross-compile build

pytest will do it anyway

#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- I ran into issues when this script tried to start sync gateway, and realized there was no need for it to do so
-

