### PR TITLE
Increase REMOTE_EXECUTOR_TIMEOUT to fix log rotation test failures

### DIFF
--- a/keywords/constants.py
+++ b/keywords/constants.py
@@ -12,7 +12,7 @@ MAX_RETRIES = 5
 
 CLIENT_REQUEST_TIMEOUT = 120
 REBALANCE_TIMEOUT_SECS = 600
-REMOTE_EXECUTOR_TIMEOUT = 60
+REMOTE_EXECUTOR_TIMEOUT = 180
 
 # Required to make sure that these are created with encryption
 # Use to build the command line flags for encryption


### PR DESCRIPTION
Cherry pick https://github.com/couchbaselabs/mobile-testkit/pull/1198/commits/99301f4cc5d2aa900b48b84cf05705407479674d

#### Fixes #.

- [ ] Ran `flake8`
- [ ] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- 
-

