### PR TITLE
Stop ws before asserting

### DIFF
--- a/testsuites/syncgateway/functional/tests/test_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_webhooks.py
@@ -80,9 +80,12 @@ def test_webhooks(params_from_base_test_setup, sg_conf_name, num_users, num_chan
     expected_events = (num_users * num_docs * num_revisions) + (num_users * num_docs)
     received_events = len(ws.get_data())
     log_info("expected_events: {} received_events {}".format(expected_events, received_events))
+    # Stop ws before asserting
+    # Else successive tests will fail to start ws
+    ws.stop()
     assert expected_events == received_events
 
-    ws.stop()
+
 
 
 @pytest.mark.sanity


### PR DESCRIPTION
#### Fixes #1381.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:
- Stop ws before asserting so that successive tests can start ws.


