### PR TITLE
Add workaround instructions for fatal error: libcouchbase/cbft.h: No …

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -77,6 +77,22 @@ $ wget http://packages.couchbase.com/clients/c/libcouchbase-2.5.6_centos7_x86_64
     rm -f *.rpm	     
 ```
 
+If you run into this error when running `source setup.sh`:
+
+```
+  src/pycbc.h:29:31: fatal error: libcouchbase/cbft.h: No such file or directory
+     #include <libcouchbase/cbft.h>
+```
+
+The update your libcouchbase version via:
+
+```
+wget http://packages.couchbase.com/releases/couchbase-release/couchbase-release-1.0-2-x86_64.rpm
+sudo rpm -iv couchbase-release-1.0-2-x86_64.rpm
+sudo yum install libcouchbase-devel libcouchbase2-bin gcc gcc-c++
+```
+
+
 === Set up virtualenv install python dependencies
 
 ```


### PR DESCRIPTION

#### Changes proposed in this pull request:

- Add workaround instructions for fatal error: libcouchbase/cbft.h: No such file or directory error

