### PR TITLE
Update timeout to get all changes

### DIFF
--- a/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
+++ b/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
@@ -109,7 +109,7 @@ def test_overloaded_channel_cache(params_from_base_test_setup, sg_conf_name, num
             end = time.time()
             time_for_users_to_get_all_changes = end - start
             log_info("Time for users to get all changes: {}".format(time_for_users_to_get_all_changes))
-            assert time_for_users_to_get_all_changes < 120, "Time to get all changes was greater than a minute: {}s".format(
+            assert time_for_users_to_get_all_changes < 240, "Time to get all changes was greater than 2 minutes: {}s".format(
                 time_for_users_to_get_all_changes
             )
 


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Getting the changes for all users exceed the timeout intermittently. Increase the timeout to avoid this. I ran a few benchmarks locally to ensure that this intermittent longer timeout is not indicative of a regression. The results locally using docker:

Time (s) to get all changes:
```
SG 1.3.1-16 w/ CBS 4.5.1 - 199.924277067
SG 1.4.1-3 w/ CBS 4.5.1  - 215.17805314064026
SG 1.5.0-424  w/ CBS 4.5.1 - 205.88099098205566
```
This appears to be environmental
