### PR TITLE
Add 1.5.0 to valid versions

### DIFF
--- a/libraries/provision/install_sync_gateway.py
+++ b/libraries/provision/install_sync_gateway.py
@@ -40,7 +40,8 @@ class SyncGatewayConfig:
             "1.4.0.1",
             "1.4.0.2",
             "1.4.1",
-            "1.4.2"
+            "1.4.2",
+            "1.5.0"
         ]
 
         self.commit = commit


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Allow provisioning of 1.5.0 SG builds

