### PR TITLE
Restore unsupported for replicator_2

### DIFF
--- a/docker/testkit-net/sg_config_xattrs_blip.json
+++ b/docker/testkit-net/sg_config_xattrs_blip.json
@@ -10,7 +10,9 @@
             "bucket": "default",
             "password": "password",
             "enable_shared_bucket_access": true,
-            "replicator_2": true,
+            "unsupported": {
+                "replicator_2": true
+            },
             "users": {
                 "GUEST": {
                     "disabled": false,


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:
- Add back unsupported for replicator_2

