### PR TITLE
Skip offline tests in DI mode

### DIFF
--- a/testsuites/syncgateway/functional/tests/test_db_online_offline.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline.py
@@ -20,6 +20,7 @@ from keywords.SyncGateway import sync_gateway_config_path_for_mode
 
 NUM_ENDPOINTS = 13
 
+
 # Scenario 1
 @pytest.mark.sanity
 @pytest.mark.syncgateway

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline.py
@@ -20,6 +20,721 @@ from keywords.SyncGateway import sync_gateway_config_path_for_mode
 
 NUM_ENDPOINTS = 13
 
+# Scenario 1
+@pytest.mark.sanity
+@pytest.mark.syncgateway
+@pytest.mark.onlineoffline
+@pytest.mark.basicauth
+@pytest.mark.role
+@pytest.mark.channel
+@pytest.mark.bulkops
+@pytest.mark.changes
+@pytest.mark.parametrize("sg_conf_name, num_docs", [
+    ("bucket_online_offline/bucket_online_offline_default", 100)
+])
+def test_online_default_rest(params_from_base_test_setup, sg_conf_name, num_docs):
+
+    cluster_conf = params_from_base_test_setup["cluster_config"]
+    mode = params_from_base_test_setup["mode"]
+
+    if mode == "di":
+        pytest.skip("Offline tests not supported in Di mode -- see https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-300841425")
+
+    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
+
+    log_info("Using cluster_conf: {}".format(cluster_conf))
+    log_info("Using sg_conf: {}".format(sg_conf))
+    log_info("Using num_docs: {}".format(num_docs))
+
+    cluster = Cluster(config=cluster_conf)
+    cluster.reset(sg_config_path=sg_conf)
+
+    # all db endpoints should function as expected
+    errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
+    assert len(errors) == 0
+
+    # Scenario 4
+    # Check the db has an Online state at each running sync_gateway
+    for sg in cluster.sync_gateways:
+        admin = Admin(sg)
+        db_info = admin.get_db_info("db")
+        assert db_info["state"] == "Online"
+
+
+# Scenario 2
+@pytest.mark.sanity
+@pytest.mark.syncgateway
+@pytest.mark.onlineoffline
+@pytest.mark.basicauth
+@pytest.mark.role
+@pytest.mark.channel
+@pytest.mark.bulkops
+@pytest.mark.changes
+@pytest.mark.parametrize("sg_conf_name, num_docs", [
+    ("bucket_online_offline/bucket_online_offline_offline_false", 100)
+])
+def test_offline_false_config_rest(params_from_base_test_setup, sg_conf_name, num_docs):
+
+    cluster_conf = params_from_base_test_setup["cluster_config"]
+    mode = params_from_base_test_setup["mode"]
+
+    if mode == "di":
+        pytest.skip("Offline tests not supported in Di mode -- see https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-300841425")
+
+    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
+
+    log_info("Using cluster_conf: {}".format(cluster_conf))
+    log_info("Using sg_conf: {}".format(sg_conf))
+    log_info("Using num_docs: {}".format(num_docs))
+
+    cluster = Cluster(config=cluster_conf)
+    cluster.reset(sg_config_path=sg_conf)
+
+    # all db endpoints should function as expected
+    errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
+
+    assert len(errors) == 0
+
+    # Scenario 4
+    # Check the db has an Online state at each running sync_gateway
+    for sg in cluster.sync_gateways:
+        admin = Admin(sg)
+        db_info = admin.get_db_info("db")
+        assert db_info["state"] == "Online"
+
+
+# Scenario 3
+@pytest.mark.sanity
+@pytest.mark.syncgateway
+@pytest.mark.onlineoffline
+@pytest.mark.basicauth
+@pytest.mark.role
+@pytest.mark.channel
+@pytest.mark.bulkops
+@pytest.mark.changes
+@pytest.mark.parametrize("sg_conf_name, num_docs", [
+    ("bucket_online_offline/bucket_online_offline_default", 100)
+])
+def test_online_to_offline_check_503(params_from_base_test_setup, sg_conf_name, num_docs):
+
+    cluster_conf = params_from_base_test_setup["cluster_config"]
+    mode = params_from_base_test_setup["mode"]
+
+    if mode == "di":
+        pytest.skip("Offline tests not supported in Di mode -- see https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-300841425")
+
+    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
+
+    log_info("Using cluster_conf: {}".format(cluster_conf))
+    log_info("Using sg_conf: {}".format(sg_conf))
+    log_info("Using num_docs: {}".format(num_docs))
+
+    cluster = Cluster(config=cluster_conf)
+    cluster.reset(sg_config_path=sg_conf)
+    admin = Admin(cluster.sync_gateways[0])
+
+    # all db endpoints should function as expected
+    errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
+    assert len(errors) == 0
+
+    # Take bucket offline
+    status = admin.take_db_offline(db="db")
+    assert status == 200
+
+    # all db endpoints should return 503
+    errors = rest_scan(cluster.sync_gateways[0], db="db", online=False, num_docs=num_docs, user_name="seth", channels=["ABC"])
+
+    # We hit NUM_ENDPOINT unique REST endpoints + num of doc PUT failures
+    assert len(errors) == NUM_ENDPOINTS + (num_docs * 2)
+    for error_tuple in errors:
+        log_info("({},{})".format(error_tuple[0], error_tuple[1]))
+        assert error_tuple[1] == 503
+
+
+# Scenario 5 - continuous
+# NOTE: Was disabled for di
+@pytest.mark.sanity
+@pytest.mark.syncgateway
+@pytest.mark.onlineoffline
+@pytest.mark.basicauth
+@pytest.mark.parametrize("sg_conf_name, num_docs", [
+    ("bucket_online_offline/bucket_online_offline_default", 5000)
+])
+def test_online_to_offline_changes_feed_controlled_close_continuous(params_from_base_test_setup, sg_conf_name, num_docs):
+
+    cluster_conf = params_from_base_test_setup["cluster_config"]
+    mode = params_from_base_test_setup["mode"]
+
+    if mode == "di":
+        pytest.skip("Offline tests not supported in Di mode -- see https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-300841425")
+
+    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
+
+    log_info("Using cluster_conf: {}".format(cluster_conf))
+    log_info("Using sg_conf: {}".format(sg_conf))
+    log_info("Using num_docs: {}".format(num_docs))
+
+    cluster = Cluster(config=cluster_conf)
+    cluster.reset(sg_config_path=sg_conf)
+
+    admin = Admin(cluster.sync_gateways[0])
+    seth = admin.register_user(target=cluster.sync_gateways[0], db="db", name="seth", password="password", channels=["ABC"])
+    doc_pusher = admin.register_user(target=cluster.sync_gateways[0], db="db", name="doc_pusher", password="password", channels=["ABC"])
+
+    docs_in_changes = dict()
+    doc_add_errors = list()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=libraries.testkit.settings.MAX_REQUEST_WORKERS) as executor:
+        futures = dict()
+        futures[executor.submit(seth.start_continuous_changes_tracking, termination_doc_id=None)] = "continuous"
+        futures[executor.submit(doc_pusher.add_docs, num_docs)] = "docs_push"
+        time.sleep(5)
+        futures[executor.submit(admin.take_db_offline, "db")] = "db_offline_task"
+
+        for future in concurrent.futures.as_completed(futures):
+            task_name = futures[future]
+
+            if task_name == "db_offline_task":
+                log_info("DB OFFLINE")
+                # make sure db_offline returns 200
+                assert future.result() == 200
+            elif task_name == "docs_push":
+                log_info("DONE PUSHING DOCS")
+                doc_add_errors = future.result()
+            elif task_name == "continuous":
+                docs_in_changes = future.result()
+                log_info("DOCS FROM CHANGES")
+                for k, v in docs_in_changes.items():
+                    log_info("DFC -> {}:{}".format(k, v))
+
+    log_info("Number of docs from _changes ({})".format(len(docs_in_changes)))
+    log_info("Number of docs add errors ({})".format(len(doc_add_errors)))
+
+    # Some docs should have made it to _changes
+    assert len(docs_in_changes) > 0
+
+    # Bring db back online
+    status = admin.bring_db_online("db")
+    assert status == 200
+
+    # Get all docs that have been pushed
+    # Verify that changes returns all of them
+    all_docs = doc_pusher.get_all_docs()
+    num_docs_pushed = len(all_docs["rows"])
+    verify_changes(doc_pusher, expected_num_docs=num_docs_pushed, expected_num_revisions=0, expected_docs=doc_pusher.cache)
+
+    # Check that the number of errors return when trying to push while db is offline + num of docs in db
+    # should equal the number of docs
+    assert num_docs_pushed + len(doc_add_errors) == num_docs
+
+
+# Scenario 6 - longpoll
+@pytest.mark.sanity
+@pytest.mark.syncgateway
+@pytest.mark.onlineoffline
+@pytest.mark.changes
+@pytest.mark.basicauth
+@pytest.mark.parametrize("sg_conf_name, num_docs, num_users", [
+    ("bucket_online_offline/bucket_online_offline_default", 5000, 40)
+])
+def test_online_to_offline_continous_changes_feed_controlled_close_sanity_mulitple_users(params_from_base_test_setup, sg_conf_name, num_docs, num_users):
+
+    cluster_conf = params_from_base_test_setup["cluster_config"]
+    mode = params_from_base_test_setup["mode"]
+
+    if mode == "di":
+        pytest.skip("Offline tests not supported in Di mode -- see https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-300841425")
+
+    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
+
+    log_info("Using cluster_conf: {}".format(cluster_conf))
+    log_info("Using sg_conf: {}".format(sg_conf))
+    log_info("Using num_docs: {}".format(num_docs))
+    log_info("Using num_users: {}".format(num_users))
+
+    cluster = Cluster(config=cluster_conf)
+    cluster.reset(sg_config_path=sg_conf)
+
+    admin = Admin(cluster.sync_gateways[0])
+    users = admin.register_bulk_users(target=cluster.sync_gateways[0], db="db", name_prefix="user", password="password", number=num_users, channels=["ABC"])
+
+    feed_close_results = list()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=libraries.testkit.settings.MAX_REQUEST_WORKERS) as executor:
+        # start continuous tracking with no timeout, will block until connection is closed by db going offline
+        futures = {executor.submit(user.start_continuous_changes_tracking, termination_doc_id=None): user.name for user in users}
+
+        time.sleep(5)
+        futures[executor.submit(admin.take_db_offline, "db")] = "db_offline_task"
+
+        for future in concurrent.futures.as_completed(futures):
+            task_name = futures[future]
+
+            if task_name == "db_offline_task":
+                log_info("DB OFFLINE")
+                # make sure db_offline returns 200
+                assert future.result() == 200
+            if task_name.startswith("user"):
+                # Long poll will exit with 503, return docs in the exception
+                log_info("POLLING DONE")
+                try:
+                    docs = future.result()
+                    feed_close_results.append(docs)
+                except Exception as e:
+                    log_info("Continious feed close error: {}".format(e))
+                    # continuous should be closed so this exception should never happen
+                    assert 0
+
+    # Assert that the feed close results length is num_users
+    assert len(feed_close_results) == num_users
+
+    # No docs should be returned
+    for feed_result in feed_close_results:
+        assert len(feed_result) == 0
+
+
+# Scenario 6 - longpoll
+@pytest.mark.sanity
+@pytest.mark.syncgateway
+@pytest.mark.onlineoffline
+@pytest.mark.changes
+@pytest.mark.basicauth
+@pytest.mark.parametrize("sg_conf_name, num_docs", [
+    ("bucket_online_offline/bucket_online_offline_default", 5000)
+])
+def test_online_to_offline_changes_feed_controlled_close_longpoll_sanity(params_from_base_test_setup, sg_conf_name, num_docs):
+
+    cluster_conf = params_from_base_test_setup["cluster_config"]
+    mode = params_from_base_test_setup["mode"]
+
+    if mode == "di":
+        pytest.skip("Offline tests not supported in Di mode -- see https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-300841425")
+
+    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
+
+    log_info("Using cluster_conf: {}".format(cluster_conf))
+    log_info("Using sg_conf: {}".format(sg_conf))
+    log_info("Using num_docs: {}".format(num_docs))
+
+    cluster = Cluster(config=cluster_conf)
+    cluster.reset(sg_config_path=sg_conf)
+
+    admin = Admin(cluster.sync_gateways[0])
+    seth = admin.register_user(target=cluster.sync_gateways[0], db="db", name="seth", password="password", channels=["ABC"])
+
+    docs_in_changes = dict()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=libraries.testkit.settings.MAX_REQUEST_WORKERS) as executor:
+        futures = dict()
+        # start longpoll tracking with no timeout, will block until longpoll is closed by db going offline
+        futures[executor.submit(seth.start_longpoll_changes_tracking, termination_doc_id=None, timeout=0, loop=False)] = "polling"
+        time.sleep(5)
+        futures[executor.submit(admin.take_db_offline, "db")] = "db_offline_task"
+
+        for future in concurrent.futures.as_completed(futures):
+            task_name = futures[future]
+
+            if task_name == "db_offline_task":
+                log_info("DB OFFLINE")
+                # make sure db_offline returns 200
+                assert future.result() == 200
+            if task_name == "polling":
+                # Long poll will exit with 503, return docs in the exception
+                log_info("POLLING DONE")
+                try:
+                    docs_in_changes, last_seq_num = future.result()
+                except Exception as e:
+                    log_info("Longpoll feed close error: {}".format(e))
+                    # long poll should be closed so this exception should never happen
+                    assert 0
+
+    # Account for _user doc
+    # last_seq may be of the form '1' for channel cache or '1-0' for distributed index
+    seq_num_component = last_seq_num.split("-")
+    assert 1 == int(seq_num_component[0])
+    assert len(docs_in_changes) == 0
+
+
+# Scenario 6 - longpoll
+@pytest.mark.sanity
+@pytest.mark.syncgateway
+@pytest.mark.onlineoffline
+@pytest.mark.changes
+@pytest.mark.basicauth
+@pytest.mark.parametrize("sg_conf_name, num_docs, num_users", [
+    ("bucket_online_offline/bucket_online_offline_default", 5000, 40)
+])
+def test_online_to_offline_longpoll_changes_feed_controlled_close_sanity_mulitple_users(params_from_base_test_setup, sg_conf_name, num_docs, num_users):
+
+    cluster_conf = params_from_base_test_setup["cluster_config"]
+    mode = params_from_base_test_setup["mode"]
+
+    if mode == "di":
+        pytest.skip("Offline tests not supported in Di mode -- see https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-300841425")
+
+    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
+
+    log_info("Using cluster_conf: {}".format(cluster_conf))
+    log_info("Using sg_conf: {}".format(sg_conf))
+    log_info("Using num_docs: {}".format(num_docs))
+    log_info("Using num_users: {}".format(num_users))
+
+    cluster = Cluster(config=cluster_conf)
+    cluster.reset(sg_config_path=sg_conf)
+
+    admin = Admin(cluster.sync_gateways[0])
+    users = admin.register_bulk_users(target=cluster.sync_gateways[0], db="db", name_prefix="user", password="password", number=num_users, channels=["ABC"])
+
+    feed_close_results = list()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=libraries.testkit.settings.MAX_REQUEST_WORKERS) as executor:
+        # start longpoll tracking with no timeout, will block until longpoll is closed by db going offline
+        futures = {executor.submit(user.start_longpoll_changes_tracking, termination_doc_id=None, timeout=0, loop=False): user.name for user in users}
+
+        time.sleep(5)
+        futures[executor.submit(admin.take_db_offline, "db")] = "db_offline_task"
+
+        for future in concurrent.futures.as_completed(futures):
+            task_name = futures[future]
+
+            if task_name == "db_offline_task":
+                log_info("DB OFFLINE")
+                # make sure db_offline returns 200
+                assert future.result() == 200
+            if task_name.startswith("user"):
+                # Long poll will exit with 503, return docs in the exception
+                log_info("POLLING DONE")
+                try:
+                    docs_in_changes, last_seq_num = future.result()
+                    feed_close_results.append((docs_in_changes, last_seq_num))
+                except Exception as e:
+                    log_info("Longpoll feed close error: {}".format(e))
+                    # long poll should be closed so this exception should never happen
+                    assert 0
+
+    # Assert that the feed close results length is num_users
+    assert len(feed_close_results) == num_users
+
+    # Account for _user doc
+    # last_seq may be of the form '1' for channel cache or '1-0' for distributed index
+    for feed_result in feed_close_results:
+        docs_in_changes = feed_result[0]
+        seq_num_component = feed_result[1].split("-")
+        assert len(docs_in_changes) == 0
+        assert int(seq_num_component[0]) > 0
+
+
+# Scenario 6 - longpoll
+# NOTE: Was disabled for di
+@pytest.mark.sanity
+@pytest.mark.syncgateway
+@pytest.mark.onlineoffline
+@pytest.mark.changes
+@pytest.mark.basicauth
+@pytest.mark.parametrize("sg_conf_name, num_docs", [
+    ("bucket_online_offline/bucket_online_offline_default", 5000)
+])
+def test_online_to_offline_changes_feed_controlled_close_longpoll(params_from_base_test_setup, sg_conf_name, num_docs):
+
+    cluster_conf = params_from_base_test_setup["cluster_config"]
+    mode = params_from_base_test_setup["mode"]
+
+    if mode == "di":
+        pytest.skip("Offline tests not supported in Di mode -- see https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-300841425")
+
+    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
+
+    log_info("Using cluster_conf: {}".format(cluster_conf))
+    log_info("Using sg_conf: {}".format(sg_conf))
+    log_info("Using num_docs: {}".format(num_docs))
+
+    cluster = Cluster(config=cluster_conf)
+    cluster.reset(sg_config_path=sg_conf)
+
+    admin = Admin(cluster.sync_gateways[0])
+    seth = admin.register_user(target=cluster.sync_gateways[0], db="db", name="seth", password="password", channels=["ABC"])
+    doc_pusher = admin.register_user(target=cluster.sync_gateways[0], db="db", name="doc_pusher", password="password", channels=["ABC"])
+
+    docs_in_changes = dict()
+    doc_add_errors = list()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=libraries.testkit.settings.MAX_REQUEST_WORKERS) as executor:
+        futures = dict()
+        futures[executor.submit(seth.start_longpoll_changes_tracking, termination_doc_id=None)] = "polling"
+        futures[executor.submit(doc_pusher.add_docs, num_docs)] = "docs_push"
+        time.sleep(5)
+        futures[executor.submit(admin.take_db_offline, "db")] = "db_offline_task"
+
+        for future in concurrent.futures.as_completed(futures):
+            task_name = futures[future]
+
+            if task_name == "db_offline_task":
+                log_info("DB OFFLINE")
+                # make sure db_offline returns 200
+                assert future.result() == 200
+            if task_name == "docs_push":
+                log_info("DONE PUSHING DOCS")
+                doc_add_errors = future.result()
+            if task_name == "polling":
+                # Long poll will exit with 503, return docs in the exception
+                log_info("POLLING DONE")
+                try:
+                    docs_in_changes = future.result()
+                except Exception as e:
+                    log_info(e)
+                    log_info("POLLING DONE EXCEPTION")
+                    log_info("ARGS: {}".format(e.args))
+                    docs_in_changes = e.args[0]["docs"]
+                    last_seq_num = e.args[0]["last_seq_num"]
+                    log_info("DOCS FROM longpoll")
+                    for k, v in docs_in_changes.items():
+                        log_info("DFC -> {}:{}".format(k, v))
+                    log_info("LAST_SEQ_NUM FROM longpoll {}".format(last_seq_num))
+
+    log_info("Number of docs from _changes ({})".format(len(docs_in_changes)))
+    log_info("last_seq_num _changes ({})".format(last_seq_num))
+    log_info("Number of docs add errors ({})".format(len(doc_add_errors)))
+
+    # Some docs should have made it to _changes
+    assert len(docs_in_changes) > 0
+
+    # Make sure some docs failed due to db being taken offline
+    assert len(doc_add_errors) > 0
+
+    seq_num_component = last_seq_num.split("-")
+    if mode == "cc":
+        # assert the last_seq_number == number _changes + 2 (_user doc starts and one and docs start at _user doc seq + 2)
+        assert len(docs_in_changes) + 2 == int(seq_num_component[0])
+    else:
+        # assert the value is not an empty string
+        assert last_seq_num != ""
+
+    # Bring db back online
+    status = admin.bring_db_online("db")
+    assert status == 200
+    #
+    # Get all docs that have been pushed
+    # Verify that changes returns all of them
+    all_docs = doc_pusher.get_all_docs()
+    num_docs_pushed = len(all_docs["rows"])
+    verify_changes(doc_pusher, expected_num_docs=num_docs_pushed, expected_num_revisions=0, expected_docs=doc_pusher.cache)
+
+    # Check that the number of errors return when trying to push while db is offline + num of docs in db
+    # should equal the number of docs
+    assert num_docs_pushed + len(doc_add_errors) == num_docs
+
+
+# Scenario 6
+# NOTE: Was disabled for di
+@pytest.mark.sanity
+@pytest.mark.syncgateway
+@pytest.mark.onlineoffline
+@pytest.mark.basicauth
+@pytest.mark.role
+@pytest.mark.channel
+@pytest.mark.bulkops
+@pytest.mark.changes
+@pytest.mark.parametrize("sg_conf_name, num_docs", [
+    ("bucket_online_offline/bucket_online_offline_offline_true", 100)
+])
+def test_offline_true_config_bring_online(params_from_base_test_setup, sg_conf_name, num_docs):
+
+    cluster_conf = params_from_base_test_setup["cluster_config"]
+    mode = params_from_base_test_setup["mode"]
+
+    if mode == "di":
+        pytest.skip("Offline tests not supported in Di mode -- see https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-300841425")
+
+    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
+
+    log_info("Using cluster_conf: {}".format(cluster_conf))
+    log_info("Using sg_conf: {}".format(sg_conf))
+    log_info("Using num_docs: {}".format(num_docs))
+
+    cluster = Cluster(config=cluster_conf)
+    cluster.reset(sg_config_path=sg_conf)
+
+    admin = Admin(cluster.sync_gateways[0])
+
+    # all db endpoints should fail with 503
+    errors = rest_scan(cluster.sync_gateways[0], db="db", online=False, num_docs=num_docs, user_name="seth", channels=["ABC"])
+
+    assert len(errors) == NUM_ENDPOINTS + (num_docs * 2)
+    for error_tuple in errors:
+        log_info("({},{})".format(error_tuple[0], error_tuple[1]))
+        assert error_tuple[1] == 503
+
+    # Scenario 9
+    # POST /db/_online
+    status = admin.bring_db_online(db="db")
+    assert status == 200
+
+    # all db endpoints should succeed
+    errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
+    assert len(errors) == 0
+
+
+# Scenario 14
+@pytest.mark.sanity
+@pytest.mark.syncgateway
+@pytest.mark.onlineoffline
+@pytest.mark.basicauth
+@pytest.mark.role
+@pytest.mark.channel
+@pytest.mark.bulkops
+@pytest.mark.changes
+@pytest.mark.parametrize("sg_conf_name, num_docs", [
+    ("bucket_online_offline/bucket_online_offline_default_dcp", 100),
+    ("bucket_online_offline/bucket_online_offline_default", 100)
+])
+def test_db_offline_tap_loss_sanity(params_from_base_test_setup, sg_conf_name, num_docs):
+
+    cluster_conf = params_from_base_test_setup["cluster_config"]
+    mode = params_from_base_test_setup["mode"]
+
+    if mode == "di":
+        pytest.skip("Offline tests not supported in Di mode -- see https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-300841425")
+
+    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
+
+    log_info("Using cluster_conf: {}".format(cluster_conf))
+    log_info("Using sg_conf: {}".format(sg_conf))
+    log_info("Using num_docs: {}".format(num_docs))
+
+    cluster = Cluster(config=cluster_conf)
+    cluster.reset(sg_config_path=sg_conf)
+
+    # all db rest enpoints should succeed
+    errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
+    assert len(errors) == 0
+
+    # Delete bucket to sever TAP feed
+    cluster.servers[0].delete_bucket("data-bucket")
+
+    # Check that bucket is in offline state
+    errors = rest_scan(cluster.sync_gateways[0], db="db", online=False, num_docs=num_docs, user_name="seth", channels=["ABC"])
+    assert len(errors) == NUM_ENDPOINTS + (num_docs * 2)
+    for error_tuple in errors:
+        log_info("({},{})".format(error_tuple[0], error_tuple[1]))
+        assert error_tuple[1] == 503
+
+
+# Scenario 11
+# NOTE: Was disabled for di
+@pytest.mark.sanity
+@pytest.mark.syncgateway
+@pytest.mark.onlineoffline
+@pytest.mark.basicauth
+@pytest.mark.role
+@pytest.mark.channel
+@pytest.mark.bulkops
+@pytest.mark.changes
+@pytest.mark.parametrize("sg_conf_name, num_docs", [
+    ("bucket_online_offline/bucket_online_offline_default", 100)
+])
+def test_db_delayed_online(params_from_base_test_setup, sg_conf_name, num_docs):
+
+    cluster_conf = params_from_base_test_setup["cluster_config"]
+    mode = params_from_base_test_setup["mode"]
+
+    if mode == "di":
+        pytest.skip("Offline tests not supported in Di mode -- see https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-300841425")
+
+    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
+
+    log_info("Using cluster_conf: {}".format(cluster_conf))
+    log_info("Using sg_conf: {}".format(sg_conf))
+    log_info("Using num_docs: {}".format(num_docs))
+
+    cluster = Cluster(config=cluster_conf)
+    cluster.reset(sg_config_path=sg_conf)
+
+    admin = Admin(cluster.sync_gateways[0])
+
+    time.sleep(2)
+    status = admin.take_db_offline("db")
+    log_info("offline request response status: {}".format(status))
+    time.sleep(10)
+
+    pool = ThreadPool(processes=1)
+
+    db_info = admin.get_db_info("db")
+    assert db_info["state"] == "Offline"
+
+    async_result = pool.apply_async(admin.bring_db_online, ("db", 15,))
+    status = async_result.get(timeout=15)
+    log_info("offline request response status: {}".format(status))
+
+    time.sleep(20)
+
+    db_info = admin.get_db_info("db")
+    assert db_info["state"] == "Online"
+
+    # all db rest enpoints should succeed
+    errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
+    assert len(errors) == 0
+
+
+@pytest.mark.sanity
+@pytest.mark.syncgateway
+@pytest.mark.onlineoffline
+@pytest.mark.basicauth
+@pytest.mark.role
+@pytest.mark.channel
+@pytest.mark.bulkops
+@pytest.mark.changes
+@pytest.mark.parametrize("sg_conf_name, num_docs", [
+    ("bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets", 100)
+])
+def test_multiple_dbs_unique_buckets_lose_tap(params_from_base_test_setup, sg_conf_name, num_docs):
+
+    cluster_conf = params_from_base_test_setup["cluster_config"]
+    mode = params_from_base_test_setup["mode"]
+
+    if mode == "di":
+        pytest.skip("Offline tests not supported in Di mode -- see https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-300841425")
+
+    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
+
+    log_info("Using cluster_conf: {}".format(cluster_conf))
+    log_info("Using sg_conf: {}".format(sg_conf))
+    log_info("Using num_docs: {}".format(num_docs))
+
+    cluster = Cluster(config=cluster_conf)
+    cluster.reset(sg_config_path=sg_conf)
+
+    dbs = ["db1", "db2", "db3", "db4"]
+
+    # all db rest endpoints should succeed
+    for db in dbs:
+        log_info("Doing rest scan on db: {}".format(db))
+        errors = rest_scan(cluster.sync_gateways[0], db=db, online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
+        assert len(errors) == 0
+
+    log_info("Deleting data-bucket-1 and data-bucket-3")
+    cluster.servers[0].delete_bucket("data-bucket-1")
+    cluster.servers[0].delete_bucket("data-bucket-3")
+
+    # Check that db2 and db4 are still Online
+    log_info("Check that db2 and db4 are still Online")
+    for db in ["db2", "db4"]:
+        errors = rest_scan(cluster.sync_gateways[0], db=db, online=True, num_docs=num_docs, user_name="adam", channels=["CBS"])
+        assert len(errors) == 0
+
+    # Check that db1 and db3 go offline
+    log_info("Check that db1 and db3 go offline")
+    for db in ["db1", "db3"]:
+        errors = rest_scan(cluster.sync_gateways[0], db=db, online=False, num_docs=num_docs, user_name="seth", channels=["ABC"])
+        num_expected_errors = NUM_ENDPOINTS + (num_docs * 2)
+        if len(errors) != num_expected_errors:
+            log_info("Expected {} errors, but got {}".format(num_expected_errors, len(errors)))
+            for err in errors:
+                log_info("{}".format(err))
+        assert len(errors) == num_expected_errors
+        for error_tuple in errors:
+            log_info("({},{})".format(error_tuple[0], error_tuple[1]))
+            assert error_tuple[1] == 503
+
 
 def rest_scan(sync_gateway, db, online, num_docs, user_name, channels):
 
@@ -191,686 +906,6 @@ def rest_scan(sync_gateway, db, online, num_docs, user_name, channels):
         error_responses.append((e.response.url, e.response.status_code))
 
     return error_responses
-
-
-# Scenario 1
-@pytest.mark.sanity
-@pytest.mark.syncgateway
-@pytest.mark.onlineoffline
-@pytest.mark.basicauth
-@pytest.mark.role
-@pytest.mark.channel
-@pytest.mark.bulkops
-@pytest.mark.changes
-@pytest.mark.parametrize("sg_conf_name, num_docs", [
-    ("bucket_online_offline/bucket_online_offline_default", 100)
-])
-def test_online_default_rest(params_from_base_test_setup, sg_conf_name, num_docs):
-
-    cluster_conf = params_from_base_test_setup["cluster_config"]
-    mode = params_from_base_test_setup["mode"]
-
-    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
-
-    log_info("Using cluster_conf: {}".format(cluster_conf))
-    log_info("Using sg_conf: {}".format(sg_conf))
-    log_info("Using num_docs: {}".format(num_docs))
-
-    cluster = Cluster(config=cluster_conf)
-    cluster.reset(sg_config_path=sg_conf)
-
-    # all db endpoints should function as expected
-    errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
-    assert len(errors) == 0
-
-    # Scenario 4
-    # Check the db has an Online state at each running sync_gateway
-    for sg in cluster.sync_gateways:
-        admin = Admin(sg)
-        db_info = admin.get_db_info("db")
-        assert db_info["state"] == "Online"
-
-
-# Scenario 2
-@pytest.mark.sanity
-@pytest.mark.syncgateway
-@pytest.mark.onlineoffline
-@pytest.mark.basicauth
-@pytest.mark.role
-@pytest.mark.channel
-@pytest.mark.bulkops
-@pytest.mark.changes
-@pytest.mark.parametrize("sg_conf_name, num_docs", [
-    ("bucket_online_offline/bucket_online_offline_offline_false", 100)
-])
-def test_offline_false_config_rest(params_from_base_test_setup, sg_conf_name, num_docs):
-
-    cluster_conf = params_from_base_test_setup["cluster_config"]
-    mode = params_from_base_test_setup["mode"]
-
-    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
-
-    log_info("Using cluster_conf: {}".format(cluster_conf))
-    log_info("Using sg_conf: {}".format(sg_conf))
-    log_info("Using num_docs: {}".format(num_docs))
-
-    cluster = Cluster(config=cluster_conf)
-    cluster.reset(sg_config_path=sg_conf)
-
-    # all db endpoints should function as expected
-    errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
-
-    assert len(errors) == 0
-
-    # Scenario 4
-    # Check the db has an Online state at each running sync_gateway
-    for sg in cluster.sync_gateways:
-        admin = Admin(sg)
-        db_info = admin.get_db_info("db")
-        assert db_info["state"] == "Online"
-
-
-# Scenario 3
-@pytest.mark.sanity
-@pytest.mark.syncgateway
-@pytest.mark.onlineoffline
-@pytest.mark.basicauth
-@pytest.mark.role
-@pytest.mark.channel
-@pytest.mark.bulkops
-@pytest.mark.changes
-@pytest.mark.parametrize("sg_conf_name, num_docs", [
-    ("bucket_online_offline/bucket_online_offline_default", 100)
-])
-def test_online_to_offline_check_503(params_from_base_test_setup, sg_conf_name, num_docs):
-
-    cluster_conf = params_from_base_test_setup["cluster_config"]
-    mode = params_from_base_test_setup["mode"]
-
-    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
-
-    log_info("Using cluster_conf: {}".format(cluster_conf))
-    log_info("Using sg_conf: {}".format(sg_conf))
-    log_info("Using num_docs: {}".format(num_docs))
-
-    cluster = Cluster(config=cluster_conf)
-    cluster.reset(sg_config_path=sg_conf)
-    admin = Admin(cluster.sync_gateways[0])
-
-    # all db endpoints should function as expected
-    errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
-    assert len(errors) == 0
-
-    # Take bucket offline
-    status = admin.take_db_offline(db="db")
-    assert status == 200
-
-    # all db endpoints should return 503
-    errors = rest_scan(cluster.sync_gateways[0], db="db", online=False, num_docs=num_docs, user_name="seth", channels=["ABC"])
-
-    # We hit NUM_ENDPOINT unique REST endpoints + num of doc PUT failures
-    assert len(errors) == NUM_ENDPOINTS + (num_docs * 2)
-    for error_tuple in errors:
-        log_info("({},{})".format(error_tuple[0], error_tuple[1]))
-        assert error_tuple[1] == 503
-
-
-# Scenario 5 - continuous
-# NOTE: Was disabled for di
-@pytest.mark.sanity
-@pytest.mark.syncgateway
-@pytest.mark.onlineoffline
-@pytest.mark.basicauth
-@pytest.mark.parametrize("sg_conf_name, num_docs", [
-    ("bucket_online_offline/bucket_online_offline_default", 5000)
-])
-def test_online_to_offline_changes_feed_controlled_close_continuous(params_from_base_test_setup, sg_conf_name, num_docs):
-
-    cluster_conf = params_from_base_test_setup["cluster_config"]
-    mode = params_from_base_test_setup["mode"]
-
-    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
-
-    log_info("Using cluster_conf: {}".format(cluster_conf))
-    log_info("Using sg_conf: {}".format(sg_conf))
-    log_info("Using num_docs: {}".format(num_docs))
-
-    cluster = Cluster(config=cluster_conf)
-    cluster.reset(sg_config_path=sg_conf)
-
-    admin = Admin(cluster.sync_gateways[0])
-    seth = admin.register_user(target=cluster.sync_gateways[0], db="db", name="seth", password="password", channels=["ABC"])
-    doc_pusher = admin.register_user(target=cluster.sync_gateways[0], db="db", name="doc_pusher", password="password", channels=["ABC"])
-
-    docs_in_changes = dict()
-    doc_add_errors = list()
-
-    with concurrent.futures.ThreadPoolExecutor(max_workers=libraries.testkit.settings.MAX_REQUEST_WORKERS) as executor:
-        futures = dict()
-        futures[executor.submit(seth.start_continuous_changes_tracking, termination_doc_id=None)] = "continuous"
-        futures[executor.submit(doc_pusher.add_docs, num_docs)] = "docs_push"
-        time.sleep(5)
-        futures[executor.submit(admin.take_db_offline, "db")] = "db_offline_task"
-
-        for future in concurrent.futures.as_completed(futures):
-            task_name = futures[future]
-
-            if task_name == "db_offline_task":
-                log_info("DB OFFLINE")
-                # make sure db_offline returns 200
-                assert future.result() == 200
-            elif task_name == "docs_push":
-                log_info("DONE PUSHING DOCS")
-                doc_add_errors = future.result()
-            elif task_name == "continuous":
-                docs_in_changes = future.result()
-                log_info("DOCS FROM CHANGES")
-                for k, v in docs_in_changes.items():
-                    log_info("DFC -> {}:{}".format(k, v))
-
-    log_info("Number of docs from _changes ({})".format(len(docs_in_changes)))
-    log_info("Number of docs add errors ({})".format(len(doc_add_errors)))
-
-    # Some docs should have made it to _changes
-    assert len(docs_in_changes) > 0
-
-    # Bring db back online
-    status = admin.bring_db_online("db")
-    assert status == 200
-
-    # Get all docs that have been pushed
-    # Verify that changes returns all of them
-    all_docs = doc_pusher.get_all_docs()
-    num_docs_pushed = len(all_docs["rows"])
-    verify_changes(doc_pusher, expected_num_docs=num_docs_pushed, expected_num_revisions=0, expected_docs=doc_pusher.cache)
-
-    # Check that the number of errors return when trying to push while db is offline + num of docs in db
-    # should equal the number of docs
-    assert num_docs_pushed + len(doc_add_errors) == num_docs
-
-
-# Scenario 6 - longpoll
-@pytest.mark.sanity
-@pytest.mark.syncgateway
-@pytest.mark.onlineoffline
-@pytest.mark.changes
-@pytest.mark.basicauth
-@pytest.mark.parametrize("sg_conf_name, num_docs, num_users", [
-    ("bucket_online_offline/bucket_online_offline_default", 5000, 40)
-])
-def test_online_to_offline_continous_changes_feed_controlled_close_sanity_mulitple_users(params_from_base_test_setup, sg_conf_name, num_docs, num_users):
-
-    cluster_conf = params_from_base_test_setup["cluster_config"]
-    mode = params_from_base_test_setup["mode"]
-
-    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
-
-    log_info("Using cluster_conf: {}".format(cluster_conf))
-    log_info("Using sg_conf: {}".format(sg_conf))
-    log_info("Using num_docs: {}".format(num_docs))
-    log_info("Using num_users: {}".format(num_users))
-
-    cluster = Cluster(config=cluster_conf)
-    cluster.reset(sg_config_path=sg_conf)
-
-    admin = Admin(cluster.sync_gateways[0])
-    users = admin.register_bulk_users(target=cluster.sync_gateways[0], db="db", name_prefix="user", password="password", number=num_users, channels=["ABC"])
-
-    feed_close_results = list()
-
-    with concurrent.futures.ThreadPoolExecutor(max_workers=libraries.testkit.settings.MAX_REQUEST_WORKERS) as executor:
-        # start continuous tracking with no timeout, will block until connection is closed by db going offline
-        futures = {executor.submit(user.start_continuous_changes_tracking, termination_doc_id=None): user.name for user in users}
-
-        time.sleep(5)
-        futures[executor.submit(admin.take_db_offline, "db")] = "db_offline_task"
-
-        for future in concurrent.futures.as_completed(futures):
-            task_name = futures[future]
-
-            if task_name == "db_offline_task":
-                log_info("DB OFFLINE")
-                # make sure db_offline returns 200
-                assert future.result() == 200
-            if task_name.startswith("user"):
-                # Long poll will exit with 503, return docs in the exception
-                log_info("POLLING DONE")
-                try:
-                    docs = future.result()
-                    feed_close_results.append(docs)
-                except Exception as e:
-                    log_info("Continious feed close error: {}".format(e))
-                    # continuous should be closed so this exception should never happen
-                    assert 0
-
-    # Assert that the feed close results length is num_users
-    assert len(feed_close_results) == num_users
-
-    # No docs should be returned
-    for feed_result in feed_close_results:
-        assert len(feed_result) == 0
-
-
-# Scenario 6 - longpoll
-@pytest.mark.sanity
-@pytest.mark.syncgateway
-@pytest.mark.onlineoffline
-@pytest.mark.changes
-@pytest.mark.basicauth
-@pytest.mark.parametrize("sg_conf_name, num_docs", [
-    ("bucket_online_offline/bucket_online_offline_default", 5000)
-])
-def test_online_to_offline_changes_feed_controlled_close_longpoll_sanity(params_from_base_test_setup, sg_conf_name, num_docs):
-
-    cluster_conf = params_from_base_test_setup["cluster_config"]
-    mode = params_from_base_test_setup["mode"]
-
-    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
-
-    log_info("Using cluster_conf: {}".format(cluster_conf))
-    log_info("Using sg_conf: {}".format(sg_conf))
-    log_info("Using num_docs: {}".format(num_docs))
-
-    cluster = Cluster(config=cluster_conf)
-    cluster.reset(sg_config_path=sg_conf)
-
-    admin = Admin(cluster.sync_gateways[0])
-    seth = admin.register_user(target=cluster.sync_gateways[0], db="db", name="seth", password="password", channels=["ABC"])
-
-    docs_in_changes = dict()
-
-    with concurrent.futures.ThreadPoolExecutor(max_workers=libraries.testkit.settings.MAX_REQUEST_WORKERS) as executor:
-        futures = dict()
-        # start longpoll tracking with no timeout, will block until longpoll is closed by db going offline
-        futures[executor.submit(seth.start_longpoll_changes_tracking, termination_doc_id=None, timeout=0, loop=False)] = "polling"
-        time.sleep(5)
-        futures[executor.submit(admin.take_db_offline, "db")] = "db_offline_task"
-
-        for future in concurrent.futures.as_completed(futures):
-            task_name = futures[future]
-
-            if task_name == "db_offline_task":
-                log_info("DB OFFLINE")
-                # make sure db_offline returns 200
-                assert future.result() == 200
-            if task_name == "polling":
-                # Long poll will exit with 503, return docs in the exception
-                log_info("POLLING DONE")
-                try:
-                    docs_in_changes, last_seq_num = future.result()
-                except Exception as e:
-                    log_info("Longpoll feed close error: {}".format(e))
-                    # long poll should be closed so this exception should never happen
-                    assert 0
-
-    # Account for _user doc
-    # last_seq may be of the form '1' for channel cache or '1-0' for distributed index
-    seq_num_component = last_seq_num.split("-")
-    assert 1 == int(seq_num_component[0])
-    assert len(docs_in_changes) == 0
-
-
-# Scenario 6 - longpoll
-@pytest.mark.sanity
-@pytest.mark.syncgateway
-@pytest.mark.onlineoffline
-@pytest.mark.changes
-@pytest.mark.basicauth
-@pytest.mark.parametrize("sg_conf_name, num_docs, num_users", [
-    ("bucket_online_offline/bucket_online_offline_default", 5000, 40)
-])
-def test_online_to_offline_longpoll_changes_feed_controlled_close_sanity_mulitple_users(params_from_base_test_setup, sg_conf_name, num_docs, num_users):
-
-    cluster_conf = params_from_base_test_setup["cluster_config"]
-    mode = params_from_base_test_setup["mode"]
-
-    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
-
-    log_info("Using cluster_conf: {}".format(cluster_conf))
-    log_info("Using sg_conf: {}".format(sg_conf))
-    log_info("Using num_docs: {}".format(num_docs))
-    log_info("Using num_users: {}".format(num_users))
-
-    cluster = Cluster(config=cluster_conf)
-    cluster.reset(sg_config_path=sg_conf)
-
-    admin = Admin(cluster.sync_gateways[0])
-    users = admin.register_bulk_users(target=cluster.sync_gateways[0], db="db", name_prefix="user", password="password", number=num_users, channels=["ABC"])
-
-    feed_close_results = list()
-
-    with concurrent.futures.ThreadPoolExecutor(max_workers=libraries.testkit.settings.MAX_REQUEST_WORKERS) as executor:
-        # start longpoll tracking with no timeout, will block until longpoll is closed by db going offline
-        futures = {executor.submit(user.start_longpoll_changes_tracking, termination_doc_id=None, timeout=0, loop=False): user.name for user in users}
-
-        time.sleep(5)
-        futures[executor.submit(admin.take_db_offline, "db")] = "db_offline_task"
-
-        for future in concurrent.futures.as_completed(futures):
-            task_name = futures[future]
-
-            if task_name == "db_offline_task":
-                log_info("DB OFFLINE")
-                # make sure db_offline returns 200
-                assert future.result() == 200
-            if task_name.startswith("user"):
-                # Long poll will exit with 503, return docs in the exception
-                log_info("POLLING DONE")
-                try:
-                    docs_in_changes, last_seq_num = future.result()
-                    feed_close_results.append((docs_in_changes, last_seq_num))
-                except Exception as e:
-                    log_info("Longpoll feed close error: {}".format(e))
-                    # long poll should be closed so this exception should never happen
-                    assert 0
-
-    # Assert that the feed close results length is num_users
-    assert len(feed_close_results) == num_users
-
-    # Account for _user doc
-    # last_seq may be of the form '1' for channel cache or '1-0' for distributed index
-    for feed_result in feed_close_results:
-        docs_in_changes = feed_result[0]
-        seq_num_component = feed_result[1].split("-")
-        assert len(docs_in_changes) == 0
-        assert int(seq_num_component[0]) > 0
-
-
-# Scenario 6 - longpoll
-# NOTE: Was disabled for di
-@pytest.mark.sanity
-@pytest.mark.syncgateway
-@pytest.mark.onlineoffline
-@pytest.mark.changes
-@pytest.mark.basicauth
-@pytest.mark.parametrize("sg_conf_name, num_docs", [
-    ("bucket_online_offline/bucket_online_offline_default", 5000)
-])
-def test_online_to_offline_changes_feed_controlled_close_longpoll(params_from_base_test_setup, sg_conf_name, num_docs):
-
-    cluster_conf = params_from_base_test_setup["cluster_config"]
-    mode = params_from_base_test_setup["mode"]
-
-    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
-
-    log_info("Using cluster_conf: {}".format(cluster_conf))
-    log_info("Using sg_conf: {}".format(sg_conf))
-    log_info("Using num_docs: {}".format(num_docs))
-
-    cluster = Cluster(config=cluster_conf)
-    cluster.reset(sg_config_path=sg_conf)
-
-    admin = Admin(cluster.sync_gateways[0])
-    seth = admin.register_user(target=cluster.sync_gateways[0], db="db", name="seth", password="password", channels=["ABC"])
-    doc_pusher = admin.register_user(target=cluster.sync_gateways[0], db="db", name="doc_pusher", password="password", channels=["ABC"])
-
-    docs_in_changes = dict()
-    doc_add_errors = list()
-
-    with concurrent.futures.ThreadPoolExecutor(max_workers=libraries.testkit.settings.MAX_REQUEST_WORKERS) as executor:
-        futures = dict()
-        futures[executor.submit(seth.start_longpoll_changes_tracking, termination_doc_id=None)] = "polling"
-        futures[executor.submit(doc_pusher.add_docs, num_docs)] = "docs_push"
-        time.sleep(5)
-        futures[executor.submit(admin.take_db_offline, "db")] = "db_offline_task"
-
-        for future in concurrent.futures.as_completed(futures):
-            task_name = futures[future]
-
-            if task_name == "db_offline_task":
-                log_info("DB OFFLINE")
-                # make sure db_offline returns 200
-                assert future.result() == 200
-            if task_name == "docs_push":
-                log_info("DONE PUSHING DOCS")
-                doc_add_errors = future.result()
-            if task_name == "polling":
-                # Long poll will exit with 503, return docs in the exception
-                log_info("POLLING DONE")
-                try:
-                    docs_in_changes = future.result()
-                except Exception as e:
-                    log_info(e)
-                    log_info("POLLING DONE EXCEPTION")
-                    log_info("ARGS: {}".format(e.args))
-                    docs_in_changes = e.args[0]["docs"]
-                    last_seq_num = e.args[0]["last_seq_num"]
-                    log_info("DOCS FROM longpoll")
-                    for k, v in docs_in_changes.items():
-                        log_info("DFC -> {}:{}".format(k, v))
-                    log_info("LAST_SEQ_NUM FROM longpoll {}".format(last_seq_num))
-
-    log_info("Number of docs from _changes ({})".format(len(docs_in_changes)))
-    log_info("last_seq_num _changes ({})".format(last_seq_num))
-    log_info("Number of docs add errors ({})".format(len(doc_add_errors)))
-
-    # Some docs should have made it to _changes
-    assert len(docs_in_changes) > 0
-
-    # Make sure some docs failed due to db being taken offline
-    assert len(doc_add_errors) > 0
-
-    seq_num_component = last_seq_num.split("-")
-    if mode == "cc":
-        # assert the last_seq_number == number _changes + 2 (_user doc starts and one and docs start at _user doc seq + 2)
-        assert len(docs_in_changes) + 2 == int(seq_num_component[0])
-    else:
-        # assert the value is not an empty string
-        assert last_seq_num != ""
-
-    # Bring db back online
-    status = admin.bring_db_online("db")
-    assert status == 200
-    #
-    # Get all docs that have been pushed
-    # Verify that changes returns all of them
-    all_docs = doc_pusher.get_all_docs()
-    num_docs_pushed = len(all_docs["rows"])
-    verify_changes(doc_pusher, expected_num_docs=num_docs_pushed, expected_num_revisions=0, expected_docs=doc_pusher.cache)
-
-    # Check that the number of errors return when trying to push while db is offline + num of docs in db
-    # should equal the number of docs
-    assert num_docs_pushed + len(doc_add_errors) == num_docs
-
-
-# Scenario 6
-# NOTE: Was disabled for di
-@pytest.mark.sanity
-@pytest.mark.syncgateway
-@pytest.mark.onlineoffline
-@pytest.mark.basicauth
-@pytest.mark.role
-@pytest.mark.channel
-@pytest.mark.bulkops
-@pytest.mark.changes
-@pytest.mark.parametrize("sg_conf_name, num_docs", [
-    ("bucket_online_offline/bucket_online_offline_offline_true", 100)
-])
-def test_offline_true_config_bring_online(params_from_base_test_setup, sg_conf_name, num_docs):
-
-    cluster_conf = params_from_base_test_setup["cluster_config"]
-    mode = params_from_base_test_setup["mode"]
-
-    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
-
-    log_info("Using cluster_conf: {}".format(cluster_conf))
-    log_info("Using sg_conf: {}".format(sg_conf))
-    log_info("Using num_docs: {}".format(num_docs))
-
-    cluster = Cluster(config=cluster_conf)
-    cluster.reset(sg_config_path=sg_conf)
-
-    admin = Admin(cluster.sync_gateways[0])
-
-    # all db endpoints should fail with 503
-    errors = rest_scan(cluster.sync_gateways[0], db="db", online=False, num_docs=num_docs, user_name="seth", channels=["ABC"])
-
-    assert len(errors) == NUM_ENDPOINTS + (num_docs * 2)
-    for error_tuple in errors:
-        log_info("({},{})".format(error_tuple[0], error_tuple[1]))
-        assert error_tuple[1] == 503
-
-    # Scenario 9
-    # POST /db/_online
-    status = admin.bring_db_online(db="db")
-    assert status == 200
-
-    # all db endpoints should succeed
-    errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
-    assert len(errors) == 0
-
-
-# Scenario 14
-@pytest.mark.sanity
-@pytest.mark.syncgateway
-@pytest.mark.onlineoffline
-@pytest.mark.basicauth
-@pytest.mark.role
-@pytest.mark.channel
-@pytest.mark.bulkops
-@pytest.mark.changes
-@pytest.mark.parametrize("sg_conf_name, num_docs", [
-    ("bucket_online_offline/bucket_online_offline_default_dcp", 100),
-    ("bucket_online_offline/bucket_online_offline_default", 100)
-])
-def test_db_offline_tap_loss_sanity(params_from_base_test_setup, sg_conf_name, num_docs):
-
-    cluster_conf = params_from_base_test_setup["cluster_config"]
-    mode = params_from_base_test_setup["mode"]
-
-    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
-
-    log_info("Using cluster_conf: {}".format(cluster_conf))
-    log_info("Using sg_conf: {}".format(sg_conf))
-    log_info("Using num_docs: {}".format(num_docs))
-
-    cluster = Cluster(config=cluster_conf)
-    cluster.reset(sg_config_path=sg_conf)
-
-    # all db rest enpoints should succeed
-    errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
-    assert len(errors) == 0
-
-    # Delete bucket to sever TAP feed
-    cluster.servers[0].delete_bucket("data-bucket")
-
-    # Check that bucket is in offline state
-    errors = rest_scan(cluster.sync_gateways[0], db="db", online=False, num_docs=num_docs, user_name="seth", channels=["ABC"])
-    assert len(errors) == NUM_ENDPOINTS + (num_docs * 2)
-    for error_tuple in errors:
-        log_info("({},{})".format(error_tuple[0], error_tuple[1]))
-        assert error_tuple[1] == 503
-
-
-# Scenario 11
-# NOTE: Was disabled for di
-@pytest.mark.sanity
-@pytest.mark.syncgateway
-@pytest.mark.onlineoffline
-@pytest.mark.basicauth
-@pytest.mark.role
-@pytest.mark.channel
-@pytest.mark.bulkops
-@pytest.mark.changes
-@pytest.mark.parametrize("sg_conf_name, num_docs", [
-    ("bucket_online_offline/bucket_online_offline_default", 100)
-])
-def test_db_delayed_online(params_from_base_test_setup, sg_conf_name, num_docs):
-
-    cluster_conf = params_from_base_test_setup["cluster_config"]
-    mode = params_from_base_test_setup["mode"]
-
-    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
-
-    log_info("Using cluster_conf: {}".format(cluster_conf))
-    log_info("Using sg_conf: {}".format(sg_conf))
-    log_info("Using num_docs: {}".format(num_docs))
-
-    cluster = Cluster(config=cluster_conf)
-    cluster.reset(sg_config_path=sg_conf)
-
-    admin = Admin(cluster.sync_gateways[0])
-
-    time.sleep(2)
-    status = admin.take_db_offline("db")
-    log_info("offline request response status: {}".format(status))
-    time.sleep(10)
-
-    pool = ThreadPool(processes=1)
-
-    db_info = admin.get_db_info("db")
-    assert db_info["state"] == "Offline"
-
-    async_result = pool.apply_async(admin.bring_db_online, ("db", 15,))
-    status = async_result.get(timeout=15)
-    log_info("offline request response status: {}".format(status))
-
-    time.sleep(20)
-
-    db_info = admin.get_db_info("db")
-    assert db_info["state"] == "Online"
-
-    # all db rest enpoints should succeed
-    errors = rest_scan(cluster.sync_gateways[0], db="db", online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
-    assert len(errors) == 0
-
-
-@pytest.mark.sanity
-@pytest.mark.syncgateway
-@pytest.mark.onlineoffline
-@pytest.mark.basicauth
-@pytest.mark.role
-@pytest.mark.channel
-@pytest.mark.bulkops
-@pytest.mark.changes
-@pytest.mark.parametrize("sg_conf_name, num_docs", [
-    ("bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets", 100)
-])
-def test_multiple_dbs_unique_buckets_lose_tap(params_from_base_test_setup, sg_conf_name, num_docs):
-
-    cluster_conf = params_from_base_test_setup["cluster_config"]
-    mode = params_from_base_test_setup["mode"]
-
-    sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
-
-    log_info("Using cluster_conf: {}".format(cluster_conf))
-    log_info("Using sg_conf: {}".format(sg_conf))
-    log_info("Using num_docs: {}".format(num_docs))
-
-    cluster = Cluster(config=cluster_conf)
-    cluster.reset(sg_config_path=sg_conf)
-
-    dbs = ["db1", "db2", "db3", "db4"]
-
-    # all db rest endpoints should succeed
-    for db in dbs:
-        log_info("Doing rest scan on db: {}".format(db))
-        errors = rest_scan(cluster.sync_gateways[0], db=db, online=True, num_docs=num_docs, user_name="seth", channels=["ABC"])
-        assert len(errors) == 0
-
-    log_info("Deleting data-bucket-1 and data-bucket-3")
-    cluster.servers[0].delete_bucket("data-bucket-1")
-    cluster.servers[0].delete_bucket("data-bucket-3")
-
-    # Check that db2 and db4 are still Online
-    log_info("Check that db2 and db4 are still Online")
-    for db in ["db2", "db4"]:
-        errors = rest_scan(cluster.sync_gateways[0], db=db, online=True, num_docs=num_docs, user_name="adam", channels=["CBS"])
-        assert len(errors) == 0
-
-    # Check that db1 and db3 go offline
-    log_info("Check that db1 and db3 go offline")
-    for db in ["db1", "db3"]:
-        errors = rest_scan(cluster.sync_gateways[0], db=db, online=False, num_docs=num_docs, user_name="seth", channels=["ABC"])
-        num_expected_errors = NUM_ENDPOINTS + (num_docs * 2)
-        if len(errors) != num_expected_errors:
-            log_info("Expected {} errors, but got {}".format(num_expected_errors, len(errors)))
-            for err in errors:
-                log_info("{}".format(err))
-        assert len(errors) == num_expected_errors
-        for error_tuple in errors:
-            log_info("({},{})".format(error_tuple[0], error_tuple[1]))
-            assert error_tuple[1] == 503
 
 
 # Reenable for 1.3

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline_webhooks.py
@@ -26,6 +26,9 @@ def test_webhooks(params_from_base_test_setup, sg_conf_name, num_users, num_chan
     cluster_conf = params_from_base_test_setup["cluster_config"]
     mode = params_from_base_test_setup["mode"]
 
+    if mode == "di":
+        pytest.skip("Offline tests not supported in Di mode -- see https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-300841425")
+
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
 
     log_info("Running 'test_webhooks'")
@@ -84,6 +87,9 @@ def test_db_online_offline_webhooks_offline(params_from_base_test_setup, sg_conf
 
     cluster_conf = params_from_base_test_setup["cluster_config"]
     mode = params_from_base_test_setup["mode"]
+
+    if mode == "di":
+        pytest.skip("Offline tests not supported in Di mode -- see https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-300841425")
 
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
 
@@ -163,6 +169,9 @@ def test_db_online_offline_webhooks_offline_two(params_from_base_test_setup, sg_
 
     cluster_conf = params_from_base_test_setup["cluster_config"]
     mode = params_from_base_test_setup["mode"]
+
+    if mode == "di":
+        pytest.skip("Offline tests not supported in Di mode -- see https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-300841425")
 
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
 


### PR DESCRIPTION
see https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-300841425

#### Fixes https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-300841425.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Skip offline tests in DI mode
- I moved the `rest_scan` function to the bottom of the file since it was confusing to see it at the top... when I was expecting to see actual test cases.

