### PR TITLE
Bump SG port wait_for timeout to 120

### DIFF
--- a/libraries/provision/ansible/playbooks/tasks/start-sg-accel.yml
+++ b/libraries/provision/ansible/playbooks/tasks/start-sg-accel.yml
@@ -6,5 +6,5 @@
 
 - name: SG ACCEL | Wait until sg_accel to listen on port
   become: yes
-  wait_for: port=4985 timeout=60
+  wait_for: port=4985 timeout=120
 

--- a/libraries/provision/ansible/playbooks/tasks/start-sync-gateway.yml
+++ b/libraries/provision/ansible/playbooks/tasks/start-sync-gateway.yml
@@ -6,4 +6,4 @@
 
 - name: SYNC GATEWAY | Wait until sync gateway to listen on port
   become: yes
-  wait_for: port=4985 timeout=60
+  wait_for: port=4985 timeout=120


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:
- Increase port wait_for timeout to 120

