### PR TITLE
Feature/skip tap loss offline tests

### DIFF
--- a/libraries/provision/ansible/playbooks/tasks/start-sg-accel.yml
+++ b/libraries/provision/ansible/playbooks/tasks/start-sg-accel.yml
@@ -6,5 +6,5 @@
 
 - name: SG ACCEL | Wait until sg_accel to listen on port
   become: yes
-  wait_for: port=4985 timeout=30
+  wait_for: port=4985 timeout=60
 

--- a/libraries/provision/ansible/playbooks/tasks/start-sync-gateway.yml
+++ b/libraries/provision/ansible/playbooks/tasks/start-sync-gateway.yml
@@ -6,4 +6,4 @@
 
 - name: SYNC GATEWAY | Wait until sync gateway to listen on port
   become: yes
-  wait_for: port=4985 timeout=30
+  wait_for: port=4985 timeout=60

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_cc.json
@@ -6,7 +6,7 @@
     "maxFileDescriptors": 90000,
     "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
-    "log": ["CRUD+", "Cache+", "HTTP+", "Changes+"],
+    "log": ["CRUD+", "Cache+", "HTTP+", "Changes+", "Import+"],
     "databases":{
         "db":{
             {{ autoimport }}

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -8,10 +8,33 @@ from keywords.exceptions import ProvisioningError
 from keywords.SyncGateway import (sync_gateway_config_path_for_mode,
                                   validate_sync_gateway_mode)
 from keywords.tklogging import Logging
-from keywords.utils import check_xattr_support, log_info, version_is_binary
+from keywords.utils import check_xattr_support, log_info, version_is_binary, compare_versions
 from libraries.NetworkUtils import NetworkUtils
 from libraries.testkit import cluster
 from utilities.cluster_config_utils import persist_cluster_config_environment_prop
+
+UNSUPPORTED_1_5_0_CC = {
+    "test_db_offline_tap_loss_sanity[bucket_online_offline/bucket_online_offline_default_dcp-100]": {
+        "reason": "Loss of DCP not longer puts the bucket in the offline state"
+    },
+    "test_db_offline_tap_loss_sanity[bucket_online_offline/bucket_online_offline_default-100]": {
+        "reason": "Loss of DCP not longer puts the bucket in the offline state"
+    },
+    "test_multiple_dbs_unique_buckets_lose_tap[bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets-100]": {
+        "reason": "Loss of DCP not longer puts the bucket in the offline state"
+    },
+    "test_db_online_offline_webhooks_offline_two[webhooks/webhook_offline-5-1-1-2]": {
+        "reason": "Loss of DCP not longer puts the bucket in the offline state"
+    }
+}
+
+
+def skip_if_unsupported(sync_gateway_version, mode, test_name):
+
+    # sync_gateway_version >= 1.5.0 and channel cache
+    if compare_versions(sync_gateway_version, "1.5.0") >= 0 and mode == 'cc':
+        if test_name in UNSUPPORTED_1_5_0_CC:
+            pytest.skip(UNSUPPORTED_1_5_0_CC[test_name]["reason"])
 
 
 # Add custom arguments for executing tests in this directory
@@ -134,6 +157,7 @@ def params_from_base_suite_setup(request):
     cluster_topology = cluster_utils.get_cluster_topology(cluster_config)
 
     yield {
+        "sync_gateway_version": sync_gateway_version,
         "cluster_config": cluster_config,
         "cluster_topology": cluster_topology,
         "mode": mode,
@@ -158,6 +182,15 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     xattrs_enabled = params_from_base_suite_setup["xattrs_enabled"]
 
     test_name = request.node.name
+
+    # Certain test are diabled for certain modes
+    # Given the run conditions, check if the test needs to be skipped
+    skip_if_unsupported(
+        sync_gateway_version=params_from_base_suite_setup["sync_gateway_version"],
+        mode=mode,
+        test_name=test_name
+    )
+
     log_info("Running test '{}'".format(test_name))
     log_info("cluster_config: {}".format(cluster_config))
     log_info("cluster_topology: {}".format(cluster_topology))


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Increase SG / SG Accel startup timeout - https://github.com/couchbase/sync_gateway/issues/2680 tracking ticket to reduce this once the cause has been identified
- Disable 4 invalid online / offline tests for 1.5.0+ CC. Sync Gateway no longer takes a db offline if there are intermittent errors with the DCP feed. It will try to reconnect. The disabled tests expect the offline behavior and will be run for < 1.5.0 CC Sync Gateway versions

