### PR TITLE
Skip noisy intermittent failure

### DIFF
--- a/testsuites/syncgateway/functional/tests/test_log_rotation.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation.py
@@ -336,6 +336,7 @@ def test_log_rotation_invalid_path(params_from_base_test_setup, sg_conf_name):
 @pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.skip(reason="This causes paramiko to timeout intermittently. Need to revisit.")
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation"])
 def test_log_200mb(params_from_base_test_setup, sg_conf_name):
     """Test to check maxsize with value 200MB( 100Mb by default)


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Disable intermittent test failure until we have time to investigate how to fix our test framework to work around. Tracking ticket to make sure we run for release - https://github.com/couchbaselabs/mobile-testkit/issues/1222

