### PR TITLE
Move sg stop to suite teardown from test teardown

### DIFF
--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -240,7 +240,6 @@ def params_from_base_suite_setup(request):
     c.stop_sg_and_accel()
 
 
-
 # This is called before each test and will yield the dictionary to each test that references the method
 # as a parameter to the test method
 @pytest.fixture(scope="function")

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -235,6 +235,11 @@ def params_from_base_suite_setup(request):
 
     log_info("Tearing down 'params_from_base_suite_setup' ...")
 
+    # Stop all sync_gateway and sg_accels as test finished
+    c = cluster.Cluster(cluster_config)
+    c.stop_sg_and_accel()
+
+
 
 # This is called before each test and will yield the dictionary to each test that references the method
 # as a parameter to the test method
@@ -298,6 +303,3 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
 
     assert len(errors) == 0
-
-    # Stop all sync_gateway and sg_accels as test finished
-    c.stop_sg_and_accel()

--- a/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
@@ -129,6 +129,10 @@ def params_from_base_suite_setup(request):
 
     log_info("Tearing down 'params_from_base_suite_setup' ...")
 
+    # Stop all sync_gateway and sg_accels as test finished
+    c = cluster.Cluster(cluster_config)
+    c.stop_sg_and_accel()
+
 
 # This is called before each test and will yield the cluster_config to each test in the file
 # After each test_* function, execution will continue from the yield a pull logs on failure
@@ -165,6 +169,3 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
 
     assert len(errors) == 0
-
-    # Stop all sync_gateway and sg_accels as test finished
-    c.stop_sg_and_accel()

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
@@ -134,6 +134,10 @@ def params_from_base_suite_setup(request):
 
     log_info("Tearing down 'params_from_base_suite_setup' ...")
 
+    # Stop all sync_gateway and sg_accels as test finished
+    c = Cluster(cluster_config)
+    c.stop_sg_and_accel()
+
 
 # This is called before each test and will yield the dictionary to each test that references the method
 # as a parameter to the test method
@@ -170,6 +174,3 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
 
     assert len(errors) == 0
-
-    # Stop all sync_gateway and sg_accels as test finished
-    c.stop_sg_and_accel()

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
@@ -132,6 +132,10 @@ def params_from_base_suite_setup(request):
 
     log_info("Tearing down 'params_from_base_suite_setup' ...")
 
+    # Stop all sync_gateway and sg_accels as test finished
+    c = cluster.Cluster(cluster_config)
+    c.stop_sg_and_accel()
+
 
 # This is called before each test and will yield the dictionary to each test that references the method
 # as a parameter to the test method
@@ -168,5 +172,4 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
 
     assert len(errors) == 0
 
-    # Stop all sync_gateway and sg_accels as test finished
-    c.stop_sg_and_accel()
+

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
@@ -171,5 +171,3 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
 
     assert len(errors) == 0
-
-

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -131,6 +131,10 @@ def params_from_base_suite_setup(request):
 
     log_info("Tearing down 'params_from_base_suite_setup' ...")
 
+    # Stop all sync_gateway and sg_accels as test finished
+    c = cluster.Cluster(cluster_config)
+    c.stop_sg_and_accel()
+
 
 # This is called before each test and will yield the dictionary to each test that references the method
 # as a parameter to the test method
@@ -165,5 +169,4 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
 
     assert len(errors) == 0
 
-    # Stop all sync_gateway and sg_accels as test finished
-    c.stop_sg_and_accel()
+

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -168,5 +168,3 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
 
     assert len(errors) == 0
-
-


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:
- The sg/sgaccel stop was added to test teardown causing test failures
- They should be in suite teardown instead
- The change has been tested on jenkins already
