### PR TITLE
Fix/start continuous changes tracking

### DIFF
--- a/libraries/testkit/user.py
+++ b/libraries/testkit/user.py
@@ -540,13 +540,14 @@ class User:
                     continue
 
                 # Close connection if termination doc is recieved in _changes
-                if termination_doc_id is not None and doc["doc"]["_id"] == termination_doc_id:
-                    r.close()
-                    return docs
+                if "doc" in doc:
+                    if termination_doc_id is not None and doc["doc"]["_id"] == termination_doc_id:
+                        r.close()
+                        return docs
 
-                log.debug("{} DOC FROM CONTINUOUS _changes: {}: {}".format(self.name, doc["doc"]["_id"], doc["doc"]["_rev"]))
-                # Store doc
-                docs[doc["doc"]["_id"]] = doc["doc"]["_rev"]
+                    log.debug("{} DOC FROM CONTINUOUS _changes: {}: {}".format(self.name, doc["doc"]["_id"], doc["doc"]["_rev"]))
+                    # Store doc
+                    docs[doc["doc"]["_id"]] = doc["doc"]["_rev"]
 
         # if connection is closed from server
         return docs

--- a/libraries/testkit/user.py
+++ b/libraries/testkit/user.py
@@ -536,18 +536,17 @@ class User:
                 doc = json.loads(line)
 
                 # We are not interested in _user/ docs
-                if doc["id"].startswith("_user/"):
+                if doc["id"].startswith("_user/") or "doc" not in doc:
                     continue
 
                 # Close connection if termination doc is recieved in _changes
-                if "doc" in doc:
-                    if termination_doc_id is not None and doc["doc"]["_id"] == termination_doc_id:
-                        r.close()
-                        return docs
+                if termination_doc_id is not None and doc["doc"]["_id"] == termination_doc_id:
+                    r.close()
+                    return docs
 
-                    log.debug("{} DOC FROM CONTINUOUS _changes: {}: {}".format(self.name, doc["doc"]["_id"], doc["doc"]["_rev"]))
-                    # Store doc
-                    docs[doc["doc"]["_id"]] = doc["doc"]["_rev"]
+                log.debug("{} DOC FROM CONTINUOUS _changes: {}: {}".format(self.name, doc["doc"]["_id"], doc["doc"]["_rev"]))
+                # Store doc
+                docs[doc["doc"]["_id"]] = doc["doc"]["_rev"]
 
         # if connection is closed from server
         return docs


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:
- Check if doc is present before getting its ID, to avoid KeyError 
-

