### PR TITLE
fixed replicas disabled and made upgrade cbl test not to run on windows

### DIFF
--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -364,8 +364,7 @@ class CouchbaseServer:
             "ramQuotaMB": str(ram_quota_mb),
             "authType": "sasl",
             "bucketType": "couchbase",
-            "flushEnabled": "1",
-            "replicaNumber": 0
+            "flushEnabled": "1"
         }
 
         if server_major_version <= 4:

--- a/testsuites/listener/shared/client_sg/test_upgrade.py
+++ b/testsuites/listener/shared/client_sg/test_upgrade.py
@@ -35,7 +35,7 @@ def test_upgrade_cbl(setup_client_syncgateway_test):
     liteserv_platform = setup_client_syncgateway_test["liteserv_platform"]
     liteserv_version = setup_client_syncgateway_test["liteserv_version"]
 
-    if (liteserv_platform.lower() == "android" or liteserv_platform.lower() == "net-msft") and device_enabled:
+    if liteserv_platform.lower() == "android" or liteserv_platform.lower() == "net-msft" or device_enabled:
         # There is a signature match issue on Android and older version ios does not have app for devices
         pytest.skip('upgrade lite serv app does not work on Android and there is no app for ios device created' +
                     ' for older version, so skipping the test')

--- a/testsuites/listener/shared/client_sg/test_upgrade.py
+++ b/testsuites/listener/shared/client_sg/test_upgrade.py
@@ -35,8 +35,8 @@ def test_upgrade_cbl(setup_client_syncgateway_test):
     liteserv_platform = setup_client_syncgateway_test["liteserv_platform"]
     liteserv_version = setup_client_syncgateway_test["liteserv_version"]
 
-    if liteserv_platform.lower() == "android" and device_enabled:
-        # There is a signature match issue on Android and older version does not have app for devices
+    if (liteserv_platform.lower() == "android" or liteserv_platform.lower() == "net-msft") and device_enabled:
+        # There is a signature match issue on Android and older version ios does not have app for devices
         pytest.skip('upgrade lite serv app does not work on Android and there is no app for ios device created' +
                     ' for older version, so skipping the test')
     sg_config = sync_gateway_config_path_for_mode("listener_tests/listener_tests", sg_mode)

--- a/testsuites/syncgateway/functional/tests/test_xattrs.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs.py
@@ -1763,7 +1763,7 @@ def delete_sg_docs(client, url, db, docs_to_delete, auth):
         except HTTPError as he:
             if ((he.response.status_code == 403 and str(he).startswith('403 Client Error: Forbidden for url:')) or
                 (he.response.status_code == 409 and str(he).startswith('409 Client Error: Conflict for url:')) or
-                    (he.response.status_code == 409 and str(he).startswith('404 Client Error: Not Found for url:'))):
+                    (he.response.status_code == 404 and str(he).startswith('404 Client Error: Not Found for url:'))):
                 # Doc may have been deleted by the SDK and GET fails for SG
                 # Conflict for url can happen in the following scenario:
                 # During concurrent deletes from SG and SDK,
@@ -2219,7 +2219,7 @@ def test_purge_and_view_compaction(params_from_base_test_setup, sg_conf_name):
 
     # This test should only run when using xattr meta storage
     if not xattrs_enabled or mode == "di":
-        pytest.skip('This test skipped XATTR tests require --xattrs flag or This test cannot run in DI mode')
+        pytest.skip('This test is di mode or xattrs not enabled')
 
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
     sg_admin_url = cluster_topology['sync_gateways'][0]['admin']


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- fixed replicas disabled -> made it enabled while resetting cluster
- Added condition to upgrade cbl test not to run on windows

