### PR TITLE
#1249 added new test Verify feed changes with xattrs and imports enabled

### DIFF
--- a/keywords/ChangesTracker.py
+++ b/keywords/ChangesTracker.py
@@ -130,8 +130,8 @@ class ChangesTracker:
         expected docs format: [{"id": "doc_id1" "rev": "rev1", "ok", "true"}, ...]
 
         rev_prefix_gen : if you want to verify only the prefix of revision like 1-, 2-, 3-
-            It is useful if you want to verify changes when updated by SDK as SDK does not know the actual 
-            revision, but with scenario it can know what prefix in the revision it is expecting  
+            It is useful if you want to verify changes when updated by SDK as SDK does not know the actual
+            revision, but with scenario it can know what prefix in the revision it is expecting
         """
         start = time.time()
         while True:

--- a/keywords/ChangesTracker.py
+++ b/keywords/ChangesTracker.py
@@ -66,8 +66,9 @@ class ChangesTracker:
         log_info("[Changes Tracker] Changes Tracker Starting ...")
         start = time.time()
         while not self.cancel:
+            # This if condition will run this method until the timeout and break and come out of this method.
             if time.time() - start > timeout:
-                logging.error("[Changes Tracker] wait_until: TIMEOUT")
+                logging.info("[Changes Tracker] : TIMEOUT")
                 break
             data = {
                 "feed": "longpoll",
@@ -127,6 +128,10 @@ class ChangesTracker:
         via the changes feed. This will return false if the polling exceeds the timeout
 
         expected docs format: [{"id": "doc_id1" "rev": "rev1", "ok", "true"}, ...]
+
+        rev_prefix_gen : if you want to verify only the prefix of revision like 1-, 2-, 3-
+            It is useful if you want to verify changes when updated by SDK as SDK does not know the actual 
+            revision, but with scenario it can know what prefix in the revision it is expecting  
         """
         start = time.time()
         while True:

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -84,7 +84,7 @@ class Cluster:
         status = ansible_runner.run_ansible_playbook("stop-sync-gateway.yml")
         assert status == 0, "Failed to stop sync gateway"
 
-        # Stop sync_gateways
+        # Stop sync_gateway accels
         log_info(">>> Stopping sg_accel")
         status = ansible_runner.run_ansible_playbook("stop-sg-accel.yml")
         assert status == 0, "Failed to stop sg_accel"

--- a/libraries/utilities/generate_clusters_from_pool.py
+++ b/libraries/utilities/generate_clusters_from_pool.py
@@ -402,7 +402,7 @@ def get_hosts(pool_file="resources/pool.json"):
     return ips, ip_to_node_type
 
 
-def generate_clusters_from_pool(pool_file, use_docker):
+def generate_clusters_from_pool(pool_file, use_docker=False):
 
     cluster_confs = [
 

--- a/testsuites/syncgateway/functional/tests/test_xattrs.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs.py
@@ -1248,8 +1248,7 @@ def test_sg_feed_changed_with_xattrs_importEnabled(params_from_base_test_setup,
     - Verify docs via ChangesTracker with expected revision
     - update SG docs via SDK
     - Verify docs via ChangesTracker with rev generation 3-
-   
-    """
+   """
     cluster_conf = params_from_base_test_setup['cluster_config']
     cluster_topology = params_from_base_test_setup['cluster_topology']
     mode = params_from_base_test_setup['mode']
@@ -1338,7 +1337,7 @@ def test_sg_feed_changed_with_xattrs_importEnabled(params_from_base_test_setup,
 
     with ThreadPoolExecutor(max_workers=5) as upsdk_tpe:
         log_info("Updating docs via SDK...")
-        
+
         # Update docs via SDK
         sdk_docs = sdk_client.get_multi(doc_set_ids1)
         assert len(sdk_docs.keys()) == number_docs_per_client

--- a/testsuites/syncgateway/functional/tests/test_xattrs.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs.py
@@ -1352,6 +1352,7 @@ def test_sg_feed_changed_with_xattrs_importEnabled(params_from_base_test_setup,
                 break
             try:
                 ct_task = upsdk_tpe.submit(changestrack.start(timeout=15))
+                break
             except ChangesError:
                 continue
         all_docs_via_sg_formatted = [
@@ -1385,6 +1386,7 @@ def test_sg_feed_changed_with_xattrs_importEnabled(params_from_base_test_setup,
                 break
             try:
                 ct_task = upsdksg_tpe.submit(changestrack.start(timeout=15))
+                break
             except ChangesError:
                 continue
         wait_for_changes = upsdksg_tpe.submit(
@@ -1425,6 +1427,7 @@ def test_sg_feed_changed_with_xattrs_importEnabled(params_from_base_test_setup,
                 break
             try:
                 ct_task = crsg_tpe.submit(changestrack_sg.start(timeout=15))
+                break
             except ChangesError:
                 continue
         wait_for_changes = crsg_tpe.submit(
@@ -1446,7 +1449,7 @@ def test_sg_feed_changed_with_xattrs_importEnabled(params_from_base_test_setup,
         for doc in user_docs:
             doc['updated_by_sg'] = "edits_1"
 
-        # Add the docs via build_docs
+        # Add the docs via bulk_docs
         sg_docs_update_resp = sg_client.add_bulk_docs(url=sg_url, db=sg_db, docs=user_docs, auth=autosguser_session)
         # Retry to get changes until expected changes appeared
         start = time.time()
@@ -1455,6 +1458,7 @@ def test_sg_feed_changed_with_xattrs_importEnabled(params_from_base_test_setup,
                 break
             try:
                 ct_task = upsg_tpe.submit(changestrack_sg.start(timeout=15))
+                break
             except ChangesError:
                 continue
         wait_for_changes = upsg_tpe.submit(
@@ -1483,6 +1487,7 @@ def test_sg_feed_changed_with_xattrs_importEnabled(params_from_base_test_setup,
                 break
             try:
                 ct_task = upsgsdk_tpe.submit(changestrack_sg.start(timeout=15))
+                break
             except ChangesError:
                 continue
         all_docs_via_sg_formatted = [


### PR DESCRIPTION
#### Fixes #1249 .

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- #1249 - new test added for verifying feed changes with xattrs and import enabled


