### PR TITLE
skip log rotation and backfill tests for SG 1.3

### DIFF
--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -37,6 +37,10 @@ def skip_if_unsupported(sync_gateway_version, mode, test_name):
         if test_name in UNSUPPORTED_1_5_0_CC:
             pytest.skip(UNSUPPORTED_1_5_0_CC[test_name]["reason"])
 
+    if compare_versions(sync_gateway_version, "1.3.0") >= 0:
+        if "log_rotation" in test_name or "test_backfill" in test_name or "test_awaken_backfill" in test_name:
+            pytest.skip("{} test was added for synn gateway 1.4".format(test_name))
+
 
 # Add custom arguments for executing tests in this directory
 def pytest_addoption(parser):

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -39,7 +39,7 @@ def skip_if_unsupported(sync_gateway_version, mode, test_name):
 
     if compare_versions(sync_gateway_version, "1.3.0") >= 0:
         if "log_rotation" in test_name or "test_backfill" in test_name or "test_awaken_backfill" in test_name:
-            pytest.skip("{} test was added for synn gateway 1.4".format(test_name))
+            pytest.skip("{} test was added for sync gateway 1.4".format(test_name))
 
 
 # Add custom arguments for executing tests in this directory


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:
- log rotation and backfill tests were added for sync gateway 1.4 and will fail with sync gateway 1.3


