### PR TITLE
Fix the restart method for server node

### DIFF
--- a/libraries/testkit/syncgateway.py
+++ b/libraries/testkit/syncgateway.py
@@ -82,7 +82,8 @@ class SyncGateway:
             "server_port": self.server_port,
             "server_scheme": self.server_scheme,
             "autoimport": "",
-            "xattrs": ""
+            "xattrs": "",
+            "couchbase_server_primary_node": self.couchbase_server_primary_node
         }
 
         if is_xattrs_enabled(self.cluster_config):


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:
- Fix missing couchbase_server_primary_node for restart
-

