### PR TITLE
Update expiry tests for xattr mode.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,6 @@
     "python.linting.flake8Enabled": true,
     "python.linting.flake8Path": "${workspaceRoot}/venv/bin/flake8",
     "explorer.openEditors.visible": 0,
-    "files.autoSave": "on"
+    "files.autoSave": "onFocusChange",
+    "editor.renderWhitespace": "all"
 }

--- a/testsuites/syncgateway/functional/tests/test_ttl.py
+++ b/testsuites/syncgateway/functional/tests/test_ttl.py
@@ -113,7 +113,13 @@ def test_numeric_expiry_as_ttl(params_from_base_test_setup, sg_conf_name):
     # doc_exp_3 should be expired
     with pytest.raises(HTTPError) as he:
         client.get_doc(url=sg_url, db=sg_db, doc_id=doc_exp_3["id"], auth=sg_user_session)
-    assert he.value[0].startswith("404 Client Error: Not Found for url:")
+
+    # In XATTR mode, the expiry results in a tombstone
+    # In Doc Meta mode, the expiry results in a purge
+    if xattrs_enabled:
+        assert he.value[0].startswith("403 Client Error: Forbidden for url:")
+    else:
+        assert he.value[0].startswith("404 Client Error: Not Found for url:")
 
     verify_doc_deletion_on_server(
         doc_id=doc_exp_3["id"],
@@ -195,7 +201,13 @@ def test_string_expiry_as_ttl(params_from_base_test_setup, sg_conf_name):
     # doc_exp_3 should be expired
     with pytest.raises(HTTPError) as he:
         client.get_doc(url=sg_url, db=sg_db, doc_id=doc_exp_3["id"], auth=sg_user_session)
-    assert he.value[0].startswith("404 Client Error: Not Found for url:")
+
+    # In XATTR mode, the expiry results in a tombstone
+    # In Doc Meta mode, the expiry results in a purge
+    if xattrs_enabled:
+        assert he.value[0].startswith("403 Client Error: Forbidden for url:")
+    else:
+        assert he.value[0].startswith("404 Client Error: Not Found for url:")
 
     verify_doc_deletion_on_server(
         doc_id=doc_exp_3["id"],
@@ -281,7 +293,13 @@ def test_numeric_expiry_as_unix_date(params_from_base_test_setup, sg_conf_name):
     # doc_exp_3 should be expired
     with pytest.raises(HTTPError) as he:
         client.get_doc(url=sg_url, db=sg_db, doc_id=doc_exp_3["id"], auth=sg_user_session)
-    assert he.value[0].startswith("404 Client Error: Not Found for url:")
+
+    # In XATTR mode, the expiry results in a tombstone
+    # In Doc Meta mode, the expiry results in a purge
+    if xattrs_enabled:
+        assert he.value[0].startswith("403 Client Error: Forbidden for url:")
+    else:
+        assert he.value[0].startswith("404 Client Error: Not Found for url:")
 
     verify_doc_deletion_on_server(
         doc_id=doc_exp_3["id"],
@@ -371,7 +389,13 @@ def test_string_expiry_as_unix_date(params_from_base_test_setup, sg_conf_name):
     # doc_exp_3 should be expired
     with pytest.raises(HTTPError) as he:
         client.get_doc(url=sg_url, db=sg_db, doc_id=doc_exp_3["id"], auth=sg_user_session)
-    assert he.value[0].startswith("404 Client Error: Not Found for url:")
+
+    # In XATTR mode, the expiry results in a tombstone
+    # In Doc Meta mode, the expiry results in a purge
+    if xattrs_enabled:
+        assert he.value[0].startswith("403 Client Error: Forbidden for url:")
+    else:
+        assert he.value[0].startswith("404 Client Error: Not Found for url:")
 
     verify_doc_deletion_on_server(
         doc_id=doc_exp_3["id"],
@@ -457,7 +481,13 @@ def test_string_expiry_as_iso_8601_date(params_from_base_test_setup, sg_conf_nam
     # doc_exp_3 should be expired
     with pytest.raises(HTTPError) as he:
         client.get_doc(url=sg_url, db=sg_db, doc_id=doc_exp_3["id"], auth=sg_user_session)
-    assert he.value[0].startswith("404 Client Error: Not Found for url:")
+
+    # In XATTR mode, the expiry results in a tombstone
+    # In Doc Meta mode, the expiry results in a purge
+    if xattrs_enabled:
+        assert he.value[0].startswith("403 Client Error: Forbidden for url:")
+    else:
+        assert he.value[0].startswith("404 Client Error: Not Found for url:")
 
     verify_doc_deletion_on_server(
         doc_id=doc_exp_3["id"],
@@ -608,7 +638,13 @@ def test_rolling_ttl_expires(params_from_base_test_setup, sg_conf_name):
     # doc_exp_3 should be expired
     with pytest.raises(HTTPError) as he:
         client.get_doc(url=sg_url, db=sg_db, doc_id=doc_exp_3["id"], auth=sg_user_session)
-    assert he.value[0].startswith("404 Client Error: Not Found for url:")
+
+    # In XATTR mode, the expiry results in a tombstone
+    # In Doc Meta mode, the expiry results in a purge
+    if xattrs_enabled:
+        assert he.value[0].startswith("403 Client Error: Forbidden for url:")
+    else:
+        assert he.value[0].startswith("404 Client Error: Not Found for url:")
 
     verify_doc_deletion_on_server(
         doc_id=doc_exp_3["id"],
@@ -696,7 +732,13 @@ def test_rolling_ttl_remove_expirary(params_from_base_test_setup, sg_conf_name):
     # doc_exp_10 should be expired due to the updates (10s) + sleep (5s)
     with pytest.raises(HTTPError) as he:
         client.get_doc(url=sg_url, db=sg_db, doc_id=doc_exp_10["id"], auth=sg_user_session)
-    assert he.value[0].startswith("404 Client Error: Not Found for url:")
+
+    # In XATTR mode, the expiry results in a tombstone
+    # In Doc Meta mode, the expiry results in a purge
+    if xattrs_enabled:
+        assert he.value[0].startswith("403 Client Error: Forbidden for url:")
+    else:
+        assert he.value[0].startswith("404 Client Error: Not Found for url:")
 
     verify_doc_deletion_on_server(
         doc_id=doc_exp_10["id"],

--- a/testsuites/syncgateway/functional/tests/test_ttl.py
+++ b/testsuites/syncgateway/functional/tests/test_ttl.py
@@ -652,7 +652,8 @@ def test_rolling_ttl_expires(params_from_base_test_setup, sg_conf_name):
         sg_client=client,
         sg_admin_url=sg_url_admin,
         sg_db=sg_db,
-        xattrs_enabled=xattrs_enabled
+        xattrs_enabled=xattrs_enabled,
+        expected_rev=12
     )
 
     # doc_exp_10 should be available still
@@ -860,7 +861,7 @@ def test_setting_expiry_in_bulk_docs(params_from_base_test_setup, sg_conf_name):
 #    [Tags]  sanity  syncgateway  ttl
 #    [Documentation]
 
-def verify_doc_deletion_on_server(doc_id, sdk_client, sg_client, sg_admin_url, sg_db, xattrs_enabled=False):
+def verify_doc_deletion_on_server(doc_id, sdk_client, sg_client, sg_admin_url, sg_db, xattrs_enabled=False, expected_rev=2):
     # If xattrs, check that the doc is a tombstone
     # by getting the rev and "_deleted" prop via _raw
     # If sync gateway is using document meta data
@@ -871,7 +872,7 @@ def verify_doc_deletion_on_server(doc_id, sdk_client, sg_client, sg_admin_url, s
             db=sg_db,
             doc_id=doc_id,
         )
-        assert expired_raw_doc["_sync"]["rev"].startswith("2-")
+        assert expired_raw_doc["_sync"]["rev"].startswith("{}-".format(expected_rev))
         assert expired_raw_doc["_deleted"]
     else:
         with pytest.raises(NotFoundError) as nfe:


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Update validation to handle expiry for xattrs

