### PR TITLE
Fix/no conflicts flag

### DIFF
--- a/docker/testkit-net/sg_config_xattrs_blip.json
+++ b/docker/testkit-net/sg_config_xattrs_blip.json
@@ -10,9 +10,7 @@
             "bucket": "default",
             "password": "password",
             "enable_shared_bucket_access": true,
-            "unsupported": {
-                "replicator_2": true
-            },
+            {{ no_conflicts }}
             "users": {
                 "GUEST": {
                     "disabled": false,

--- a/keywords/SyncGateway.py
+++ b/keywords/SyncGateway.py
@@ -230,7 +230,7 @@ class SyncGateway:
             playbook_vars["xattrs"] = '"enable_shared_bucket_access": true,'
 
         if no_conflicts_enabled(cluster_config):
-            playbook_vars["no_conflicts"] = '"allow_conflicts": false'
+            playbook_vars["no_conflicts"] = '"allow_conflicts": false,'
         try:
             revs_limit = get_revs_limit(cluster_config)
             playbook_vars["revs_limit"] = '"revs_limit": {},'.format(revs_limit)

--- a/libraries/provision/install_sync_gateway.py
+++ b/libraries/provision/install_sync_gateway.py
@@ -124,7 +124,7 @@ def install_sync_gateway(cluster_config, sync_gateway_config, sg_ce=False, sg_pl
         playbook_vars["xattrs"] = '"enable_shared_bucket_access": true,'
 
     if no_conflicts_enabled(cluster_config):
-        playbook_vars["no_conflicts"] = '"allow_conflicts": false'
+        playbook_vars["no_conflicts"] = '"allow_conflicts": false,'
     try:
         revs_limit = get_revs_limit(cluster_config)
         playbook_vars["revs_limit"] = '"revs_limit": {},'.format(revs_limit)

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -151,7 +151,7 @@ class Cluster:
             playbook_vars["xattrs"] = '"enable_shared_bucket_access": true,'
 
         if no_conflicts_enabled(self._cluster_config):
-            playbook_vars["no_conflicts"] = '"allow_conflicts": false'
+            playbook_vars["no_conflicts"] = '"allow_conflicts": false,'
         try:
             revs_limit = get_revs_limit(self._cluster_config)
             playbook_vars["revs_limit"] = '"revs_limit": {},'.format(revs_limit)

--- a/libraries/testkit/sgaccel.py
+++ b/libraries/testkit/sgaccel.py
@@ -58,7 +58,7 @@ class SgAccel:
             playbook_vars["xattrs"] = '"enable_shared_bucket_access": true,'
 
         if no_conflicts_enabled(self.cluster_config):
-            playbook_vars["no_conflicts"] = '"allow_conflicts": false'
+            playbook_vars["no_conflicts"] = '"allow_conflicts": false,'
         try:
             revs_limit = get_revs_limit(self.cluster_config)
             playbook_vars["revs_limit"] = '"revs_limit": {},'.format(revs_limit)

--- a/libraries/testkit/syncgateway.py
+++ b/libraries/testkit/syncgateway.py
@@ -68,7 +68,7 @@ class SyncGateway:
             playbook_vars["xattrs"] = '"enable_shared_bucket_access": true,'
 
         if no_conflicts_enabled(self.cluster_config):
-            playbook_vars["no_conflicts"] = '"allow_conflicts": false'
+            playbook_vars["no_conflicts"] = '"allow_conflicts": false,'
         try:
             revs_limit = get_revs_limit(self.cluster_config)
             playbook_vars["revs_limit"] = '"revs_limit": {},'.format(revs_limit)
@@ -104,7 +104,7 @@ class SyncGateway:
             playbook_vars["xattrs"] = '"enable_shared_bucket_access": true,'
 
         if no_conflicts_enabled(self.cluster_config):
-            playbook_vars["no_conflicts"] = '"allow_conflicts": false'
+            playbook_vars["no_conflicts"] = '"allow_conflicts": false,'
         try:
             revs_limit = get_revs_limit(self.cluster_config)
             playbook_vars["revs_limit"] = '"revs_limit": {},'.format(revs_limit)

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_cc.json
@@ -12,9 +12,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_dcp_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_dcp_cc.json
@@ -12,9 +12,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_dcp_di.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_dcp_di.json
@@ -18,9 +18,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_di.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_di.json
@@ -17,9 +17,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets_cc.json
@@ -12,9 +12,7 @@
         "db1":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket-1",
             "username":"data-bucket-1",
@@ -23,9 +21,7 @@
         "db2":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "offline":false,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket-2",
@@ -35,9 +31,7 @@
         "db3":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "offline":false,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket-3",
@@ -47,9 +41,7 @@
         "db4":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket-4",
             "username":"data-bucket-4",

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets_di.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets_di.json
@@ -17,9 +17,7 @@
     "databases":{
         "db1":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket-1",
             "username":"data-bucket-1",

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_false_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_false_cc.json
@@ -12,9 +12,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "offline":false,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_false_di.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_false_di.json
@@ -17,9 +17,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "offline":false,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_true_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_true_cc.json
@@ -12,9 +12,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "offline":true,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_true_di.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_true_di.json
@@ -17,9 +17,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "offline":true,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_all_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_all_cc.json
@@ -12,9 +12,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_all_di.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_all_di.json
@@ -17,9 +17,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "channel_index":{
                 "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
                 "bucket":"index-bucket",

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_restricted_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_restricted_cc.json
@@ -12,9 +12,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_restricted_di.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_restricted_di.json
@@ -17,9 +17,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_invalid_db_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_invalid_db_cc.json
@@ -12,9 +12,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"non-existent-bucket",
             "username":"non-existent-bucket",

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_invalid_db_di.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_invalid_db_di.json
@@ -17,9 +17,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"non-existent-bucket",
             "username":"non-existent-bucket",

--- a/resources/sync_gateway_configs/custom_sync/access_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/access_cc.json
@@ -12,9 +12,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/custom_sync/access_di.json
+++ b/resources/sync_gateway_configs/custom_sync/access_di.json
@@ -18,9 +18,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/custom_sync/grant_access_one_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/grant_access_one_cc.json
@@ -12,9 +12,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/custom_sync/grant_access_one_di.json
+++ b/resources/sync_gateway_configs/custom_sync/grant_access_one_di.json
@@ -18,9 +18,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_access_sanity_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_access_sanity_cc.json
@@ -12,9 +12,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_access_sanity_di.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_access_sanity_di.json
@@ -18,9 +18,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_cc.json
@@ -12,9 +12,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_di.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_di.json
@@ -18,9 +18,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_one_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_one_cc.json
@@ -12,9 +12,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_one_di.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_one_di.json
@@ -18,9 +18,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_require_roles_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_require_roles_cc.json
@@ -12,9 +12,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_require_roles_di.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_require_roles_di.json
@@ -18,9 +18,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_role_sanity_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_role_sanity_cc.json
@@ -12,9 +12,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_role_sanity_di.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_role_sanity_di.json
@@ -18,9 +18,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/custom_sync/wake_changes_access_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/wake_changes_access_cc.json
@@ -12,9 +12,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/custom_sync/wake_changes_access_di.json
+++ b/resources/sync_gateway_configs/custom_sync/wake_changes_access_di.json
@@ -18,9 +18,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/custom_sync/wake_changes_roles_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/wake_changes_roles_cc.json
@@ -12,9 +12,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/custom_sync/wake_changes_roles_di.json
+++ b/resources/sync_gateway_configs/custom_sync/wake_changes_roles_di.json
@@ -18,9 +18,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_cc.json
@@ -6,9 +6,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_di.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_di.json
@@ -17,9 +17,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_revslimit_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_revslimit_cc.json
@@ -6,9 +6,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_revslimit_di.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_revslimit_di.json
@@ -17,9 +17,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "revs_limit": 100,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_user_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_user_cc.json
@@ -6,9 +6,7 @@
     "db": {
       {{ autoimport }}
       {{ xattrs }}
-      "unsupported": {
-        {{ no_conflicts }}
-      },
+      {{ no_conflicts }}
       "server": "{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
       "bucket": "data-bucket",
       "username":"data-bucket",

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_user_di.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_user_di.json
@@ -17,9 +17,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/listener_tests/multiple_sync_gateways_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/multiple_sync_gateways_cc.json
@@ -6,9 +6,7 @@
         "sg_db1":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket-1",
             "username":"data-bucket-1",
@@ -17,9 +15,7 @@
         "sg_db2":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket-2",
             "username":"data-bucket-2",

--- a/resources/sync_gateway_configs/listener_tests/multiple_sync_gateways_di.json
+++ b/resources/sync_gateway_configs/listener_tests/multiple_sync_gateways_di.json
@@ -17,9 +17,7 @@
     "databases":{
         "sg_db1":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket-1",
             "username":"data-bucket-1",

--- a/resources/sync_gateway_configs/log_rotation_cc.json
+++ b/resources/sync_gateway_configs/log_rotation_cc.json
@@ -16,9 +16,7 @@
     "db": {
       {{ autoimport }}
       {{ xattrs }}
-      "unsupported": {
-             {{ no_conflicts }}
-      },
+      {{ no_conflicts }}
       "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
       "bucket":"data-bucket",
       "username":"data-bucket",

--- a/resources/sync_gateway_configs/log_rotation_di.json
+++ b/resources/sync_gateway_configs/log_rotation_di.json
@@ -23,9 +23,7 @@
   "databases": {
     "db": {
       {{ xattrs }}
-      "unsupported": {
-          {{ no_conflicts }}
-      },
+      {{ no_conflicts }}
       "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
       "bucket":"data-bucket",
       "username":"data-bucket",

--- a/resources/sync_gateway_configs/missing_num_shards_di.json
+++ b/resources/sync_gateway_configs/missing_num_shards_di.json
@@ -17,9 +17,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/multiple_dbs_shared_data_shared_index_cc.json
+++ b/resources/sync_gateway_configs/multiple_dbs_shared_data_shared_index_cc.json
@@ -12,9 +12,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",
@@ -23,9 +21,7 @@
         "db2":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/multiple_dbs_shared_data_shared_index_di.json
+++ b/resources/sync_gateway_configs/multiple_dbs_shared_data_shared_index_di.json
@@ -33,9 +33,7 @@
         },
         "db2":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_cc.json
+++ b/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_cc.json
@@ -12,9 +12,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",
@@ -23,9 +21,7 @@
         "db2":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket-2",
             "username":"data-bucket-2",

--- a/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_di.json
+++ b/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_di.json
@@ -32,9 +32,7 @@
         },
         "db2":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket-2",
             "username":"data-bucket-2",

--- a/resources/sync_gateway_configs/performance/sync_gateway_default_performance_cc.json
+++ b/resources/sync_gateway_configs/performance/sync_gateway_default_performance_cc.json
@@ -11,9 +11,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/performance/sync_gateway_default_performance_di.json
+++ b/resources/sync_gateway_configs/performance/sync_gateway_default_performance_di.json
@@ -17,9 +17,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/reject_all_cc.json
+++ b/resources/sync_gateway_configs/reject_all_cc.json
@@ -11,9 +11,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/reject_all_di.json
+++ b/resources/sync_gateway_configs/reject_all_di.json
@@ -18,9 +18,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/sync_gateway_allow_conflicts_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_allow_conflicts_cc.json
@@ -11,14 +11,11 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
+            "allow_conflicts": true,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",
-            "password": "password",
-            "unsupported":
-            {
-               "allow_conflicts": true
-            }
+            "password": "password"
         }
     }
 }

--- a/resources/sync_gateway_configs/sync_gateway_allow_conflicts_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_allow_conflicts_di.json
@@ -17,9 +17,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                "allow_conflicts": true
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/sync_gateway_bucketshadow_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_bucketshadow_cc.json
@@ -9,9 +9,7 @@
     "log": ["*"],
     "databases":{
         "db":{
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/sync_gateway_bucketshadow_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_bucketshadow_di.json
@@ -16,9 +16,7 @@
   },
   "databases":{
     "db":{
-      "unsupported": {
-        {{ no_conflicts }}
-      },
+      {{ no_conflicts }}
       "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
       "bucket":"data-bucket",
       "username":"data-bucket",

--- a/resources/sync_gateway_configs/sync_gateway_bucketshadow_low_revs_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_bucketshadow_low_revs_cc.json
@@ -9,9 +9,7 @@
     "log": ["*"],
     "databases":{
         "db":{
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/sync_gateway_bucketshadow_low_revs_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_bucketshadow_low_revs_di.json
@@ -16,9 +16,7 @@
   },
   "databases":{
     "db":{
-      "unsupported": {
-        {{ no_conflicts }}
-      },
+      {{ no_conflicts }}
       "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
       "bucket":"data-bucket",
       "username":"data-bucket",

--- a/resources/sync_gateway_configs/sync_gateway_channel_cache_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_channel_cache_cc.json
@@ -7,9 +7,7 @@
         "db": {
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/sync_gateway_channel_cache_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_channel_cache_di.json
@@ -12,9 +12,7 @@
     "databases":{
         "db": {
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/sync_gateway_default_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_cc.json
@@ -11,9 +11,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/sync_gateway_default_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_di.json
@@ -18,9 +18,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_cc.json
@@ -11,9 +11,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_di.json
@@ -17,9 +17,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_revslimit50_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_revslimit50_cc.json
@@ -11,9 +11,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_revslimit50_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_revslimit50_di.json
@@ -17,9 +17,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/sync_gateway_default_low_revs_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_low_revs_cc.json
@@ -11,9 +11,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/sync_gateway_default_low_revs_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_low_revs_di.json
@@ -17,9 +17,7 @@
   "databases":{
     "db":{
       {{ xattrs }}
-      "unsupported": {
-        {{ no_conflicts }}
-      },
+      {{ no_conflicts }}
       "channel_index":{
         "num_shards":16,
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",

--- a/resources/sync_gateway_configs/sync_gateway_gzip_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_gzip_cc.json
@@ -11,9 +11,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/sync_gateway_gzip_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_gzip_di.json
@@ -17,9 +17,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/sync_gateway_openid_connect_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_openid_connect_cc.json
@@ -59,9 +59,7 @@
          },
         {{ autoimport }}
         {{ xattrs }}
-        "unsupported": {
-            {{ no_conflicts }}
-        },
+        {{ no_conflicts }}
         "unsupported": {
             "oidc_test_provider":{
                 "enabled":true

--- a/resources/sync_gateway_configs/sync_gateway_openid_connect_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_openid_connect_di.json
@@ -73,9 +73,7 @@
         }
       },
       {{ xattrs }}
-      "unsupported": {
-        {{ no_conflicts }}
-      },
+      {{ no_conflicts }}
       "unsupported": {
         "oidc_test_provider": {
           "enabled": true

--- a/resources/sync_gateway_configs/sync_gateway_openid_connect_unsigned_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_openid_connect_unsigned_cc.json
@@ -59,9 +59,7 @@
          },
         {{ autoimport }}
         {{ xattrs }}
-        "unsupported": {
-            {{ no_conflicts }}
-        },
+        {{ no_conflicts }}
         "unsupported": {
             "oidc_test_provider":{
                 "enabled":true,

--- a/resources/sync_gateway_configs/sync_gateway_openid_connect_unsigned_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_openid_connect_unsigned_di.json
@@ -65,9 +65,7 @@
             }
          },
         {{ xattrs }}
-        "unsupported": {
-            {{ no_conflicts }}
-        },
+        {{ no_conflicts }}
         "unsupported": {
             "oidc_test_provider":{
                 "enabled":true,

--- a/resources/sync_gateway_configs/sync_gateway_revs_conflict_configurable_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_revs_conflict_configurable_cc.json
@@ -11,9 +11,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             {{ revs_limit }}
             "rev_cache_size": 1000,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",

--- a/resources/sync_gateway_configs/sync_gateway_revs_conflict_configurable_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_revs_conflict_configurable_di.json
@@ -17,9 +17,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             {{ revs_limit }}
             "rev_cache_size": 1000,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",

--- a/resources/sync_gateway_configs/sync_gateway_sg_replicate_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_sg_replicate_cc.json
@@ -11,9 +11,7 @@
         "db1":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket-1",
             "username":"data-bucket-1",
@@ -22,9 +20,7 @@
         "db2":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket-2",
             "username":"data-bucket-2",

--- a/resources/sync_gateway_configs/sync_gateway_sg_replicate_continuous_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_sg_replicate_continuous_cc.json
@@ -21,9 +21,7 @@
     "db1": {
       {{ autoimport }}
       {{ xattrs }}
-      "unsupported": {
-        {{ no_conflicts }}
-      },
+      {{ no_conflicts }}
       "server": "{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
       "bucket": "data-bucket-1",
       "username":"data-bucket-1",
@@ -32,9 +30,7 @@
     "db2": {
       {{ autoimport }}
       {{ xattrs }}
-      "unsupported": {
-        {{ no_conflicts }}
-      },
+      {{ no_conflicts }}
       "server": "{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
       "bucket": "data-bucket-2",
       "username":"data-bucket-2",

--- a/resources/sync_gateway_configs/sync_gateway_sg_replicate_continuous_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_sg_replicate_continuous_di.json
@@ -27,9 +27,7 @@
   "databases": {
     "db1": {
       {{ xattrs }}
-      "unsupported": {
-        {{ no_conflicts }}
-      },
+      {{ no_conflicts }}
       "server": "{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
       "bucket": "data-bucket-1",
       "username":"data-bucket-1",
@@ -45,9 +43,7 @@
     },
     "db2": {
       {{ xattrs }}
-      "unsupported": {
-        {{ no_conflicts }}
-      },
+      {{ no_conflicts }}
       "server": "{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
       "bucket": "data-bucket-2",
       "username":"data-bucket-2",

--- a/resources/sync_gateway_configs/sync_gateway_sg_replicate_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_sg_replicate_di.json
@@ -17,9 +17,7 @@
     "databases":{
         "db1":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket-1",
             "username":"data-bucket-1",
@@ -35,9 +33,7 @@
         },
         "db2":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket-2",
             "username":"data-bucket-2",

--- a/resources/sync_gateway_configs/testfest_todo_cc.json
+++ b/resources/sync_gateway_configs/testfest_todo_cc.json
@@ -6,9 +6,7 @@
     "todo": {
       {{ autoimport }}
       {{ xattrs }}
-      "unsupported": {
-        {{ no_conflicts }}
-      },
+      {{ no_conflicts }}
       "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
       "bucket": "data-bucket",
       "username":"data-bucket",

--- a/resources/sync_gateway_configs/testfest_todo_di.json
+++ b/resources/sync_gateway_configs/testfest_todo_di.json
@@ -12,9 +12,7 @@
   "databases": {
     "todo": {
       {{ xattrs }}
-      "unsupported": {
-        {{ no_conflicts }}
-      },
+      {{ no_conflicts }}
       "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
       "bucket": "data-bucket",
       "username":"data-bucket",

--- a/resources/sync_gateway_configs/user_views/user_views_cc.json
+++ b/resources/sync_gateway_configs/user_views/user_views_cc.json
@@ -13,9 +13,7 @@
     "db": {
       {{ autoimport }}
       {{ xattrs }}
-      "unsupported": {
-        {{ no_conflicts }}
-      },
+      {{ no_conflicts }}
       "unsupported": {
         "user_views": {
           "enabled":true

--- a/resources/sync_gateway_configs/user_views/user_views_di.json
+++ b/resources/sync_gateway_configs/user_views/user_views_di.json
@@ -19,9 +19,7 @@
   "databases": {
     "db": {
       {{ xattrs }}
-      "unsupported": {
-        {{ no_conflicts }}
-      },
+      {{ no_conflicts }}
       "unsupported": {
         "user_views": {
           "enabled":true

--- a/resources/sync_gateway_configs/webhooks/webhook_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_cc.json
@@ -6,9 +6,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/webhooks/webhook_di.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_di.json
@@ -12,9 +12,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/webhooks/webhook_filter_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_filter_cc.json
@@ -6,9 +6,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/webhooks/webhook_filter_di.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_filter_di.json
@@ -12,9 +12,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",
             "username":"data-bucket",

--- a/resources/sync_gateway_configs/webhooks/webhook_offline_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_offline_cc.json
@@ -12,9 +12,7 @@
         "db":{
             {{ autoimport }}
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "offline":false,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",

--- a/resources/sync_gateway_configs/webhooks/webhook_offline_di.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_offline_di.json
@@ -18,9 +18,7 @@
     "databases":{
         "db":{
             {{ xattrs }}
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "offline":false,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",

--- a/resources/sync_gateway_configs/xattrs/mobile_opt_in_cc.json
+++ b/resources/sync_gateway_configs/xattrs/mobile_opt_in_cc.json
@@ -9,9 +9,7 @@
     "log": ["CRUD+", "Cache+", "HTTP+", "Changes+", "Import+"],
     "databases":{
         "db":{
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "enable_shared_bucket_access": true,
             "import_docs": "continuous",
             "import_filter": `function(doc){ return doc.type == "mobile"}`,

--- a/resources/sync_gateway_configs/xattrs/mobile_opt_in_di.json
+++ b/resources/sync_gateway_configs/xattrs/mobile_opt_in_di.json
@@ -18,9 +18,7 @@
         "db":{
             "enable_shared_bucket_access": true,
             "import_docs": "continuous",
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "import_filter": `function(doc){ return doc.type == "mobile"}`,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",

--- a/resources/sync_gateway_configs/xattrs/mobile_opt_in_no_import_cc.json
+++ b/resources/sync_gateway_configs/xattrs/mobile_opt_in_no_import_cc.json
@@ -9,9 +9,7 @@
     "log": ["CRUD+", "Cache+", "HTTP+", "Changes+", "Import+"],
     "databases":{
         "db":{
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "enable_shared_bucket_access": true,
             "import_filter": `function(doc){ return doc.type == "mobile"}`,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",

--- a/resources/sync_gateway_configs/xattrs/mobile_opt_in_no_import_di.json
+++ b/resources/sync_gateway_configs/xattrs/mobile_opt_in_no_import_di.json
@@ -16,9 +16,7 @@
     },
     "databases":{
         "db":{
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "enable_shared_bucket_access": true,
             "import_filter": `function(doc){ return doc.type == "mobile"}`,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",

--- a/resources/sync_gateway_configs/xattrs/no_import_cc.json
+++ b/resources/sync_gateway_configs/xattrs/no_import_cc.json
@@ -9,9 +9,7 @@
     "log": ["*"],
     "databases":{
         "db":{
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "enable_shared_bucket_access": true,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",

--- a/resources/sync_gateway_configs/xattrs/no_import_di.json
+++ b/resources/sync_gateway_configs/xattrs/no_import_di.json
@@ -16,9 +16,7 @@
     },
     "databases":{
         "db":{
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "enable_shared_bucket_access": true,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
             "bucket":"data-bucket",

--- a/resources/sync_gateway_configs/xattrs/old_doc_cc.json
+++ b/resources/sync_gateway_configs/xattrs/old_doc_cc.json
@@ -4,9 +4,7 @@
     "log": ["*"],
     "databases":{
         "db":{
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "import_docs": "continuous",
             "enable_shared_bucket_access": true,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",

--- a/resources/sync_gateway_configs/xattrs/old_doc_di.json
+++ b/resources/sync_gateway_configs/xattrs/old_doc_di.json
@@ -11,9 +11,7 @@
     },
     "databases":{
         "db":{
-            "unsupported": {
-                {{ no_conflicts }}
-            },
+            {{ no_conflicts }}
             "import_docs": "continuous",
             "enable_shared_bucket_access": true,
             "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -273,7 +273,7 @@ def params_from_base_suite_setup(request):
 
     # Stop all sync_gateway and sg_accels as test finished
     c = cluster.Cluster(cluster_config)
-    # c.stop_sg_and_accel()
+    c.stop_sg_and_accel()
 
 
 # This is called before each test and will yield the dictionary to each test that references the method

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -30,7 +30,7 @@ UNSUPPORTED_1_5_0_CC = {
 }
 
 
-def skip_if_unsupported(sync_gateway_version, mode, test_name):
+def skip_if_unsupported(sync_gateway_version, mode, test_name, no_conflicts_enabled):
 
     # sync_gateway_version >= 1.5.0 and channel cache
     if compare_versions(sync_gateway_version, "1.5.0") >= 0 and mode == 'cc':
@@ -40,6 +40,9 @@ def skip_if_unsupported(sync_gateway_version, mode, test_name):
     if compare_versions(sync_gateway_version, "1.4.0") <= 0:
         if "log_rotation" in test_name or "test_backfill" in test_name or "test_awaken_backfill" in test_name:
             pytest.skip("{} test was added for sync gateway 1.4".format(test_name))
+
+    if sync_gateway_version < "2.0.0" and no_conflicts_enabled:
+        pytest.skip("{} test cannot run with no-conflicts with sg version < 2.0.0".format(test_name))
 
 
 # Add custom arguments for executing tests in this directory
@@ -270,7 +273,7 @@ def params_from_base_suite_setup(request):
 
     # Stop all sync_gateway and sg_accels as test finished
     c = cluster.Cluster(cluster_config)
-    c.stop_sg_and_accel()
+    # c.stop_sg_and_accel()
 
 
 # This is called before each test and will yield the dictionary to each test that references the method
@@ -304,7 +307,8 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     skip_if_unsupported(
         sync_gateway_version=params_from_base_suite_setup["sync_gateway_version"],
         mode=mode,
-        test_name=test_name
+        test_name=test_name,
+        no_conflicts_enabled=no_conflicts_enabled
     )
 
     log_info("Running test '{}'".format(test_name))

--- a/testsuites/syncgateway/functional/tests/test_no_conflicts.py
+++ b/testsuites/syncgateway/functional/tests/test_no_conflicts.py
@@ -46,6 +46,7 @@ def test_no_conflicts_enabled(params_from_base_test_setup, sg_conf_name, num_of_
 
     if not no_conflicts_enabled:
         pytest.skip('--no-conflicts is not enabled, so skipping the test')
+
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
     c = cluster.Cluster(cluster_config)
     c.reset(sg_conf)
@@ -279,11 +280,12 @@ def test_conflicts_sg_accel_added(params_from_base_test_setup, sg_conf_name, num
     mode = params_from_base_test_setup["mode"]
     sg_url = topology["sync_gateways"][0]["public"]
     sg_admin_url = topology["sync_gateways"][0]["admin"]
+    no_conflicts_enabled = params_from_base_test_setup["no_conflicts_enabled"]
     sg_db = "db"
     total_updates = revs_limit + additional_updates
     new_updates = 2
 
-    if mode != "di":
+    if not no_conflicts_enabled or mode != "di":
         pytest.skip('--no-conflicts is not enabled or mode is not di, so skipping the test')
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
     c = cluster.Cluster(cluster_config)

--- a/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
@@ -109,6 +109,9 @@ def params_from_base_suite_setup(request):
         log_info("Running with allow conflicts")
         persist_cluster_config_environment_prop(cluster_config, 'no_conflicts_enabled', False)
 
+    if sync_gateway_version < "2.0.0" and no_conflicts_enabled:
+        pytest.skip("Test cannot run with no-conflicts with sg version < 2.0.0")
+
     # Skip provisioning if user specifies '--skip-provisoning' or '--sequoia'
     should_provision = True
     if skip_provisioning or use_sequoia:

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
@@ -114,6 +114,9 @@ def params_from_base_suite_setup(request):
         log_info("Running with allow conflicts")
         persist_cluster_config_environment_prop(cluster_config, 'no_conflicts_enabled', False)
 
+    if sync_gateway_version < "2.0.0" and no_conflicts_enabled:
+        pytest.skip("Test cannot run with no-conflicts with sg version < 2.0.0")
+
     # Skip provisioning if user specifies '--skip-provisoning' or '--sequoia'
     should_provision = True
     if skip_provisioning or use_sequoia:

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
@@ -112,6 +112,9 @@ def params_from_base_suite_setup(request):
         log_info("Running with allow conflicts")
         persist_cluster_config_environment_prop(cluster_config, 'no_conflicts_enabled', False)
 
+    if sync_gateway_version < "2.0.0" and no_conflicts_enabled:
+        pytest.skip("Test cannot run with no-conflicts with sg version < 2.0.0")
+
     # Skip provisioning if user specifies '--skip-provisoning' or '--sequoia'
     should_provision = True
     if skip_provisioning or use_sequoia:

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -112,6 +112,9 @@ def params_from_base_suite_setup(request):
         log_info("Running with allow conflicts")
         persist_cluster_config_environment_prop(cluster_config, 'no_conflicts_enabled', False)
 
+    if sync_gateway_version < "2.0.0" and no_conflicts_enabled:
+        pytest.skip("Test cannot run with no-conflicts with sg version < 2.0.0")
+
     # Skip provisioning if user specifies '--skip-provisoning' or '--sequoia'
     should_provision = True
     if skip_provisioning or use_sequoia:


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- removed unsupported flag
- added condition not to run tests if no-conflicts enabled and sg version < 2.0

