### PR TITLE
Enabled xattrs for lite tests

### DIFF
--- a/testsuites/listener/shared/client_sg/conftest.py
+++ b/testsuites/listener/shared/client_sg/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import datetime
 
-from keywords.utils import log_info
+from keywords.utils import log_info, check_xattr_support, version_is_binary
 from keywords.constants import RESULTS_DIR
 from keywords.constants import CLUSTER_CONFIGS_DIR
 from keywords.LiteServFactory import LiteServFactory
@@ -23,6 +23,7 @@ def pytest_addoption(parser):
     parser.addoption("--sync-gateway-version", action="store", help="sync-gateway-version: the version of sync_gateway to run tests against")
     parser.addoption("--sync-gateway-mode", action="store", help="sync-gateway-mode: the mode of sync_gateway to run tests against, channel_cache ('cc') or distributed_index ('di')")
     parser.addoption("--server-version", action="store", help="server-version: version of Couchbase Server to install and run tests against")
+    parser.addoption("--xattrs", action="store_true", help="Use xattrs for sync meta storage. Sync Gateway 1.5.0+ and Couchbase Server 5.0+")
 
 
 # This will get called once before the first test that
@@ -47,12 +48,16 @@ def setup_client_syncgateway_suite(request):
     sync_gateway_mode = request.config.getoption("--sync-gateway-mode")
 
     server_version = request.config.getoption("--server-version")
+    xattrs_enabled = request.config.getoption("--xattrs")
 
     liteserv = LiteServFactory.create(platform=liteserv_platform,
                                       version_build=liteserv_version,
                                       host=liteserv_host,
                                       port=liteserv_port,
                                       storage_engine=liteserv_storage_engine)
+
+    if xattrs_enabled and version_is_binary(sync_gateway_version):
+            check_xattr_support(server_version, sync_gateway_version)
 
     log_info("Downloading LiteServ ...")
     # Download LiteServ
@@ -81,6 +86,13 @@ def setup_client_syncgateway_suite(request):
         log_info("Running test with sync_gateway version {}".format(sync_gateway_version))
         persist_cluster_config_environment_prop(cluster_config, 'sync_gateway_version', sync_gateway_version)
 
+    if xattrs_enabled:
+        log_info("Running test with xattrs for sync meta storage")
+        persist_cluster_config_environment_prop(cluster_config, 'xattrs_enabled', True)
+    else:
+        log_info("Using document storage for sync meta data")
+        persist_cluster_config_environment_prop(cluster_config, 'xattrs_enabled', False)
+
     sg_config = sync_gateway_config_path_for_mode("listener_tests/listener_tests", sync_gateway_mode)
 
     if not skip_provisioning:
@@ -98,7 +110,8 @@ def setup_client_syncgateway_suite(request):
     yield {
         "liteserv": liteserv,
         "cluster_config": cluster_config,
-        "sg_mode": sync_gateway_mode
+        "sg_mode": sync_gateway_mode,
+        "xattrs_enabled": xattrs_enabled
     }
 
     log_info("Tearing down suite ...")
@@ -115,6 +128,7 @@ def setup_client_syncgateway_test(request, setup_client_syncgateway_suite):
 
     liteserv = setup_client_syncgateway_suite["liteserv"]
     cluster_config = setup_client_syncgateway_suite["cluster_config"]
+    xattrs_enabled = setup_client_syncgateway_suite["xattrs_enabled"]
     test_name = request.node.name
 
     if request.config.getoption("--liteserv-platform") == "macosx" and \
@@ -140,7 +154,8 @@ def setup_client_syncgateway_test(request, setup_client_syncgateway_suite):
         "sg_mode": setup_client_syncgateway_suite["sg_mode"],
         "ls_url": ls_url,
         "sg_url": sg_url,
-        "sg_admin_url": sg_admin_url
+        "sg_admin_url": sg_admin_url,
+        "xattrs_enabled": xattrs_enabled
     }
 
     log_info("Tearing down test")

--- a/testsuites/listener/shared/client_sg_topology_specific/conftest.py
+++ b/testsuites/listener/shared/client_sg_topology_specific/conftest.py
@@ -9,4 +9,4 @@ def pytest_addoption(parser):
     parser.addoption("--sync-gateway-version", action="store", help="sync-gateway-version: the version of sync_gateway to run tests against")
     parser.addoption("--sync-gateway-mode", action="store", help="sync-gateway-mode: the version of sync_gateway to run tests against, channel_cache ('cc') or distributed_index ('di')")
     parser.addoption("--server-version", action="store", help="server-version: version of Couchbase Server to install and run tests against")
-    parser.addoption("--xattrs", action="store_true", help="topospecific data Use xattrs for sync meta storage. Only works with Sync Gateway 1.5.0+ and Couchbase Server 5.0+")
+    parser.addoption("--xattrs", action="store_true", help="Use xattrs for sync meta storage. Only works with Sync Gateway 1.5.0+ and Couchbase Server 5.0+")

--- a/testsuites/listener/shared/client_sg_topology_specific/conftest.py
+++ b/testsuites/listener/shared/client_sg_topology_specific/conftest.py
@@ -9,3 +9,4 @@ def pytest_addoption(parser):
     parser.addoption("--sync-gateway-version", action="store", help="sync-gateway-version: the version of sync_gateway to run tests against")
     parser.addoption("--sync-gateway-mode", action="store", help="sync-gateway-mode: the version of sync_gateway to run tests against, channel_cache ('cc') or distributed_index ('di')")
     parser.addoption("--server-version", action="store", help="server-version: version of Couchbase Server to install and run tests against")
+    parser.addoption("--xattrs", action="store_true", help="topospecific data Use xattrs for sync meta storage. Only works with Sync Gateway 1.5.0+ and Couchbase Server 5.0+")

--- a/testsuites/listener/shared/client_sg_topology_specific/multiple_sync_gateways/conftest.py
+++ b/testsuites/listener/shared/client_sg_topology_specific/multiple_sync_gateways/conftest.py
@@ -1,7 +1,7 @@
-import pytest
 import datetime
+import pytest
 
-from keywords.utils import log_info
+from keywords.utils import log_info, check_xattr_support, version_is_binary
 from keywords.LiteServFactory import LiteServFactory
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
 from keywords.ClusterKeywords import ClusterKeywords
@@ -32,14 +32,17 @@ def setup_client_syncgateway_suite(request):
     skip_provisioning = request.config.getoption("--skip-provisioning")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
     sync_gateway_mode = request.config.getoption("--sync-gateway-mode")
-
     server_version = request.config.getoption("--server-version")
+    xattrs_enabled = request.config.getoption("--xattrs")
 
     liteserv = LiteServFactory.create(platform=liteserv_platform,
                                       version_build=liteserv_version,
                                       host=liteserv_host,
                                       port=liteserv_port,
                                       storage_engine=liteserv_storage_engine)
+
+    if xattrs_enabled and version_is_binary(sync_gateway_version):
+            check_xattr_support(server_version, sync_gateway_version)
 
     log_info("Downloading LiteServ ...")
     # Download LiteServ
@@ -68,6 +71,13 @@ def setup_client_syncgateway_suite(request):
         log_info("Running test with sync_gateway version {}".format(sync_gateway_version))
         persist_cluster_config_environment_prop(cluster_config, 'sync_gateway_version', sync_gateway_version)
 
+    if xattrs_enabled:
+        log_info("Running test with xattrs for sync meta storage")
+        persist_cluster_config_environment_prop(cluster_config, 'xattrs_enabled', True)
+    else:
+        log_info("Using document storage for sync meta data")
+        persist_cluster_config_environment_prop(cluster_config, 'xattrs_enabled', False)
+
     sg_config = sync_gateway_config_path_for_mode("listener_tests/listener_tests", sync_gateway_mode)
 
     if not skip_provisioning:
@@ -85,7 +95,8 @@ def setup_client_syncgateway_suite(request):
     yield {
         "liteserv": liteserv,
         "cluster_config": cluster_config,
-        "sg_mode": sync_gateway_mode
+        "sg_mode": sync_gateway_mode,
+        "xattrs_enabled": xattrs_enabled
     }
 
     log_info("Tearing down suite ...")
@@ -103,6 +114,7 @@ def setup_client_syncgateway_test(request, setup_client_syncgateway_suite):
 
     liteserv = setup_client_syncgateway_suite["liteserv"]
     cluster_config = setup_client_syncgateway_suite["cluster_config"]
+    xattrs_enabled = setup_client_syncgateway_suite["xattrs_enabled"]
     test_name = request.node.name
 
     client = MobileRestClient()
@@ -123,7 +135,8 @@ def setup_client_syncgateway_test(request, setup_client_syncgateway_suite):
         "sg_mode": setup_client_syncgateway_suite["sg_mode"],
         "ls_url": ls_url,
         "sg_url": sg_url,
-        "sg_admin_url": sg_admin_url
+        "sg_admin_url": sg_admin_url,
+        "xattrs_enabled": xattrs_enabled
     }
 
     log_info("Tearing down test")

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -72,7 +72,7 @@ def pytest_addoption(parser):
 
     parser.addoption("--xattrs",
                      action="store_true",
-                     help="Use xattrs for sync meta storage. Only works with Sync Gateway 2.0+ and Couchbase Server 5.0+")
+                     help="Use xattrs for sync meta storage. Only works with Sync Gateway 1.5.0+ and Couchbase Server 5.0+")
 
     parser.addoption("--collect-logs",
                      action="store_true",


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Enabled xattrs for client_sg tests
- Enabled xattrs for client_sg_topoplogy specific tests

