### PR TITLE
skipping tests which cannot run sg < 2.0

### DIFF
--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -288,6 +288,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     xattrs_enabled = params_from_base_suite_setup["xattrs_enabled"]
     sg_lb = params_from_base_suite_setup["sg_lb"]
     no_conflicts_enabled = params_from_base_suite_setup["no_conflicts_enabled"]
+    sync_gateway_version = params_from_base_suite_setup["sync_gateway_version"]
 
     test_name = request.node.name
 
@@ -318,7 +319,8 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         "cluster_topology": cluster_topology,
         "mode": mode,
         "xattrs_enabled": xattrs_enabled,
-        "no_conflicts_enabled": no_conflicts_enabled
+        "no_conflicts_enabled": no_conflicts_enabled,
+        "sync_gateway_version": sync_gateway_version
     }
 
     # Code after the yield will execute when each test finishes

--- a/testsuites/syncgateway/functional/tests/test_no_conflicts.py
+++ b/testsuites/syncgateway/functional/tests/test_no_conflicts.py
@@ -369,13 +369,15 @@ def test_migrate_conflicts_to_noConflicts(params_from_base_test_setup, sg_conf_n
     mode = params_from_base_test_setup["mode"]
     sg_url = topology["sync_gateways"][0]["public"]
     sg_admin_url = topology["sync_gateways"][0]["admin"]
+    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
     sg_db = "db"
+
     if revs_limit is None:
         revs_limit = 1000
     additional_updates = revs_limit
 
-    if no_conflicts_enabled:
-        pytest.skip('--no-conflicts is enabled, so skipping the test')
+    if no_conflicts_enabled or sync_gateway_version < "2.0":
+        pytest.skip('--no-conflicts is enabled and does not work with sg < 2.0 , so skipping the test')
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
     # 1. Start sg with default(i.e allow_conflicts=true)
     c = cluster.Cluster(cluster_config)
@@ -666,6 +668,11 @@ def test_revs_cache_size(params_from_base_test_setup, sg_conf_name, num_of_docs)
     sg_admin_url = topology["sync_gateways"][0]["admin"]
     sg_db = "db"
     retrieved_docs = num_of_docs / 2
+
+    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
+
+    if sync_gateway_version < "2.0":
+        pytest.skip('--no-conflicts is enabled and does not work with sg < 2.0 , so skipping the test')
 
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
     c = cluster.Cluster(cluster_config)


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- skipping 2 tests which cannot run sg < 2.0


