### PR TITLE
added new test for xattrs for branched revision scenario

### DIFF
--- a/keywords/MobileRestClient.py
+++ b/keywords/MobileRestClient.py
@@ -1207,7 +1207,7 @@ class MobileRestClient:
 
         return added_docs
 
-    def add_bulk_docs(self, url, db, docs, auth=None, ):
+    def add_bulk_docs(self, url, db, docs, auth=None):
         """
         Keyword that issues POST _bulk docs with the specified 'docs'.
         Use the Document.create_docs() to create the docs.

--- a/keywords/MobileRestClient.py
+++ b/keywords/MobileRestClient.py
@@ -1207,7 +1207,7 @@ class MobileRestClient:
 
         return added_docs
 
-    def add_bulk_docs(self, url, db, docs, auth=None):
+    def add_bulk_docs(self, url, db, docs, auth=None, ):
         """
         Keyword that issues POST _bulk docs with the specified 'docs'.
         Use the Document.create_docs() to create the docs.
@@ -2162,3 +2162,24 @@ class MobileRestClient:
         )
 
         return status
+
+    def get_changes_style_all_docs(self, url, db, auth=None, include_docs=False):
+        """ Get all changes with include docs enabled and style all_docs """
+        auth_type = get_auth_type(auth)
+
+        params = {}
+        if include_docs:
+            params["include_docs"] = "true"
+            params["style"] = "all_docs"
+
+        if auth_type == AuthType.session:
+            resp = self._session.get("{}/{}/_changes".format(url, db), params=params, cookies=dict(SyncGatewaySession=auth[1]))
+        elif auth_type == AuthType.http_basic:
+            resp = self._session.get("{}/{}/_changes".format(url, db), params=params, auth=auth)
+        else:
+            resp = self._session.get("{}/{}/_changes".format(url, db), params=params)
+
+        log_r(resp)
+        resp.raise_for_status()
+        resp_obj = resp.json()
+        return resp_obj


### PR DESCRIPTION
#### Fixes #1046 .

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- New test for Shared Updates with conflicts from sg side
  Scenario covered is : 
- Create docs via SG and get the revision number 1-rev
    - Update docs via SDK and get the revision number 2-rev
    - Update docs via SG with new_edits=false by giving parent revision 1-rev
        and get the revision number 2-rev1
    - update docs via SDK again and get the revision number 3-rev
    - Verify with _all_changes by enabling include docs and verify 2 branched revisions appear in changes feed
    - Verify no errors occur while updating docs via SG
    - Delete docs via SDK
    - Delete docs via SG
    - Verify no errors while deletion
    - Verify changes feed that branched revision are removed
    - Verify changes feed that keys "deleted" is true and keys "removed"


