### PR TITLE
CRUD webhook tests with and without filtering (docmeta / xattrs)

### DIFF
--- a/libraries/testkit/web_server.py
+++ b/libraries/testkit/web_server.py
@@ -1,11 +1,9 @@
-from BaseHTTPServer import BaseHTTPRequestHandler
-import time
 import json
-from BaseHTTPServer import HTTPServer
 import threading
-from libraries.testkit import settings
-import logging
-log = logging.getLogger(settings.LOGGER)
+import time
+from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+
+from keywords.utils import log_info
 
 
 class HttpHandler(BaseHTTPRequestHandler):
@@ -13,7 +11,7 @@ class HttpHandler(BaseHTTPRequestHandler):
     server_recieved_data = []
 
     def do_GET(self):
-        log.info('Received GET request')
+        log_info('Received GET request')
         self.send_response(200)
         self.send_header('Last-Modified', self.date_time_string(time.time()))
         self.end_headers()
@@ -21,13 +19,13 @@ class HttpHandler(BaseHTTPRequestHandler):
         return
 
     def do_POST(self):
-        log.info('Received POST request')
+        log_info('Received POST request')
         content_len = int(self.headers.getheader('content-length', 0))
         post_body = self.rfile.read(content_len)
         data = json.loads(post_body)
         HttpHandler.server_recieved_data.append(data)
-        log.info("Received {} data in Post request".format(data))
-        log.info("Appended POST data payload to server_received_data")
+        log_info("Received {} data in Post request".format(data))
+        log_info("Appended POST data payload to server_received_data")
         self.send_response(200)
         self.send_header("Content-type", "text/html")
         self.end_headers()
@@ -40,6 +38,7 @@ class WebServer(object):
         self.server = HTTPServer(('', port), HttpHandler)
 
     def start(self):
+        log_info('Starting webserver on port :8080 ...')
         thread = threading.Thread(target=self.server.serve_forever)
         thread.daemon = True
         try:
@@ -48,8 +47,11 @@ class WebServer(object):
             raise ValueError("Caught exception could not launch webserver thread", e)
 
     def stop(self):
-        HttpHandler.server_recieved_data = []
+        self.clear_data()
         self.server.shutdown()
+
+    def clear_data(self):
+        HttpHandler.server_recieved_data = []
 
     def get_data(self):
         return HttpHandler.server_recieved_data

--- a/libraries/testkit/web_server.py
+++ b/libraries/testkit/web_server.py
@@ -19,13 +19,10 @@ class HttpHandler(BaseHTTPRequestHandler):
         return
 
     def do_POST(self):
-        log_info('Received POST request')
         content_len = int(self.headers.getheader('content-length', 0))
         post_body = self.rfile.read(content_len)
         data = json.loads(post_body)
         HttpHandler.server_recieved_data.append(data)
-        log_info("Received {} data in Post request".format(data))
-        log_info("Appended POST data payload to server_received_data")
         self.send_response(200)
         self.send_header("Content-type", "text/html")
         self.end_headers()

--- a/libraries/testkit/web_server.py
+++ b/libraries/testkit/web_server.py
@@ -22,6 +22,7 @@ class HttpHandler(BaseHTTPRequestHandler):
         content_len = int(self.headers.getheader('content-length', 0))
         post_body = self.rfile.read(content_len)
         data = json.loads(post_body)
+        log_info("Webhook doc received: {}".format(data["_id"]))
         HttpHandler.server_recieved_data.append(data)
         self.send_response(200)
         self.send_header("Content-type", "text/html")

--- a/mobile_testkit_tests/test_get_buckets_from_sync_gateway_config.py
+++ b/mobile_testkit_tests/test_get_buckets_from_sync_gateway_config.py
@@ -47,8 +47,8 @@ from libraries.provision.install_sync_gateway import get_buckets_from_sync_gatew
     ("sync_gateway_sg_replicate_continuous_di.json", ['index-bucket-2', 'data-bucket-1', 'index-bucket-1', 'data-bucket', 'data-bucket-2']),
     ("sync_gateway_sg_replicate_di.json", ['index-bucket-2', 'data-bucket-1', 'index-bucket-1', 'data-bucket', 'data-bucket-2']),
     ("sync_gateway_todolite.json", ['data-bucket', 'cbgt-bucket', 'index-bucket']),
-    ("sync_gateway_webhook_cc.json", ['data-bucket']),
-    ("sync_gateway_webhook_di.json", ['data-bucket', 'index-bucket']),
+    ("webhooks/webhook_offline_cc.json", ['data-bucket']),
+    ("webhooks/webhook_offline_di.json", ['data-bucket', 'index-bucket']),
     ("testfest_todo_di.json", ['data-bucket', 'index-bucket']),
     ("todolite.json", ['data-bucket']),
 ])

--- a/resources/sync_gateway_configs/webhooks/webhook_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_cc.json
@@ -1,0 +1,27 @@
+{
+    "interface":":4984",
+    "adminInterface": "0.0.0.0:4985",
+    "log": ["CRUD+", "Cache+", "HTTP+", "Changes+", "Events+"],
+    "databases":{
+        "db":{
+            {{ autoimport }}
+            "unsupported": {
+                {{ xattrs }}
+            },
+            "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
+            "bucket":"data-bucket",
+            "username":"data-bucket",
+            "password": "password",
+            "event_handlers": {
+               "document_changed":[{
+                    "handler": "webhook",
+                    "url": "http://{{ webhook_ip }}:8080"
+                }],
+               "db_state_changed":[{
+                   "handler":"webhook",
+                   "url":"http://{{ webhook_ip }}:8080"
+                }]
+            }
+        }
+    }
+}

--- a/resources/sync_gateway_configs/webhooks/webhook_di.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_di.json
@@ -21,11 +21,11 @@
             "event_handlers": {
                "document_changed":[{
                     "handler": "webhook",
-                    "url": "http://{{ webhook_ip }}:8080",
+                    "url": "http://{{ webhook_ip }}:8080"
                 }],
                "db_state_changed":[{
                    "handler":"webhook",
-                   "url":"http://{{ webhook_ip }}:8080",
+                   "url":"http://{{ webhook_ip }}:8080"
                 }]
             },
             "channel_index":{

--- a/resources/sync_gateway_configs/webhooks/webhook_di.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_di.json
@@ -1,13 +1,7 @@
 {
     "interface":":4984",
     "adminInterface": "0.0.0.0:4985",
-    "maxIncomingConnections": 0,
-    "maxCouchbaseConnections": 16,
-    "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
-    "compressResponses": false,
     "log": ["CRUD+", "Cache+", "HTTP+", "Changes+"],
-    "verbose":"true",
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",
@@ -20,22 +14,21 @@
             "unsupported": {
                 {{ xattrs }}
             },
-            "feed_type":"DCPSHARD",
-            "offline":false,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",
             "password": "password",
-            "sync": `function(doc){
-                  channel(doc.channels);
-                }`,
-            "users": {"GUEST": {"disabled": false, "admin_channels": ["*"] }},
             "event_handlers": {
-               "document_changed":[{"handler":"webhook","max_processes" : 500,"wait_for_process" : "600000","url":"http://{{ webhook_ip }}:8080","timeout":60}],
-               "db_state_changed":[{"handler":"webhook","max_processes" : 500,"wait_for_process" : "600000","url":"http://{{ webhook_ip }}:8080","timeout":60}]
+               "document_changed":[{
+                    "handler": "webhook",
+                    "url": "http://{{ webhook_ip }}:8080",
+                }],
+               "db_state_changed":[{
+                   "handler":"webhook",
+                   "url":"http://{{ webhook_ip }}:8080",
+                }]
             },
             "channel_index":{
-                "num_shards":16,
                 "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
                 "bucket":"index-bucket",
                 "username":"index-bucket",

--- a/resources/sync_gateway_configs/webhooks/webhook_filter_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_filter_cc.json
@@ -1,0 +1,33 @@
+{
+    "interface":":4984",
+    "adminInterface": "0.0.0.0:4985",
+    "log": ["CRUD+", "Cache+", "HTTP+", "Changes+", "Events+"],
+    "databases":{
+        "db":{
+            {{ autoimport }}
+            "unsupported": {
+                {{ xattrs }}
+            },
+            "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
+            "bucket":"data-bucket",
+            "username":"data-bucket",
+            "password": "password",
+            "event_handlers": {
+               "document_changed":[{
+                    "handler": "webhook",
+                    "url": "http://{{ webhook_ip }}:8080",
+                    "filter": `function(doc) {
+                        if (doc.filtered || doc._deleted) {
+                            return true;
+                        }
+                        return false;
+                    }`
+                }],
+               "db_state_changed":[{
+                   "handler":"webhook",
+                   "url":"http://{{ webhook_ip }}:8080"
+                }]
+            }
+        }
+    }
+}

--- a/resources/sync_gateway_configs/webhooks/webhook_filter_di.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_filter_di.json
@@ -1,0 +1,46 @@
+{
+    "interface":":4984",
+    "adminInterface": "0.0.0.0:4985",
+    "log": ["CRUD+", "Cache+", "HTTP+", "Changes+"],
+    "cluster_config": {
+        "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
+        "data_dir":".",
+        "bucket":"data-bucket",
+        "username":"data-bucket",
+        "password": "password"
+    },
+    "databases":{
+        "db":{
+            "unsupported": {
+                {{ xattrs }}
+            },
+            "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
+            "bucket":"data-bucket",
+            "username":"data-bucket",
+            "password": "password",
+            "event_handlers": {
+               "document_changed":[{
+                    "handler": "webhook",
+                    "url": "http://{{ webhook_ip }}:8080",
+                    "filter": `function(doc) {
+                        if (doc.filtered || doc._deleted) {
+                            return true;
+                        }
+                        return false;
+                    }`
+                }],
+               "db_state_changed":[{
+                   "handler":"webhook",
+                   "url":"http://{{ webhook_ip }}:8080",
+                }]
+            },
+            "channel_index":{
+                "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
+                "bucket":"index-bucket",
+                "username":"index-bucket",
+                "password": "password",
+                "writer":{{ is_index_writer }}
+            }
+        }
+    }
+}

--- a/resources/sync_gateway_configs/webhooks/webhook_filter_di.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_filter_di.json
@@ -31,7 +31,7 @@
                 }],
                "db_state_changed":[{
                    "handler":"webhook",
-                   "url":"http://{{ webhook_ip }}:8080",
+                   "url":"http://{{ webhook_ip }}:8080"
                 }]
             },
             "channel_index":{

--- a/resources/sync_gateway_configs/webhooks/webhook_offline_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_offline_cc.json
@@ -24,8 +24,21 @@
                 }`,
             "users": {"GUEST": {"disabled": false, "admin_channels": ["*"] }},
             "event_handlers": {
-               "document_changed":[{"handler":"webhook","max_processes" : 500,"wait_for_process" : "600000","url":"http://{{ webhook_ip }}:8080","timeout":60}],
-               "db_state_changed":[{"handler":"webhook","max_processes" : 500,"wait_for_process" : "600000","url":"http://{{ webhook_ip }}:8080","timeout":60}] }
+               "document_changed":[{
+                    "handler": "webhook",
+                    "max_processes": 500,
+                    "wait_for_process": "600000",
+                    "url": "http://{{ webhook_ip }}:8080",
+                    "timeout": 60
+                }],
+               "db_state_changed":[{
+                   "handler":"webhook",
+                   "max_processes": 500,
+                   "wait_for_process": "600000",
+                   "url":"http://{{ webhook_ip }}:8080",
+                   "timeout":60
+                }]
+            }
         }
     }
 }

--- a/resources/sync_gateway_configs/webhooks/webhook_offline_di.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_offline_di.json
@@ -1,0 +1,59 @@
+{
+    "interface":":4984",
+    "adminInterface": "0.0.0.0:4985",
+    "maxIncomingConnections": 0,
+    "maxCouchbaseConnections": 16,
+    "maxFileDescriptors": 90000,
+    "slowServerCallWarningThreshold": 500,
+    "compressResponses": false,
+    "log": ["CRUD+", "Cache+", "HTTP+", "Changes+"],
+    "verbose":"true",
+    "cluster_config": {
+        "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
+        "data_dir":".",
+        "bucket":"data-bucket",
+        "username":"data-bucket",
+        "password": "password"
+    },
+    "databases":{
+        "db":{
+            "unsupported": {
+                {{ xattrs }}
+            },
+            "feed_type":"DCPSHARD",
+            "offline":false,
+            "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
+            "bucket":"data-bucket",
+            "username":"data-bucket",
+            "password": "password",
+            "sync": `function(doc){
+                  channel(doc.channels);
+                }`,
+            "users": {"GUEST": {"disabled": false, "admin_channels": ["*"] }},
+            "event_handlers": {
+               "document_changed":[{
+                   "handler": "webhook",
+                   "max_processes": 500,
+                   "wait_for_process": "600000",
+                   "url": "http://{{ webhook_ip }}:8080",
+                   "timeout": 60
+                }],
+                "db_state_changed":[{
+                    "handler": "webhook",
+                    "max_processes": 500,
+                    "wait_for_process": "600000",
+                    "url":"http://{{ webhook_ip }}:8080",
+                    "timeout":60
+                }]
+            },
+            "channel_index":{
+                "num_shards":16,
+                "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
+                "bucket":"index-bucket",
+                "username":"index-bucket",
+                "password": "password",
+                "writer":{{ is_index_writer }}
+            }
+        }
+    }
+}

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline_webhooks.py
@@ -16,7 +16,7 @@ from keywords.SyncGateway import sync_gateway_config_path_for_mode
 @pytest.mark.onlineoffline
 @pytest.mark.webhooks
 @pytest.mark.parametrize("sg_conf_name, num_users, num_channels, num_docs, num_revisions", [
-    ("sync_gateway_webhook", 5, 1, 1, 2),
+    ("webhooks/webhook_offline", 5, 1, 1, 2),
 ])
 def test_db_online_offline_webhooks_offline(params_from_base_test_setup, sg_conf_name, num_users, num_channels, num_docs, num_revisions):
 
@@ -98,7 +98,7 @@ def test_db_online_offline_webhooks_offline(params_from_base_test_setup, sg_conf
 @pytest.mark.onlineoffline
 @pytest.mark.webhooks
 @pytest.mark.parametrize("sg_conf_name, num_users, num_channels, num_docs, num_revisions", [
-    ("sync_gateway_webhook", 5, 1, 1, 2),
+    ("webhooks/webhook_offline", 5, 1, 1, 2),
 ])
 def test_db_online_offline_webhooks_offline_two(params_from_base_test_setup, sg_conf_name, num_users, num_channels, num_docs, num_revisions):
 


### PR DESCRIPTION
#### Fixes #1206 .

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Cleanup of webhook tests / configs
- Add test for full CRUD webhooks (docmeta / xattrs) with a filter and no filter

