### PR TITLE
Add product information verification

### DIFF
--- a/keywords/ClusterKeywords.py
+++ b/keywords/ClusterKeywords.py
@@ -8,9 +8,11 @@ from keywords import couchbaseserver
 from keywords.constants import CLUSTER_CONFIGS_DIR
 from keywords.exceptions import ProvisioningError
 from keywords.SyncGateway import (verify_sg_accel_version,
-                                  verify_sync_gateway_version)
+                                  verify_sync_gateway_version,
+                                  verify_sg_accel_product_info,
+                                  verify_sync_gateway_product_info)
 from keywords.utils import (log_info, log_r, version_and_build,
-                            version_is_binary)
+                            version_is_binary, compare_versions)
 from libraries.testkit.cluster import Cluster
 
 
@@ -146,10 +148,14 @@ class ClusterKeywords:
 
         # Verify sync_gateway versions
         for sg in cluster_obj["sync_gateways"]:
+            verify_sync_gateway_product_info(sg["ip"])
             verify_sync_gateway_version(sg["ip"], expected_sync_gateway_version)
 
         # Verify sg_accel versions, use the same expected version for sync_gateway for now
         for ac in cluster_obj["sg_accels"]:
+            if compare_versions(expected_sync_gateway_version, "1.5.0") >= 0:
+                # Only verify the correct product naming after 1.5 since it was fixed in 1.5
+                verify_sg_accel_product_info(ac["ip"])
             verify_sg_accel_version(ac["ip"], expected_sync_gateway_version)
 
     def reset_cluster(self, cluster_config, sync_gateway_config):

--- a/keywords/SyncGateway.py
+++ b/keywords/SyncGateway.py
@@ -66,6 +66,28 @@ def get_sync_gateway_version(host):
     return running_version_formatted, running_vendor_version
 
 
+def verify_sync_gateway_product_info(host):
+    """ Get the product information from host and verify for Sync Gateway:
+    - vendor name in GET / request
+    - Server header in response
+    """
+
+    resp = requests.get("http://{}:4984".format(host))
+    log_r(resp)
+    resp.raise_for_status()
+    resp_obj = resp.json()
+
+    server_header = resp.headers["server"]
+    log_info("'server' header: {}".format(server_header))
+    if not server_header.startswith("Couchbase Sync Gateway"):
+        raise ProvisioningError("Wrong product info. Expected 'Couchbase Sync Gateway'")
+
+    vendor_name = resp_obj["vendor"]["name"]
+    log_info("vendor name: {}".format(vendor_name))
+    if vendor_name != "Couchbase Sync Gateway":
+        raise ProvisioningError("Wrong vendor name. Expected 'Couchbase Sync Gateway'")
+
+
 def verify_sync_gateway_version(host, expected_sync_gateway_version):
     running_sg_version, running_sg_vendor_version = get_sync_gateway_version(host)
 
@@ -102,6 +124,28 @@ def get_sg_accel_version(host):
 
     # Returns the version as 338493 commit format or 1.2.1-4 version format
     return running_version_formatted
+
+
+def verify_sg_accel_product_info(host):
+    """ Get the product information from host and verify for SG Accel:
+    - vendor name in GET / request
+    - Server header in response
+    """
+
+    resp = requests.get("http://{}:4985".format(host))
+    log_r(resp)
+    resp.raise_for_status()
+    resp_obj = resp.json()
+
+    server_header = resp.headers["server"]
+    log_info("'server' header: {}".format(server_header))
+    if not server_header.startswith("Couchbase SG Accel"):
+        raise ProvisioningError("Wrong product info. Expected 'Couchbase SG Accel'")
+
+    vendor_name = resp_obj["vendor"]["name"]
+    log_info("vendor name: {}".format(vendor_name))
+    if vendor_name != "Couchbase SG Accel":
+        raise ProvisioningError("Wrong vendor name. Expected 'Couchbase SG Accel'")
 
 
 def verify_sg_accel_version(host, expected_sg_accel_version):


### PR DESCRIPTION
#### Fixes #1160.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- If we are running SG 1.5+, verify the product naming for SG / SG Accel

