### PR TITLE
Only reference _id if in the web hook data

### DIFF
--- a/libraries/testkit/web_server.py
+++ b/libraries/testkit/web_server.py
@@ -22,7 +22,10 @@ class HttpHandler(BaseHTTPRequestHandler):
         content_len = int(self.headers.getheader('content-length', 0))
         post_body = self.rfile.read(content_len)
         data = json.loads(post_body)
-        log_info("Webhook doc received: {}".format(data["_id"]))
+        if "_id" in data:
+            log_info("Webhook doc received: {}".format(data["_id"]))
+        else:
+            log_info("Webhook data received: {}".format(data))
         HttpHandler.server_recieved_data.append(data)
         self.send_response(200)
         self.send_header("Content-type", "text/html")


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Fixes an issue when database event webhooks did not include `_id` in the payload. This would cause the webserver to throw an exception and fail tests.

