### PR TITLE
Reenable rebalance / failover scenarios

### DIFF
--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/test_multiple_servers.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/test_multiple_servers.py
@@ -22,7 +22,6 @@ from keywords import couchbaseserver
 @pytest.mark.session
 @pytest.mark.channel
 @pytest.mark.bulkops
-@pytest.mark.skip(reason="Failing due to - https://github.com/couchbase/sync_gateway/issues/2173")
 def test_rebalance_sanity(params_from_base_test_setup):
 
     cluster_config = params_from_base_test_setup["cluster_config"]
@@ -101,7 +100,6 @@ def test_rebalance_sanity(params_from_base_test_setup):
 @pytest.mark.session
 @pytest.mark.channel
 @pytest.mark.bulkops
-@pytest.mark.skip(reason="Failing due to - https://github.com/couchbase/sync_gateway/issues/2197")
 def test_server_goes_down_sanity(params_from_base_test_setup):
     """
     1. Start with a two node couchbase server cluster


### PR DESCRIPTION
#### Fixes #1344.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Reenable rebalance / failover tests

