### PR TITLE
Add support for provisioning 4.6.2

### DIFF
--- a/libraries/provision/install_couchbase_server.py
+++ b/libraries/provision/install_couchbase_server.py
@@ -65,6 +65,7 @@ def resolve_cb_mobile_url(version):
 
     """
     released_versions = {
+        "4.6.2": "3905",
         "4.6.1": "3652",
         "4.6.0": "3573",
         "4.5.1": "2844",


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Allow provisioning 4.6.2 with `--server-version=4.6.2`

