### PR TITLE
stopping sg and accel in teardown to have clean run for next jenkins …

### DIFF
--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -301,6 +301,20 @@ class Cluster:
 
         return errors
 
+    def stop_sg_and_accel(self):
+
+        ansible_runner = AnsibleRunner(self._cluster_config)
+
+        # Stop sync_gateways
+        log_info(">>> Stopping sync_gateway")
+        status = ansible_runner.run_ansible_playbook("stop-sync-gateway.yml")
+        assert status == 0, "Failed to stop sync gateway"
+
+        # Stop sync_gateway accels
+        log_info(">>> Stopping sg_accel")
+        status = ansible_runner.run_ansible_playbook("stop-sg-accel.yml")
+        assert status == 0, "Failed to stop sg_accel"
+
     def __repr__(self):
         s = "\n\n"
         s += "Sync Gateways\n"

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -303,17 +303,17 @@ class Cluster:
 
     def stop_sg_and_accel(self):
 
-        ansible_runner = AnsibleRunner(self._cluster_config)
-
         # Stop sync_gateways
         log_info(">>> Stopping sync_gateway")
-        status = ansible_runner.run_ansible_playbook("stop-sync-gateway.yml")
-        assert status == 0, "Failed to stop sync gateway"
+        for sg in self.sync_gateways:
+            status = sg.stop()
+            assert status == 0, "Failed to stop sync gateway for host {}".format(sg.hostname)
 
         # Stop sync_gateway accels
         log_info(">>> Stopping sg_accel")
-        status = ansible_runner.run_ansible_playbook("stop-sg-accel.yml")
-        assert status == 0, "Failed to stop sg_accel"
+        for sgaccel in self.sg_accels:
+            status = sgaccel.stop()
+            assert status == 0, "Failed to stop sync gateway for host {}".format(sgaccel.hostname)
 
     def __repr__(self):
         s = "\n\n"

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -298,3 +298,6 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
 
     assert len(errors) == 0
+
+    # Stop all sync_gateway and sg_accels as test finished
+    c.stop_sg_and_accel()

--- a/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
@@ -165,3 +165,6 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
 
     assert len(errors) == 0
+
+    # Stop all sync_gateway and sg_accels as test finished
+    c.stop_sg_and_accel()

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
@@ -170,3 +170,6 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
 
     assert len(errors) == 0
+
+    # Stop all sync_gateway and sg_accels as test finished
+    c.stop_sg_and_accel()

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
@@ -167,3 +167,6 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
 
     assert len(errors) == 0
+
+    # Stop all sync_gateway and sg_accels as test finished
+    c.stop_sg_and_accel()

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -164,3 +164,6 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
 
     assert len(errors) == 0
+
+    # Stop all sync_gateway and sg_accels as test finished
+    c.stop_sg_and_accel()


### PR DESCRIPTION
…build

#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- added logic to  stop sg and accel in teardown
- Added in all functional tests of sg

