### PR TITLE
Ability to run SG tests on amazon AMI and Ubuntu and sanity cleanup

### DIFF
--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -312,7 +312,7 @@ class CouchbaseServer:
         """
 
         # Leave 20% of RAM available for the underlying OS
-        ram_multiplier = 0.60
+        ram_multiplier = 0.80
 
         # Needed for N1QL indexing overhead. This enables us to use N1QL in the Couchbase
         # python SDK for direct validation in Couchbase server in some of the functional tests

--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -312,7 +312,7 @@ class CouchbaseServer:
         """
 
         # Leave 20% of RAM available for the underlying OS
-        ram_multiplier = 0.80
+        ram_multiplier = 0.60
 
         # Needed for N1QL indexing overhead. This enables us to use N1QL in the Couchbase
         # python SDK for direct validation in Couchbase server in some of the functional tests

--- a/libraries/provision/ansible/playbooks/check-sg-accel.yml
+++ b/libraries/provision/ansible/playbooks/check-sg-accel.yml
@@ -3,7 +3,7 @@
   any_errors_fatal: true
   tasks:
   - include: tasks/check-sg-accel.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/check-sg-accel-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/check-sg-accel.yml
+++ b/libraries/provision/ansible/playbooks/check-sg-accel.yml
@@ -3,7 +3,7 @@
   any_errors_fatal: true
   tasks:
   - include: tasks/check-sg-accel.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/check-sg-accel-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/check-sync-gateway.yml
+++ b/libraries/provision/ansible/playbooks/check-sync-gateway.yml
@@ -3,7 +3,7 @@
   any_errors_fatal: true
   tasks:
   - include: tasks/check-sync-gateway.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/check-sync-gateway-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/check-sync-gateway.yml
+++ b/libraries/provision/ansible/playbooks/check-sync-gateway.yml
@@ -3,7 +3,7 @@
   any_errors_fatal: true
   tasks:
   - include: tasks/check-sync-gateway.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/check-sync-gateway-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/delete-sg-accel-artifacts.yml
+++ b/libraries/provision/ansible/playbooks/delete-sg-accel-artifacts.yml
@@ -3,7 +3,7 @@
 - hosts: sg_accels
   tasks:
   - include: tasks/delete-sg-accel-artifacts.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/delete-sg-accel-artifacts-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/delete-sg-accel-artifacts.yml
+++ b/libraries/provision/ansible/playbooks/delete-sg-accel-artifacts.yml
@@ -3,7 +3,7 @@
 - hosts: sg_accels
   tasks:
   - include: tasks/delete-sg-accel-artifacts.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/delete-sg-accel-artifacts-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/delete-sync-gateway-artifacts.yml
+++ b/libraries/provision/ansible/playbooks/delete-sync-gateway-artifacts.yml
@@ -3,7 +3,7 @@
 - hosts: sync_gateways
   tasks:
   - include: tasks/delete-sync-gateway-artifacts.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/delete-sync-gateway-artifacts-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/delete-sync-gateway-artifacts.yml
+++ b/libraries/provision/ansible/playbooks/delete-sync-gateway-artifacts.yml
@@ -3,7 +3,7 @@
 - hosts: sync_gateways
   tasks:
   - include: tasks/delete-sync-gateway-artifacts.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/delete-sync-gateway-artifacts-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/fetch-sync-gateway-logs.yml
+++ b/libraries/provision/ansible/playbooks/fetch-sync-gateway-logs.yml
@@ -3,7 +3,7 @@
   any_errors_fatal: true
   tasks:
   - include: tasks/fetch-sync-gateway-logs.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/fetch-sync-gateway-logs-windows.yml
     when: ansible_os_family == "Windows"
@@ -13,7 +13,7 @@
   any_errors_fatal: true
   tasks:
   - include: tasks/fetch-sg-accel-logs.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/fetch-sg-accel-logs-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/fetch-sync-gateway-logs.yml
+++ b/libraries/provision/ansible/playbooks/fetch-sync-gateway-logs.yml
@@ -3,7 +3,7 @@
   any_errors_fatal: true
   tasks:
   - include: tasks/fetch-sync-gateway-logs.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/fetch-sync-gateway-logs-windows.yml
     when: ansible_os_family == "Windows"
@@ -13,7 +13,7 @@
   any_errors_fatal: true
   tasks:
   - include: tasks/fetch-sg-accel-logs.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/fetch-sg-accel-logs-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/redeploy-local-sg-build.yml
+++ b/libraries/provision/ansible/playbooks/redeploy-local-sg-build.yml
@@ -8,7 +8,7 @@
 
   tasks:
   - include: tasks/stop-sync-gateway.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/stop-sync-gateway-windows.yml
     when: ansible_os_family == "Windows"
@@ -23,7 +23,7 @@
 
   tasks:
   - include: tasks/stop-sg-accel.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/stop-sg-accel-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/redeploy-local-sg-build.yml
+++ b/libraries/provision/ansible/playbooks/redeploy-local-sg-build.yml
@@ -8,7 +8,7 @@
 
   tasks:
   - include: tasks/stop-sync-gateway.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/stop-sync-gateway-windows.yml
     when: ansible_os_family == "Windows"
@@ -23,7 +23,7 @@
 
   tasks:
   - include: tasks/stop-sg-accel.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/stop-sg-accel-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/restart-services.yml
+++ b/libraries/provision/ansible/playbooks/restart-services.yml
@@ -26,7 +26,7 @@
   - name: Restart sync gateway service
     become: yes
     service: name=sync_gateway state=restarted
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/start-sync-gateway-windows.yml
     when: ansible_os_family == "Windows"
@@ -44,7 +44,7 @@
   - name: Restart sg accel service
     become: yes
     service: name=sg_accel state=restarted
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/start-sg-accel-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/restart-services.yml
+++ b/libraries/provision/ansible/playbooks/restart-services.yml
@@ -26,7 +26,7 @@
   - name: Restart sync gateway service
     become: yes
     service: name=sync_gateway state=restarted
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/start-sync-gateway-windows.yml
     when: ansible_os_family == "Windows"
@@ -44,7 +44,7 @@
   - name: Restart sg accel service
     become: yes
     service: name=sg_accel state=restarted
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/start-sg-accel-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/restart-sync-gateway.yml
+++ b/libraries/provision/ansible/playbooks/restart-sync-gateway.yml
@@ -4,7 +4,7 @@
   tasks:
   - include: tasks/stop-sync-gateway.yml
     become: yes
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/stop-sync-gateway-windows.yml
     when: ansible_os_family == "Windows"
@@ -15,7 +15,7 @@
   tasks:
   - include: tasks/start-sync-gateway.yml
     become: yes
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/start-sync-gateway-windows.yml
     when: ansible_os_family == "Windows"
@@ -25,7 +25,7 @@
   tasks:
   - include: tasks/stop-sg-accel.yml
     become: yes
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/stop-sg-accel-windows.yml
     when: ansible_os_family == "Windows"
@@ -36,7 +36,7 @@
   tasks:
   - include: tasks/start-sg-accel.yml
     become: yes
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/start-sg-accel-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/restart-sync-gateway.yml
+++ b/libraries/provision/ansible/playbooks/restart-sync-gateway.yml
@@ -4,7 +4,7 @@
   tasks:
   - include: tasks/stop-sync-gateway.yml
     become: yes
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/stop-sync-gateway-windows.yml
     when: ansible_os_family == "Windows"
@@ -15,7 +15,7 @@
   tasks:
   - include: tasks/start-sync-gateway.yml
     become: yes
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/start-sync-gateway-windows.yml
     when: ansible_os_family == "Windows"
@@ -25,7 +25,7 @@
   tasks:
   - include: tasks/stop-sg-accel.yml
     become: yes
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/stop-sg-accel-windows.yml
     when: ansible_os_family == "Windows"
@@ -36,7 +36,7 @@
   tasks:
   - include: tasks/start-sg-accel.yml
     become: yes
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/start-sg-accel-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/start-sg-accel.yml
+++ b/libraries/provision/ansible/playbooks/start-sg-accel.yml
@@ -14,7 +14,7 @@
     server_port:
   tasks:
   - include: tasks/deploy-sg-accel-config.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/deploy-sg-accel-config-windows.yml
     when: ansible_os_family == "Windows"
@@ -27,7 +27,7 @@
     couchbase_server_primary_node:
   tasks:
   - include: tasks/start-sg-accel.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/start-sg-accel-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/start-sg-accel.yml
+++ b/libraries/provision/ansible/playbooks/start-sg-accel.yml
@@ -14,7 +14,7 @@
     server_port:
   tasks:
   - include: tasks/deploy-sg-accel-config.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/deploy-sg-accel-config-windows.yml
     when: ansible_os_family == "Windows"
@@ -27,7 +27,7 @@
     couchbase_server_primary_node:
   tasks:
   - include: tasks/start-sg-accel.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/start-sg-accel-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/start-sync-gateway.yml
+++ b/libraries/provision/ansible/playbooks/start-sync-gateway.yml
@@ -16,7 +16,7 @@
 
   tasks:
   - include: tasks/deploy-sync-gateway-config.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/deploy-sync-gateway-config-windows.yml
     when: ansible_os_family == "Windows"
@@ -30,7 +30,7 @@
     
   tasks:
   - include: tasks/start-sync-gateway.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/start-sync-gateway-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/start-sync-gateway.yml
+++ b/libraries/provision/ansible/playbooks/start-sync-gateway.yml
@@ -16,7 +16,7 @@
 
   tasks:
   - include: tasks/deploy-sync-gateway-config.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/deploy-sync-gateway-config-windows.yml
     when: ansible_os_family == "Windows"
@@ -30,7 +30,7 @@
     
   tasks:
   - include: tasks/start-sync-gateway.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/start-sync-gateway-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/stop-sg-accel.yml
+++ b/libraries/provision/ansible/playbooks/stop-sg-accel.yml
@@ -4,7 +4,7 @@
 
   tasks:
   - include: tasks/stop-sg-accel.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/stop-sg-accel-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/stop-sg-accel.yml
+++ b/libraries/provision/ansible/playbooks/stop-sg-accel.yml
@@ -4,7 +4,7 @@
 
   tasks:
   - include: tasks/stop-sg-accel.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/stop-sg-accel-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/stop-sync-gateway.yml
+++ b/libraries/provision/ansible/playbooks/stop-sync-gateway.yml
@@ -4,7 +4,7 @@
 
   tasks:
   - include: tasks/stop-sync-gateway.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
   - include: tasks/stop-sync-gateway-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/stop-sync-gateway.yml
+++ b/libraries/provision/ansible/playbooks/stop-sync-gateway.yml
@@ -4,7 +4,7 @@
 
   tasks:
   - include: tasks/stop-sync-gateway.yml
-    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
   - include: tasks/stop-sync-gateway-windows.yml
     when: ansible_os_family == "Windows"

--- a/libraries/provision/ansible/playbooks/tasks/check-sg-accel.yml
+++ b/libraries/provision/ansible/playbooks/tasks/check-sg-accel.yml
@@ -10,4 +10,4 @@
   shell: /sbin/initctl status sg_accel
   register: output
   failed_when: output.stdout | search("dead")
-  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6") or ansible_distribution == "RedHat"
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6") or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"

--- a/libraries/provision/ansible/playbooks/tasks/check-sg-accel.yml
+++ b/libraries/provision/ansible/playbooks/tasks/check-sg-accel.yml
@@ -10,4 +10,4 @@
   shell: /sbin/initctl status sg_accel
   register: output
   failed_when: output.stdout | search("dead")
-  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6") or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6") or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"

--- a/libraries/provision/ansible/playbooks/tasks/check-sync-gateway.yml
+++ b/libraries/provision/ansible/playbooks/tasks/check-sync-gateway.yml
@@ -10,4 +10,4 @@
   shell: /sbin/initctl status sync_gateway
   register: output
   failed_when: output.stdout | search("dead")
-  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6")  or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6")  or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"

--- a/libraries/provision/ansible/playbooks/tasks/check-sync-gateway.yml
+++ b/libraries/provision/ansible/playbooks/tasks/check-sync-gateway.yml
@@ -10,4 +10,4 @@
   shell: /sbin/initctl status sync_gateway
   register: output
   failed_when: output.stdout | search("dead")
-  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6")  or ansible_distribution == "RedHat"
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6")  or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"

--- a/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config.yml
+++ b/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config.yml
@@ -1,10 +1,10 @@
 - name: SYNC GATEWAY | Copy sync gateway config to host
   become: yes
-  template: src={{ sync_gateway_config_filepath }} dest=/opt/sync_gateway/etc/sync_gateway.json owner=sync_gateway group=sync_gateway mode=0644 force=true
+  template: src={{ sync_gateway_config_filepath }} dest=/home/sync_gateway/syn_gateway.json owner=sync_gateway group=sync_gateway mode=0644 force=true
 
 - name: SYNC GATEWAY | Check deployed config
   become: yes
-  shell: cat /opt/sync_gateway/etc/sync_gateway.json
+  shell: cat /home/sync_gateway/syn_gateway.json
   register: out
 
 - name: SYNC GATEWAY | Print deployed config

--- a/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config.yml
+++ b/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config.yml
@@ -1,10 +1,10 @@
 - name: SYNC GATEWAY | Copy sync gateway config to host
   become: yes
-  template: src={{ sync_gateway_config_filepath }} dest=/home/sync_gateway/sync_gateway.json owner=sync_gateway group=sync_gateway mode=0644 force=true
+  template: src={{ sync_gateway_config_filepath }} dest=/opt/sync_gateway/etc/sync_gateway.json owner=sync_gateway group=sync_gateway mode=0644 force=true
 
 - name: SYNC GATEWAY | Check deployed config
   become: yes
-  shell: cat /home/sync_gateway/sync_gateway.json
+  shell: cat /opt/sync_gateway/etc/sync_gateway.json
   register: out
 
 - name: SYNC GATEWAY | Print deployed config

--- a/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config.yml
+++ b/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config.yml
@@ -1,10 +1,10 @@
 - name: SYNC GATEWAY | Copy sync gateway config to host
   become: yes
-  template: src={{ sync_gateway_config_filepath }} dest=/home/sync_gateway/syn_gateway.json owner=sync_gateway group=sync_gateway mode=0644 force=true
+  template: src={{ sync_gateway_config_filepath }} dest=/home/sync_gateway/sync_gateway.json owner=sync_gateway group=sync_gateway mode=0644 force=true
 
 - name: SYNC GATEWAY | Check deployed config
   become: yes
-  shell: cat /home/sync_gateway/syn_gateway.json
+  shell: cat /home/sync_gateway/sync_gateway.json
   register: out
 
 - name: SYNC GATEWAY | Print deployed config

--- a/libraries/provision/ansible/playbooks/tasks/remove-sg-accel.yml
+++ b/libraries/provision/ansible/playbooks/tasks/remove-sg-accel.yml
@@ -6,7 +6,7 @@
 
 - name: SG ACCEL | Stop sg_accel for CentOS 6
   shell: /sbin/initctl stop sg_accel
-  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6")  or ansible_distribution == "RedHat"
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6")  or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
   ignore_errors: yes
 
 # Remove sg_accel package

--- a/libraries/provision/ansible/playbooks/tasks/remove-sg-accel.yml
+++ b/libraries/provision/ansible/playbooks/tasks/remove-sg-accel.yml
@@ -6,7 +6,7 @@
 
 - name: SG ACCEL | Stop sg_accel for CentOS 6
   shell: /sbin/initctl stop sg_accel
-  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6")  or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6")  or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
   ignore_errors: yes
 
 # Remove sg_accel package

--- a/libraries/provision/ansible/playbooks/tasks/remove-sync-gateway.yml
+++ b/libraries/provision/ansible/playbooks/tasks/remove-sync-gateway.yml
@@ -6,7 +6,7 @@
 
 - name: SYNC GATEWAY | Stop sync_gateway for CentOS 6
   shell: /sbin/initctl stop sync_gateway
-  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6") or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6") or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
   ignore_errors: yes
 
 # Remove sync_gateway package

--- a/libraries/provision/ansible/playbooks/tasks/remove-sync-gateway.yml
+++ b/libraries/provision/ansible/playbooks/tasks/remove-sync-gateway.yml
@@ -6,7 +6,7 @@
 
 - name: SYNC GATEWAY | Stop sync_gateway for CentOS 6
   shell: /sbin/initctl stop sync_gateway
-  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6") or ansible_distribution == "RedHat"
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6") or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
   ignore_errors: yes
 
 # Remove sync_gateway package

--- a/libraries/provision/ansible/playbooks/tasks/stop-sg-accel.yml
+++ b/libraries/provision/ansible/playbooks/tasks/stop-sg-accel.yml
@@ -7,7 +7,7 @@
 - name: SG ACCEL | stop sg_accel for CentOS 6
   become: yes
   shell: /sbin/initctl stop sg_accel
-  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6") or ansible_distribution == "RedHat"
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6") or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
 
 - name: SG ACCEL | verify sg_accel not listening on port
   become: yes

--- a/libraries/provision/ansible/playbooks/tasks/stop-sg-accel.yml
+++ b/libraries/provision/ansible/playbooks/tasks/stop-sg-accel.yml
@@ -7,7 +7,7 @@
 - name: SG ACCEL | stop sg_accel for CentOS 6
   become: yes
   shell: /sbin/initctl stop sg_accel
-  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6") or ansible_distribution == "RedHat" or ansible_distribution == "Amazon"
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6") or ansible_distribution == "RedHat" or ansible_distribution == "Amazon" or ansible_distribution == "Ubuntu"
 
 - name: SG ACCEL | verify sg_accel not listening on port
   become: yes

--- a/libraries/provision/ansible/playbooks/tasks/stop-sync-gateway.yml
+++ b/libraries/provision/ansible/playbooks/tasks/stop-sync-gateway.yml
@@ -2,7 +2,7 @@
 - name: SYNC GATEWAY | Stop sync_gateway service
   become: yes
   service: name=sync_gateway state=stopped
-  when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "7") or (ansible_distribution == "Amazon")
 
 - name: SYNC GATEWAY | Stop sync_gateway for CentOS 6
   become: yes

--- a/libraries/provision/ansible/playbooks/tasks/stop-sync-gateway.yml
+++ b/libraries/provision/ansible/playbooks/tasks/stop-sync-gateway.yml
@@ -2,7 +2,7 @@
 - name: SYNC GATEWAY | Stop sync_gateway service
   become: yes
   service: name=sync_gateway state=stopped
-  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "7") or (ansible_distribution == "Amazon")
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "7") or (ansible_distribution == "Amazon") or (ansible_distribution == "Ubuntu")
 
 - name: SYNC GATEWAY | Stop sync_gateway for CentOS 6
   become: yes

--- a/libraries/provision/install_sync_gateway.py
+++ b/libraries/provision/install_sync_gateway.py
@@ -16,10 +16,10 @@ class SyncGatewayConfig:
     def __init__(self,
                  commit,
                  version_number,
+                 build_number,
                  config_path,
                  build_flags,
-                 skip_bucketcreation,
-                 build_number=None):
+                 skip_bucketcreation):
 
         self._version_number = version_number
         self._build_number = build_number
@@ -212,35 +212,6 @@ def get_buckets_from_sync_gateway_config(sync_gateway_config_path):
     if os.path.exists(temp_config_path):
         os.remove(temp_config_path)
     return bucket_name_set
-
-
-def resolve_sg_mobile_url(sg_version):
-    """
-    Resolve a download URL for the corresponding package to given
-    version on http://cbmobile-packages.s3.amazonaws.com (an S3 bucket
-    for couchbase mobile that mirrors released couchbase server versions)
-
-    Given:
-
-    version - the version without any build number information, eg 4.5.0
-
-    Return the base_url of the package download URL (everything except the filename)
-
-    """
-    released_versions = {
-        "1.2.0": "83",
-        "1.2.1": "4",
-        "1.3.0": "274",
-        "1.3.1": "16",
-        "1.4.0": "2",
-        "1.4.1": "3",
-        "1.5.0": "594"
-    }
-    build_number = released_versions[sg_version]
-    base_url = "http://cbmobile-packages.s3.amazonaws.com"
-    sg_package_name = "couchbase-sync-gateway-enterprise_{}-{}_x86_64.rpm".format(sg_version, build_number)
-    sgaccel_package_name = "couchbase-sg-accel-enterprise_{}-{}_x86_64.rpm".format(sg_version, build_number)
-    return base_url, sg_package_name, sgaccel_package_name
 
 
 if __name__ == "__main__":

--- a/libraries/provision/install_sync_gateway.py
+++ b/libraries/provision/install_sync_gateway.py
@@ -16,31 +16,13 @@ class SyncGatewayConfig:
     def __init__(self,
                  commit,
                  version_number,
-                 build_number,
                  config_path,
                  build_flags,
-                 skip_bucketcreation):
+                 skip_bucketcreation,
+                 build_number=None):
 
         self._version_number = version_number
         self._build_number = build_number
-        self._valid_versions = [
-            "1.1.0",
-            "1.1.1",
-            "1.2.0",
-            "1.2.1",
-            "1.3.0",
-            "1.3.1",
-            "1.3.1.2",
-            "1.4.0",
-            "1.4",
-            "1.4.0.1",
-            "1.4.0.2",
-            "1.4.1",
-            "1.4.1.1",
-            "1.4.2",
-            "1.5.0"
-        ]
-
         self.commit = commit
         self.build_flags = build_flags
         self.config_path = config_path
@@ -230,6 +212,35 @@ def get_buckets_from_sync_gateway_config(sync_gateway_config_path):
     if os.path.exists(temp_config_path):
         os.remove(temp_config_path)
     return bucket_name_set
+
+
+def resolve_sg_mobile_url(sg_version):
+    """
+    Resolve a download URL for the corresponding package to given
+    version on http://cbmobile-packages.s3.amazonaws.com (an S3 bucket
+    for couchbase mobile that mirrors released couchbase server versions)
+
+    Given:
+
+    version - the version without any build number information, eg 4.5.0
+
+    Return the base_url of the package download URL (everything except the filename)
+
+    """
+    released_versions = {
+        "1.2.0": "83",
+        "1.2.1": "4",
+        "1.3.0": "274",
+        "1.3.1": "16",
+        "1.4.0": "2",
+        "1.4.1": "3",
+        "1.5.0": "594"
+    }
+    build_number = released_versions[sg_version]
+    base_url = "http://cbmobile-packages.s3.amazonaws.com"
+    sg_package_name = "couchbase-sync-gateway-enterprise_{}-{}_x86_64.rpm".format(sg_version, build_number)
+    sgaccel_package_name = "couchbase-sg-accel-enterprise_{}-{}_x86_64.rpm".format(sg_version, build_number)
+    return base_url, sg_package_name, sgaccel_package_name
 
 
 if __name__ == "__main__":

--- a/testsuites/syncgateway/functional/tests/test_attachments.py
+++ b/testsuites/syncgateway/functional/tests/test_attachments.py
@@ -13,7 +13,6 @@ from keywords import document
 from keywords import attachment
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.attachments
 @pytest.mark.basicauth
@@ -89,7 +88,6 @@ def test_attachment_revpos_when_ancestor_unavailable(params_from_base_test_setup
     )
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.attachments
 @pytest.mark.session

--- a/testsuites/syncgateway/functional/tests/test_changes_backfill.py
+++ b/testsuites/syncgateway/functional/tests/test_changes_backfill.py
@@ -209,7 +209,6 @@ def test_backfill_channels_oneshot_changes(params_from_base_test_setup, sg_conf_
     assert len(user_b_changes["results"]) == 0
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.session
@@ -439,7 +438,6 @@ def test_backfill_channels_oneshot_limit_changes(params_from_base_test_setup, sg
     assert len(user_b_changes_after_grant_four["results"]) == 0
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.session
@@ -657,7 +655,6 @@ def test_awaken_backfill_channels_longpoll_changes_with_limit(params_from_base_t
     assert len(zero_results["results"]) == 0
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.access

--- a/testsuites/syncgateway/functional/tests/test_channels.py
+++ b/testsuites/syncgateway/functional/tests/test_channels.py
@@ -13,8 +13,6 @@ from keywords import userinfo
 from keywords import document
 
 
-@pytest.mark.sanity
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.session

--- a/testsuites/syncgateway/functional/tests/test_conflicts.py
+++ b/testsuites/syncgateway/functional/tests/test_conflicts.py
@@ -12,7 +12,6 @@ from keywords import userinfo
 from keywords import document
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.conflicts
 @pytest.mark.changes

--- a/testsuites/syncgateway/functional/tests/test_continuous.py
+++ b/testsuites/syncgateway/functional/tests/test_continuous.py
@@ -12,7 +12,6 @@ from keywords.utils import log_info
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.basicauth

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline.py
@@ -61,7 +61,6 @@ def test_online_default_rest(params_from_base_test_setup, sg_conf_name, num_docs
 
 
 # Scenario 2
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
 @pytest.mark.basicauth
@@ -103,7 +102,6 @@ def test_offline_false_config_rest(params_from_base_test_setup, sg_conf_name, nu
 
 
 # Scenario 3
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
 @pytest.mark.basicauth
@@ -152,7 +150,6 @@ def test_online_to_offline_check_503(params_from_base_test_setup, sg_conf_name, 
 
 # Scenario 5 - continuous
 # NOTE: Was disabled for di
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
 @pytest.mark.basicauth
@@ -230,7 +227,6 @@ def test_online_to_offline_changes_feed_controlled_close_continuous(params_from_
 
 
 # Scenario 6 - longpoll
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
 @pytest.mark.changes
@@ -296,7 +292,6 @@ def test_online_to_offline_continous_changes_feed_controlled_close_sanity_mulitp
 
 
 # Scenario 6 - longpoll
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
 @pytest.mark.changes
@@ -359,7 +354,6 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll_sanity(params_
 
 
 # Scenario 6 - longpoll
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
 @pytest.mark.changes
@@ -431,7 +425,6 @@ def test_online_to_offline_longpoll_changes_feed_controlled_close_sanity_mulitpl
 
 # Scenario 6 - longpoll
 # NOTE: Was disabled for di
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
 @pytest.mark.changes
@@ -535,7 +528,6 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll(params_from_ba
 
 # Scenario 6
 # NOTE: Was disabled for di
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
 @pytest.mark.basicauth
@@ -584,7 +576,6 @@ def test_offline_true_config_bring_online(params_from_base_test_setup, sg_conf_n
 
 
 # Scenario 14
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
 @pytest.mark.basicauth
@@ -630,7 +621,6 @@ def test_db_offline_tap_loss_sanity(params_from_base_test_setup, sg_conf_name, n
 
 # Scenario 11
 # NOTE: Was disabled for di
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
 @pytest.mark.basicauth
@@ -685,7 +675,6 @@ def test_db_delayed_online(params_from_base_test_setup, sg_conf_name, num_docs):
     assert len(errors) == 0
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
 @pytest.mark.basicauth

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline_resync.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline_resync.py
@@ -150,7 +150,6 @@ def test_bucket_online_offline_resync_sanity(params_from_base_test_setup, sg_con
 # put DB offline, run _resync, attempt to bring DB online while _resync is running,
 # expected result _online will fail with status 503, when _resync is complete,
 # attempt to bring DB _online, expected result _online will succeed, return status 200.
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
 @pytest.mark.parametrize("sg_conf_name, num_users, num_docs, num_revisions", [
@@ -335,7 +334,6 @@ def test_bucket_online_offline_resync_with_online(params_from_base_test_setup, s
 # #13
 # With DB running a _resync, make REST API call to get DB runtime details /db/,
 # expected result 'state' property with value 'Resyncing' is returned.
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
 @pytest.mark.parametrize("sg_conf_name, num_users, num_docs, num_revisions", [

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline_webhooks.py
@@ -101,7 +101,6 @@ def test_db_online_offline_webhooks_offline(params_from_base_test_setup, sg_conf
 
 
 # implements scenarios: 21
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
 @pytest.mark.webhooks

--- a/testsuites/syncgateway/functional/tests/test_log_rotation.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation.py
@@ -114,7 +114,6 @@ def test_log_rotation_default_values(params_from_base_test_setup, sg_conf_name):
     os.remove(temp_conf)
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.logging
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation"])
@@ -166,7 +165,6 @@ def test_log_logKeys_string(params_from_base_test_setup, sg_conf_name):
     pytest.fail("SG shouldn't be started!!!!")
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.logging
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation"])
@@ -213,7 +211,6 @@ def test_log_nondefault_logKeys_set(params_from_base_test_setup, sg_conf_name):
     os.remove(temp_conf)
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.logging
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation"])
@@ -280,7 +277,6 @@ def test_log_maxage_10_timestamp_ignored(params_from_base_test_setup, sg_conf_na
 
 
 # https://github.com/couchbase/sync_gateway/issues/2221
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.logging
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation"])
@@ -333,7 +329,6 @@ def test_log_rotation_invalid_path(params_from_base_test_setup, sg_conf_name):
     pytest.fail("SG shouldn't be started!!!!")
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.logging
 @pytest.mark.skip(reason="This causes paramiko to timeout intermittently. Need to revisit.")
@@ -392,7 +387,6 @@ def test_log_200mb(params_from_base_test_setup, sg_conf_name):
     os.remove(temp_conf)
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.logging
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation"])
@@ -449,7 +443,6 @@ def test_log_number_backups(params_from_base_test_setup, sg_conf_name):
 
 
 # https://github.com/couchbase/sync_gateway/issues/2222
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.logging
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation"])
@@ -510,7 +503,6 @@ def test_log_rotation_negative(params_from_base_test_setup, sg_conf_name):
 
 
 # https://github.com/couchbase/sync_gateway/issues/2225
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.logging
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation"])
@@ -568,7 +560,6 @@ def test_log_maxbackups_0(params_from_base_test_setup, sg_conf_name):
     os.remove(temp_conf)
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.logging
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation"])

--- a/testsuites/syncgateway/functional/tests/test_longpoll.py
+++ b/testsuites/syncgateway/functional/tests/test_longpoll.py
@@ -18,7 +18,6 @@ from keywords import document
 from keywords import userinfo
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.basicauth
@@ -134,7 +133,6 @@ def test_longpoll_changes_sanity(params_from_base_test_setup, sg_conf_name, num_
     verify_same_docs(expected_num_docs=num_docs, doc_dict_one=docs_in_changes, doc_dict_two=abc_doc_pusher.cache)
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.basicauth
@@ -371,7 +369,6 @@ def test_longpoll_awaken_doc_add_update(params_from_base_test_setup, sg_conf_nam
         assert rev_from_change == 2
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.basicauth
@@ -599,7 +596,6 @@ def test_longpoll_awaken_channels(params_from_base_test_setup, sg_conf_name):
         assert andy_changes["results"][0]["changes"][0]["rev"].startswith("2-")
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.basicauth
@@ -775,7 +771,6 @@ def test_longpoll_awaken_roles(params_from_base_test_setup, sg_conf_name):
         assert andy_changes["results"][0]["id"] == "abc_doc_0"
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.basicauth
@@ -894,7 +889,6 @@ def test_longpoll_awaken_via_sync_access(params_from_base_test_setup, sg_conf_na
     assert len(andy_changes["results"]) == 0
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.basicauth

--- a/testsuites/syncgateway/functional/tests/test_multiple_dbs.py
+++ b/testsuites/syncgateway/functional/tests/test_multiple_dbs.py
@@ -10,7 +10,6 @@ from keywords.SyncGateway import sync_gateway_config_path_for_mode
 from keywords.utils import log_info
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.basicauth
 @pytest.mark.channel

--- a/testsuites/syncgateway/functional/tests/test_openid_connect.py
+++ b/testsuites/syncgateway/functional/tests/test_openid_connect.py
@@ -229,7 +229,6 @@ def test_openidconnect_basic_test(params_from_base_test_setup, sg_conf_name, is_
         id_tokens.append(id_token_refresh)
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.oidc
 @pytest.mark.parametrize("sg_conf_name", [
@@ -278,7 +277,6 @@ def test_openidconnect_notauthenticated(params_from_base_test_setup, sg_conf_nam
     assert response.status_code == 401
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.oidc
 @pytest.mark.parametrize("sg_conf_name", [
@@ -318,7 +316,6 @@ def test_openidconnect_oidc_challenge_invalid_provider_name(params_from_base_tes
     assert response.status_code == 400
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.oidc
 @pytest.mark.parametrize("sg_conf_name", [
@@ -361,7 +358,6 @@ def test_openidconnect_no_session(params_from_base_test_setup, sg_conf_name):
     assert "Set-Cookie" not in response.headers
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.oidc
 @pytest.mark.parametrize("sg_conf_name", [
@@ -431,7 +427,6 @@ def test_openidconnect_expired_token(params_from_base_test_setup, sg_conf_name):
     assert resp.status_code != 200, "Expected non-200 response"
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.oidc
 @pytest.mark.parametrize("sg_conf_name", [
@@ -485,7 +480,6 @@ def test_openidconnect_negative_token_expiry(params_from_base_test_setup, sg_con
     assert response.status_code == 500
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.oidc
 @pytest.mark.parametrize("sg_conf_name", [
@@ -565,7 +559,6 @@ def test_openidconnect_garbage_token(params_from_base_test_setup, sg_conf_name):
     assert resp.status_code != 200, "Expected non-200 response"
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.oidc
 @pytest.mark.parametrize("sg_conf_name", [
@@ -605,7 +598,6 @@ def test_openidconnect_invalid_scope(params_from_base_test_setup, sg_conf_name):
     raise Exception("Expected HTTPError since we are using invalid scope")
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.oidc
 @pytest.mark.parametrize("sg_conf_name", [
@@ -666,7 +658,6 @@ def test_openidconnect_small_scope(params_from_base_test_setup, sg_conf_name):
     assert "email" not in decoded_id_token.keys()
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.oidc
 @pytest.mark.parametrize("sg_conf_name", [
@@ -729,7 +720,6 @@ def test_openidconnect_large_scope(params_from_base_test_setup, sg_conf_name):
     assert "nickname" in decoded_id_token.keys()
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.oidc
 @pytest.mark.parametrize("sg_conf_name", [

--- a/testsuites/syncgateway/functional/tests/test_sync-function-reject.py
+++ b/testsuites/syncgateway/functional/tests/test_sync-function-reject.py
@@ -12,7 +12,6 @@ from keywords import document
 from keywords import attachment
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.attachments
 @pytest.mark.session

--- a/testsuites/syncgateway/functional/tests/test_sync.py
+++ b/testsuites/syncgateway/functional/tests/test_sync.py
@@ -16,7 +16,6 @@ from keywords.SyncGateway import sync_gateway_config_path_for_mode
 
 
 # https://github.com/couchbase/sync_gateway/issues/1524
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sync
 @pytest.mark.basicauth
@@ -401,7 +400,6 @@ def test_sync_sanity_backfill(params_from_base_test_setup, sg_conf_name):
     verify_changes(dj_0, expected_num_docs=number_of_docs_per_pusher, expected_num_revisions=0, expected_docs=kdwb_docs)
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sync
 @pytest.mark.role

--- a/testsuites/syncgateway/functional/tests/test_ttl.py
+++ b/testsuites/syncgateway/functional/tests/test_ttl.py
@@ -135,7 +135,6 @@ def test_numeric_expiry_as_ttl(params_from_base_test_setup, sg_conf_name):
     assert doc_exp_10_result["_id"] == "exp_10"
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.ttl
 @pytest.mark.session
@@ -223,7 +222,6 @@ def test_string_expiry_as_ttl(params_from_base_test_setup, sg_conf_name):
     assert doc_exp_10_result["_id"] == "exp_10"
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.ttl
 @pytest.mark.session
@@ -315,7 +313,6 @@ def test_numeric_expiry_as_unix_date(params_from_base_test_setup, sg_conf_name):
     assert doc_exp_years_result["_id"] == "exp_years"
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.ttl
 @pytest.mark.session
@@ -411,7 +408,6 @@ def test_string_expiry_as_unix_date(params_from_base_test_setup, sg_conf_name):
     assert doc_exp_years_result["_id"] == "exp_years"
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.ttl
 @pytest.mark.session
@@ -503,7 +499,6 @@ def test_string_expiry_as_iso_8601_date(params_from_base_test_setup, sg_conf_nam
     assert doc_exp_years_result["_id"] == "exp_years"
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.ttl
 @pytest.mark.session
@@ -571,7 +566,6 @@ def test_removing_expiry(params_from_base_test_setup, sg_conf_name):
     assert doc_exp_10_result["_id"] == "exp_10"
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.ttl
 @pytest.mark.session
@@ -661,7 +655,6 @@ def test_rolling_ttl_expires(params_from_base_test_setup, sg_conf_name):
     assert doc_exp_10_result["_id"] == "exp_10"
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.ttl
 @pytest.mark.session
@@ -751,7 +744,6 @@ def test_rolling_ttl_remove_expirary(params_from_base_test_setup, sg_conf_name):
     )
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.ttl
 @pytest.mark.session

--- a/testsuites/syncgateway/functional/tests/test_users_channels.py
+++ b/testsuites/syncgateway/functional/tests/test_users_channels.py
@@ -72,7 +72,6 @@ def test_multiple_users_multiple_channels(params_from_base_test_setup, sg_conf_n
     verify_changes([traun], expected_num_docs=num_docs_seth + num_docs_adam + num_docs_traun, expected_num_revisions=0, expected_docs=traun_expected_docs)
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.basicauth
 @pytest.mark.channel
@@ -125,7 +124,6 @@ def test_muliple_users_single_channel(params_from_base_test_setup, sg_conf_name)
     verify_changes([seth, adam, traun], expected_num_docs=num_docs_seth + num_docs_adam + num_docs_traun, expected_num_revisions=0, expected_docs=all_docs)
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.basicauth
 @pytest.mark.channel
@@ -172,7 +170,6 @@ def test_single_user_multiple_channels(params_from_base_test_setup, sg_conf_name
     log_info("TIME:{}s".format(end - start))
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.basicauth
 @pytest.mark.channel

--- a/testsuites/syncgateway/functional/tests/test_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_webhooks.py
@@ -86,7 +86,6 @@ def test_webhooks(params_from_base_test_setup, sg_conf_name, num_users, num_chan
     assert expected_events == received_events
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
 @pytest.mark.session

--- a/testsuites/syncgateway/functional/tests/test_xattrs.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs.py
@@ -31,7 +31,6 @@ SG_OP_SLEEP = 0.001
 SDK_OP_SLEEP = 0.05
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
 @pytest.mark.session
@@ -153,7 +152,6 @@ def test_olddoc_nil(params_from_base_test_setup, sg_conf_name):
     assert len(errors) == 0
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
 @pytest.mark.changes
@@ -387,7 +385,6 @@ def test_on_demand_import_of_external_updates(params_from_base_test_setup, sg_co
     assert sg_updated_rev.startswith("3-")
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
 @pytest.mark.session
@@ -512,7 +509,6 @@ def test_offline_processing_of_external_updates(params_from_base_test_setup, sg_
     sg_client.verify_docs_in_changes(url=sg_url, db=sg_db, expected_docs=docs_to_verify_in_changes, auth=seth_auth)
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
 @pytest.mark.session
@@ -809,7 +805,6 @@ def test_purge(params_from_base_test_setup, sg_conf_name, use_multiple_channels)
         )
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
 @pytest.mark.changes
@@ -908,7 +903,6 @@ def test_sdk_does_not_see_sync_meta(params_from_base_test_setup, sg_conf_name):
             assert att_bytes == local_bytes
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
 @pytest.mark.changes
@@ -1115,7 +1109,6 @@ def test_sg_sdk_interop_unique_docs(params_from_base_test_setup, sg_conf_name):
     assert len(sdk_doc_delete_scratch_pad) == 0
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
 @pytest.mark.changes
@@ -1362,7 +1355,6 @@ def test_sg_sdk_interop_shared_docs(params_from_base_test_setup,
     verify_sdk_deletes(sdk_client, all_doc_ids)
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
 @pytest.mark.changes
@@ -1997,7 +1989,6 @@ def verify_doc_ids_in_sdk_get_multi(response, expected_number_docs, expected_ids
     assert len(expected_ids_scratch_pad) == 0
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
 @pytest.mark.changes

--- a/testsuites/syncgateway/functional/tests/test_xattrs.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs.py
@@ -385,6 +385,7 @@ def test_on_demand_import_of_external_updates(params_from_base_test_setup, sg_co
     assert sg_updated_rev.startswith("3-")
 
 
+@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
 @pytest.mark.session


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:
- Adds ability to run SG tests against Amazon AMI and Ubuntu
- Cleaned up sanity tags - 57 sanity tests.
- This does not provide provisioning capability for Amazon AMI and Ubuntu VMs.

