### PR TITLE
Add script to restart all services

### DIFF
--- a/libraries/provision/ansible/playbooks/restart-services.yml
+++ b/libraries/provision/ansible/playbooks/restart-services.yml
@@ -1,0 +1,50 @@
+
+- hosts: couchbase_servers
+  any_errors_fatal: true
+  become: yes
+
+  tasks:
+  - name: Restart Couchbase Server service
+    service: name=couchbase-server state=restarted
+  - name: Wait for listening on port 8091
+    wait_for: port=8091 timeout=60
+  - name: Wait for listenting on port 11210
+    wait_for: port=11210 timeout=60
+  - name: Add artificial delay to workaround sync gateway startup issue (https://github.com/couchbase/sync_gateway/issues/2716)
+    pause:
+      seconds: 30
+
+
+- hosts: sync_gateways
+  any_errors_fatal: true
+
+  vars:
+    sync_gateway_config_filepath:
+    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
+    
+  tasks:
+  - name: Restart sync gateway service
+    become: yes
+    service: name=sync_gateway state=restarted
+    when: ansible_distribution == "CentOS"
+
+  - include: tasks/start-sync-gateway-windows.yml
+    when: ansible_os_family == "Windows"
+
+
+    
+- hosts: sg_accels
+  any_errors_fatal: true
+
+  vars:
+    sync_gateway_config_filepath:
+    couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
+
+  tasks:
+  - name: Restart sg accel service
+    become: yes
+    service: name=sg_accel state=restarted
+    when: ansible_distribution == "CentOS"
+
+  - include: tasks/start-sg-accel-windows.yml
+    when: ansible_os_family == "Windows"

--- a/libraries/provision/restart_services.py
+++ b/libraries/provision/restart_services.py
@@ -1,0 +1,15 @@
+import os
+
+from keywords.utils import log_info
+from libraries.testkit.cluster import Cluster
+
+if __name__ == "__main__":
+
+    try:
+        cluster_conf = os.environ["CLUSTER_CONFIG"]
+    except KeyError as ke:
+        log_info("Make sure CLUSTER_CONFIG is defined and pointing to the configuration you would like to provision")
+        raise KeyError("CLUSTER_CONFIG not defined. Unable to provision cluster.")
+
+    cluster = Cluster(config=cluster_conf)
+    cluster.restart_services()

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -161,6 +161,14 @@ class Cluster:
 
         return mode
 
+    def restart_services(self):
+        ansible_runner = AnsibleRunner(self._cluster_config)
+        status = ansible_runner.run_ansible_playbook(
+            "restart-services.yml",
+            extra_vars={}
+        )
+        assert status == 0, "Failed to restart services"
+
     def save_cbgt_diagnostics(self):
 
         # CBGT REST Admin API endpoint


### PR DESCRIPTION
#### Fixes #1290.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- A script that takes no args and just runs systemctl start on all the relevant machines?
- Timesaver when restarting docker containers and wanting to re-run a test with `--skip-provisioning`
- Also needed when redeploying from a local cross-compile build via [these instructions](https://github.com/couchbase/sync_gateway/blob/master/docs/BUILD.md#cross-compiling-for-linux) 

