### PR TITLE
fixed delete RBAC user on delete bucket issue

### DIFF
--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -270,7 +270,7 @@ class CouchbaseServer:
         except HTTPError as h:
             log_info("resp code: {}; error: {}".format(resp, h))
             if '404 Client Error: Object Not Found for url' in h.message:
-                log_info(" Rbac user does not exist, no need to delete")
+                log_info("RBAC user does not exist, no need to delete RBAC bucket user {}".format(bucketname))
             else:
                 raise RBACUserDeletionError(h)
 

--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -269,7 +269,10 @@ class CouchbaseServer:
             resp.raise_for_status()
         except HTTPError as h:
             log_info("resp code: {}; error: {}".format(resp, h))
-            raise RBACUserDeletionError(h)
+            if '404 Client Error: Object Not Found for url' in h.message:
+                log_info(" Rbac user does not exist, no need to delete")
+            else:
+                raise RBACUserDeletionError(h)
 
     def _get_mem_total_lowest(self, server_info):
         # Workaround for https://github.com/couchbaselabs/mobile-testkit/issues/709


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Fixed to ignore if RBAC user is deleted already

