### PR TITLE
Feature/sg msi installer

### DIFF
--- a/keywords/ClusterKeywords.py
+++ b/keywords/ClusterKeywords.py
@@ -196,7 +196,7 @@ class ClusterKeywords:
         cluster = Cluster(config=cluster_config)
         cluster.reset(sync_gateway_config)
 
-    def provision_cluster(self, cluster_config, server_version, sync_gateway_version, sync_gateway_config, race_enabled=False, sg_ce=False, cbs_platform="centos7", sg_platform="centos", sa_platform="centos"):
+    def provision_cluster(self, cluster_config, server_version, sync_gateway_version, sync_gateway_config, race_enabled=False, sg_ce=False, cbs_platform="centos7", sg_platform="centos", sg_installer_type="msi", sa_platform="centos"):
         if server_version is None or sync_gateway_version is None or sync_gateway_version is None:
             raise ProvisioningError("Please make sure you have server_version, sync_gateway_version, and sync_gateway_config are set")
 
@@ -243,6 +243,7 @@ class ClusterKeywords:
             sg_ce=sg_ce,
             cbs_platform=cbs_platform,
             sg_platform=sg_platform,
+            sg_installer_type=sg_installer_type,
             sa_platform=sa_platform
         )
 

--- a/keywords/ClusterKeywords.py
+++ b/keywords/ClusterKeywords.py
@@ -196,7 +196,7 @@ class ClusterKeywords:
         cluster = Cluster(config=cluster_config)
         cluster.reset(sync_gateway_config)
 
-    def provision_cluster(self, cluster_config, server_version, sync_gateway_version, sync_gateway_config, race_enabled=False, sg_ce=False, cbs_platform="centos7", sg_platform="centos", sg_installer_type="msi", sa_platform="centos"):
+    def provision_cluster(self, cluster_config, server_version, sync_gateway_version, sync_gateway_config, race_enabled=False, sg_ce=False, cbs_platform="centos7", sg_platform="centos", sg_installer_type="msi", sa_platform="centos", sa_installer_type="msi"):
         if server_version is None or sync_gateway_version is None or sync_gateway_version is None:
             raise ProvisioningError("Please make sure you have server_version, sync_gateway_version, and sync_gateway_config are set")
 
@@ -244,7 +244,8 @@ class ClusterKeywords:
             cbs_platform=cbs_platform,
             sg_platform=sg_platform,
             sg_installer_type=sg_installer_type,
-            sa_platform=sa_platform
+            sa_platform=sa_platform,
+            sa_installer_type=sa_installer_type
         )
 
         # verify running services are the expected versions

--- a/keywords/tklogging.py
+++ b/keywords/tklogging.py
@@ -16,7 +16,9 @@ def fetch_sync_gateway_logs(cluster_config, prefix):
     # fetch logs from sync_gateway instances
     status = ansible_runner.run_ansible_playbook("fetch-sync-gateway-logs.yml")
     if status != 0:
-        raise CollectionError("Could not pull logs")
+        # raise CollectionError("Could not pull logs")
+        log_info("Could not pull logs")
+        return
 
     # zip logs and timestamp
     if os.path.isdir("/tmp/sg_logs"):

--- a/libraries/provision/ansible/playbooks/install-sg-accel-package-windows.yml
+++ b/libraries/provision/ansible/playbooks/install-sg-accel-package-windows.yml
@@ -22,7 +22,7 @@
     couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
 
   tasks:
-  - name: SG Accel | Download sg_accel exe {{ couchbase_sg_accel_package_url }}
+  - name: SG Accel | Download sg_accel {{ couchbase_sg_accel_package_url }}
     win_get_url: url={{ couchbase_sg_accel_package_url }} dest="C:\Users\Administrator\AppData\Local\Temp\{{ couchbase_sg_accel_package }}"
 
 # Install sg_accel

--- a/libraries/provision/ansible/playbooks/install-sync-gateway-package-windows.yml
+++ b/libraries/provision/ansible/playbooks/install-sync-gateway-package-windows.yml
@@ -42,7 +42,7 @@
     couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
 
   tasks:
-  - name: SYNC GATEWAY |  Download sync_gateway exe {{ couchbase_sync_gateway_package_url }}
+  - name: SYNC GATEWAY |  Download sync_gateway {{ couchbase_sync_gateway_package_url }}
     win_get_url: url={{ couchbase_sync_gateway_package_url }} dest="C:\Users\Administrator\AppData\Local\Temp\{{ couchbase_sync_gateway_package }}"
   
 # Install sync_gateway

--- a/libraries/provision/ansible/playbooks/tasks/deploy-sg-accel-config-windows.yml
+++ b/libraries/provision/ansible/playbooks/tasks/deploy-sg-accel-config-windows.yml
@@ -1,11 +1,34 @@
-- name: SG ACCEL | Copy sg_accel config to Windows host
+- name: SG ACCEL | Check if C:\PROGRA~2\Couchbase is present on Windows
+  win_stat:
+    path: 'C:\PROGRA~2\Couchbase'
+  register: pa
+  
+- name: SG ACCEL | Copy sg_accel config to C:\PROGRA~2\Couchbase
   win_template:
     src: "{{ sync_gateway_config_filepath }}"
     dest: 'C:\PROGRA~2\Couchbase\basic_sg_accel_config.json'
+  when: pa.stat.exists
 
 - name: SG ACCEL | Check deployed config
   win_shell: type C:\PROGRA~2\Couchbase\basic_sg_accel_config.json
   register: out
+  when: pa.stat.exists
+
+- name: SG ACCEL | Check if C:\PROGRA~1\Couchbase\Sync Gateway Accelerator is present on Windows
+  win_stat:
+    path: 'C:\PROGRA~1\Couchbase\Sync Gateway Accelerator'
+  register: pb
+  
+- name: SG ACCEL | Copy sg_accel config to C:\PROGRA~1\Couchbase\Sync Gateway Accelerator
+  win_template:
+    src: "{{ sync_gateway_config_filepath }}"
+    dest: 'C:\PROGRA~1\Couchbase\Sync Gateway Accelerator\basic_sg_accel_config.json'
+  when: pb.stat.exists
+
+- name: SG ACCEL | Check deployed config C:\PROGRA~1\Couchbase\Sync Gateway\basic_sg_accel_config.json
+  win_shell: type "C:\PROGRA~1\Couchbase\Sync Gateway Accelerator\basic_sg_accel_config.json"
+  register: out
+  when: pb.stat.exists
 
 - name: SG ACCEL | Print deployed config
   debug: var=out.stdout

--- a/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config-windows.yml
+++ b/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config-windows.yml
@@ -1,11 +1,34 @@
-- name: SYNC GATEWAY | Copy sync gateway config to Windows host
+- name: SYNC GATEWAY | Check if C:\PROGRA~2\Couchbase is present on Windows
+  win_stat:
+    path: 'C:\PROGRA~2\Couchbase'
+  register: pa
+  
+- name: SYNC GATEWAY | Copy sync gateway config to C:\PROGRA~2\Couchbase
   win_template:
     src: "{{ sync_gateway_config_filepath }}"
     dest: 'C:\PROGRA~2\Couchbase\serviceconfig.json'
-
-- name: SYNC GATEWAY | Check deployed config
+  when: pa.stat.exists
+  
+- name: SYNC GATEWAY | Check deployed config C:\PROGRA~2\Couchbase\serviceconfig.json
   win_shell: type C:\PROGRA~2\Couchbase\serviceconfig.json
   register: out
+  when: pa.stat.exists
+
+- name: SYNC GATEWAY | Check if C:\PROGRA~1\Couchbase\Sync Gateway is present on Windows
+  win_stat:
+    path: 'C:\PROGRA~1\Couchbase\Sync Gateway'
+  register: pb
+  
+- name: SYNC GATEWAY | Copy sync gateway config to C:\PROGRA~1\Couchbase\Sync Gateway
+  win_template:
+    src: "{{ sync_gateway_config_filepath }}"
+    dest: 'C:\PROGRA~1\Couchbase\Sync Gateway\serviceconfig.json'
+  when: pb.stat.exists
+
+- name: SYNC GATEWAY | Check deployed config C:\PROGRA~1\Couchbase\Sync Gateway\serviceconfig.json
+  win_shell: type "C:\PROGRA~1\Couchbase\Sync Gateway\serviceconfig.json"
+  register: out
+  when: pb.stat.exists
 
 - name: SYNC GATEWAY | Print deployed config
   debug: var=out.stdout

--- a/libraries/provision/ansible/playbooks/tasks/install-sg-accel-windows.yml
+++ b/libraries/provision/ansible/playbooks/tasks/install-sg-accel-windows.yml
@@ -1,5 +1,10 @@
 # Install and stop sg_accel service
-- name: SG ACCEL | Install sg_accel exe {{ couchbase_sg_accel_package | regex_replace('rpm', 'exe') }}
-  win_shell: C:\Users\Administrator\AppData\Local\Temp\{{ couchbase_sg_accel_package | regex_replace('rpm', 'exe') }} /S /v /qn
+- name: SG ACCEL | Install sg_accel exe {{ couchbase_sg_accel_package }}
+  win_shell: C:\Users\Administrator\AppData\Local\Temp\{{ couchbase_sg_accel_package }} /S /v /qn
+  when: "{{ couchbase_sg_accel_package  | search('exe$') }}"
+
+- name: SG ACCEL | Install sg_accel msi - {{ couchbase_sync_gateway_package }}
+  win_shell: Start-Process "C:\Users\Administrator\AppData\Local\Temp\{{ couchbase_sg_accel_package }}" /qn -wait
+  when: "{{ couchbase_sg_accel_package | search('msi$') }}"
 
 - include: stop-sg-accel-windows.yml

--- a/libraries/provision/ansible/playbooks/tasks/install-sg-windows.yml
+++ b/libraries/provision/ansible/playbooks/tasks/install-sg-windows.yml
@@ -1,10 +1,10 @@
 # Install and stop sync_gateway service
-- name: SYNC GATEWAY | Install sync_gateway exe {{ couchbase_sync_gateway_package }}
+- name: SYNC GATEWAY | Install sync_gateway exe - {{ couchbase_sync_gateway_package }}
   win_shell: C:\Users\Administrator\AppData\Local\Temp\{{ couchbase_sync_gateway_package }} /S /v /qn
   when: "{{ couchbase_sync_gateway_package  | search('exe$') }}"
 
-- name: SYNC GATEWAY | Install sync_gateway msi {{ couchbase_sync_gateway_package }}
-  win_shell: Start-Process msiexec.exe -ArgumentList @('/i', 'C:\Users\Administrator\AppData\Local\Temp\{{ couchbase_sync_gateway_package }}', '/qn') -wait
+- name: SYNC GATEWAY | Install sync_gateway msi - {{ couchbase_sync_gateway_package }}
+  win_shell: Start-Process "C:\Users\Administrator\AppData\Local\Temp\{{ couchbase_sync_gateway_package }}" /qn -wait
   when: "{{ couchbase_sync_gateway_package | search('msi$') }}"
 
 - include: stop-sync-gateway-windows.yml

--- a/libraries/provision/ansible/playbooks/tasks/install-sg-windows.yml
+++ b/libraries/provision/ansible/playbooks/tasks/install-sg-windows.yml
@@ -1,5 +1,10 @@
 # Install and stop sync_gateway service
-- name: SYNC GATEWAY | Install sync_gateway exe {{ couchbase_sync_gateway_package | regex_replace('rpm', 'exe') }}
-  win_shell: C:\Users\Administrator\AppData\Local\Temp\{{ couchbase_sync_gateway_package | regex_replace('rpm', 'exe') }} /S /v /qn
+- name: SYNC GATEWAY | Install sync_gateway exe {{ couchbase_sync_gateway_package }}
+  win_shell: C:\Users\Administrator\AppData\Local\Temp\{{ couchbase_sync_gateway_package }} /S /v /qn
+  when: "{{ couchbase_sync_gateway_package  | search('exe$') }}"
+
+- name: SYNC GATEWAY | Install sync_gateway msi {{ couchbase_sync_gateway_package }}
+  win_shell: Start-Process msiexec.exe -ArgumentList @('/i', 'C:\Users\Administrator\AppData\Local\Temp\{{ couchbase_sync_gateway_package }}', '/qn') -wait
+  when: "{{ couchbase_sync_gateway_package | search('msi$') }}"
 
 - include: stop-sync-gateway-windows.yml

--- a/libraries/provision/ansible/playbooks/tasks/remove-sg-accel-windows.yml
+++ b/libraries/provision/ansible/playbooks/tasks/remove-sg-accel-windows.yml
@@ -1,11 +1,17 @@
 # Remove sync_gateway package
-- name: SG ACCEL | Uninstall sync_gateway_accel exe
+- name: SG ACCEL | Uninstall sync_gateway_accel
   win_command: wmic product where name='Couchbase Sync Gateway Accelerator' call uninstall
 
 # Delete sync_gateway binary
 - name: SG ACCEL | Delete sync_gateway_accel install directory
   win_file: 
     path: C:\PROGRA~2\Couchbase 
+    state: absent
+  ignore_errors: yes
+
+- name: SG ACCEL | Delete sync_gateway_accel install directory
+  win_file: 
+    path: 'C:\PROGRA~1\Couchbase\Sync Gateway Accelerator'
     state: absent
   ignore_errors: yes
 

--- a/libraries/provision/ansible/playbooks/tasks/remove-sync-gateway-windows.yml
+++ b/libraries/provision/ansible/playbooks/tasks/remove-sync-gateway-windows.yml
@@ -1,5 +1,5 @@
 # Remove sync_gateway package
-- name: SYNC GATEWAY | Uninstall sync_gateway exe
+- name: SYNC GATEWAY | Uninstall sync_gateway
   win_command: wmic product where name='Couchbase Sync Gateway' call uninstall
 
 # Delete sync_gateway binary

--- a/libraries/provision/ansible/playbooks/tasks/remove-sync-gateway-windows.yml
+++ b/libraries/provision/ansible/playbooks/tasks/remove-sync-gateway-windows.yml
@@ -9,6 +9,12 @@
     state: absent
   ignore_errors: yes
 
+- name: SYNC GATEWAY | Delete sync_gateway install directory
+  win_file: 
+    path: 'C:\PROGRA~1\Couchbase\Sync Gateway'
+    state: absent
+  ignore_errors: yes
+
 - name: SYNC GATEWAY | Remove tmp logging dir (log rotation tests)
   win_file: 
     path: C:\Users\Administrator\AppData\Local\Temp\sg_logs

--- a/libraries/provision/ansible/playbooks/tasks/start-sg-accel-windows.yml
+++ b/libraries/provision/ansible/playbooks/tasks/start-sg-accel-windows.yml
@@ -7,9 +7,9 @@
 
 # There is no win_wait_for
 # This workaround delegates port check to localhost
-- name: SG ACCEL | Wait until sg_accel to listen on port
+- name: SG ACCEL | Wait until sg_accel to listen on windows at 4985
   wait_for:
     host={{ ansible_host }}
-    port=4984
+    port=4985
     timeout=600
   delegate_to: localhost

--- a/libraries/provision/install_sync_gateway.py
+++ b/libraries/provision/install_sync_gateway.py
@@ -39,11 +39,11 @@ class SyncGatewayConfig:
         output += "  skip bucketcreation: {}\n".format(self.skip_bucketcreation)
         return output
 
-    def sync_gateway_base_url_and_package(self, sg_ce=False, sg_platform="centos", sa_platform="centos"):
+    def sync_gateway_base_url_and_package(self, sg_ce=False, sg_platform="centos", sg_installer_type="msi", sa_platform="centos"):
         platform_extension = {
             "centos": "rpm",
             "ubuntu": "deb",
-            "windows": "exe"
+            "windows": sg_installer_type
         }
 
         if self._version_number == "1.1.0" or self._build_number == "1.1.1":
@@ -87,7 +87,7 @@ class SyncGatewayConfig:
         return True
 
 
-def install_sync_gateway(cluster_config, sync_gateway_config, sg_ce=False, sg_platform="centos", sa_platform="centos"):
+def install_sync_gateway(cluster_config, sync_gateway_config, sg_ce=False, sg_platform="centos", sg_installer_type="msi", sa_platform="centos"):
 
     log_info(sync_gateway_config)
 
@@ -145,7 +145,7 @@ def install_sync_gateway(cluster_config, sync_gateway_config, sg_ce=False, sg_pl
 
     else:
         # Install from Package
-        sync_gateway_base_url, sync_gateway_package_name, sg_accel_package_name = sync_gateway_config.sync_gateway_base_url_and_package(sg_ce=sg_ce, sg_platform=sg_platform, sa_platform=sa_platform)
+        sync_gateway_base_url, sync_gateway_package_name, sg_accel_package_name = sync_gateway_config.sync_gateway_base_url_and_package(sg_ce=sg_ce, sg_platform=sg_platform, sg_installer_type=sg_installer_type, sa_platform=sa_platform)
 
         playbook_vars["couchbase_sync_gateway_package_base_url"] = sync_gateway_base_url
         playbook_vars["couchbase_sync_gateway_package"] = sync_gateway_package_name

--- a/libraries/provision/install_sync_gateway.py
+++ b/libraries/provision/install_sync_gateway.py
@@ -43,7 +43,7 @@ class SyncGatewayConfig:
         platform_extension = {
             "centos": "rpm",
             "ubuntu": "deb",
-            "windows": sg_installer_type
+            "windows": "msi"
         }
 
         if self._version_number == "1.1.0" or self._build_number == "1.1.1":
@@ -60,6 +60,9 @@ class SyncGatewayConfig:
 
             if sg_ce:
                 sg_type = "community"
+
+            if (sg_platform == "windows" or sa_platform == "windows") and sg_installer_type != "msi":
+                platform_extension["windows"] = "exe"
 
             sg_package_name = "couchbase-sync-gateway-{0}_{1}-{2}_x86_64.{3}".format(sg_type, self._version_number, self._build_number, platform_extension[sg_platform])
             accel_package_name = "couchbase-sg-accel-enterprise_{0}-{1}_x86_64.{2}".format(self._version_number, self._build_number, platform_extension[sa_platform])

--- a/libraries/provision/install_sync_gateway.py
+++ b/libraries/provision/install_sync_gateway.py
@@ -39,7 +39,7 @@ class SyncGatewayConfig:
         output += "  skip bucketcreation: {}\n".format(self.skip_bucketcreation)
         return output
 
-    def sync_gateway_base_url_and_package(self, sg_ce=False, sg_platform="centos", sg_installer_type="msi", sa_platform="centos"):
+    def sync_gateway_base_url_and_package(self, sg_ce=False, sg_platform="centos", sg_installer_type="msi", sa_platform="centos", sa_installer_type="msi"):
         platform_extension = {
             "centos": "rpm",
             "ubuntu": "deb",
@@ -61,7 +61,7 @@ class SyncGatewayConfig:
             if sg_ce:
                 sg_type = "community"
 
-            if (sg_platform == "windows" or sa_platform == "windows") and sg_installer_type != "msi":
+            if (sg_platform == "windows" or sa_platform == "windows") and (sg_installer_type != "msi" or sa_installer_type != "msi"):
                 platform_extension["windows"] = "exe"
 
             sg_package_name = "couchbase-sync-gateway-{0}_{1}-{2}_x86_64.{3}".format(sg_type, self._version_number, self._build_number, platform_extension[sg_platform])
@@ -90,7 +90,7 @@ class SyncGatewayConfig:
         return True
 
 
-def install_sync_gateway(cluster_config, sync_gateway_config, sg_ce=False, sg_platform="centos", sg_installer_type="msi", sa_platform="centos"):
+def install_sync_gateway(cluster_config, sync_gateway_config, sg_ce=False, sg_platform="centos", sg_installer_type="msi", sa_platform="centos", sa_installer_type="msi"):
 
     log_info(sync_gateway_config)
 
@@ -148,7 +148,7 @@ def install_sync_gateway(cluster_config, sync_gateway_config, sg_ce=False, sg_pl
 
     else:
         # Install from Package
-        sync_gateway_base_url, sync_gateway_package_name, sg_accel_package_name = sync_gateway_config.sync_gateway_base_url_and_package(sg_ce=sg_ce, sg_platform=sg_platform, sg_installer_type=sg_installer_type, sa_platform=sa_platform)
+        sync_gateway_base_url, sync_gateway_package_name, sg_accel_package_name = sync_gateway_config.sync_gateway_base_url_and_package(sg_ce=sg_ce, sg_platform=sg_platform, sg_installer_type=sg_installer_type, sa_platform=sa_platform, sa_installer_type=sa_installer_type)
 
         playbook_vars["couchbase_sync_gateway_package_base_url"] = sync_gateway_base_url
         playbook_vars["couchbase_sync_gateway_package"] = sync_gateway_package_name

--- a/libraries/provision/provision_cluster.py
+++ b/libraries/provision/provision_cluster.py
@@ -23,7 +23,7 @@ from keywords.couchbaseserver import CouchbaseServer
 from keywords.ClusterKeywords import ClusterKeywords
 
 
-def provision_cluster(cluster_config, couchbase_server_config, sync_gateway_config, sg_ce=False, cbs_platform="centos7", sg_platform="centos", sg_installer_type="msi", sa_platform="centos"):
+def provision_cluster(cluster_config, couchbase_server_config, sync_gateway_config, sg_ce=False, cbs_platform="centos7", sg_platform="centos", sg_installer_type="msi", sa_platform="centos", sa_installer_type="msi"):
 
     log_info("\n>>> Cluster info:\n")
     server_version = "{}-{}".format(couchbase_server_config.version, couchbase_server_config.build)
@@ -100,6 +100,7 @@ def provision_cluster(cluster_config, couchbase_server_config, sync_gateway_conf
         sg_platform=sg_platform,
         sg_installer_type=sg_installer_type,
         sa_platform=sa_platform,
+        sa_installer_type=sa_installer_type,
         sg_ce=sg_ce
     )
 

--- a/libraries/provision/provision_cluster.py
+++ b/libraries/provision/provision_cluster.py
@@ -23,7 +23,7 @@ from keywords.couchbaseserver import CouchbaseServer
 from keywords.ClusterKeywords import ClusterKeywords
 
 
-def provision_cluster(cluster_config, couchbase_server_config, sync_gateway_config, sg_ce=False, cbs_platform="centos7", sg_platform="centos", sa_platform="centos"):
+def provision_cluster(cluster_config, couchbase_server_config, sync_gateway_config, sg_ce=False, cbs_platform="centos7", sg_platform="centos", sg_installer_type="msi", sa_platform="centos"):
 
     log_info("\n>>> Cluster info:\n")
     server_version = "{}-{}".format(couchbase_server_config.version, couchbase_server_config.build)
@@ -98,6 +98,7 @@ def provision_cluster(cluster_config, couchbase_server_config, sync_gateway_conf
         cluster_config=cluster_config,
         sync_gateway_config=sync_gateway_config,
         sg_platform=sg_platform,
+        sg_installer_type=sg_installer_type,
         sa_platform=sa_platform,
         sg_ce=sg_ce
     )

--- a/mobile_testkit_tests/test_sync_gateway_base_url_and_package.py
+++ b/mobile_testkit_tests/test_sync_gateway_base_url_and_package.py
@@ -5,11 +5,12 @@ from libraries.provision.install_sync_gateway import SyncGatewayConfig
 from keywords.utils import version_and_build
 
 
-@pytest.mark.parametrize("sg_ce, sg_type, sg_platform, sa_platform, platform_ext", [
-    (True, "community", "centos", "centos", "rpm"),
-    (False, "enterprise", "windows", "windows", "exe"),
+@pytest.mark.parametrize("sg_ce, sg_type, sg_platform, sa_platform, platform_ext, sg_installer_type", [
+    (True, "community", "centos", "centos", "rpm", None),
+    (False, "enterprise", "windows", "windows", "exe", "exe"),
+    (False, "enterprise", "windows", "windows", "msi", "msi"),
 ])
-def test_ce_ee_package(sg_ce, sg_type, sg_platform, sa_platform, platform_ext):
+def test_ce_ee_package(sg_ce, sg_type, sg_platform, sa_platform, platform_ext, sg_installer_type):
     sync_gateway_version = "1.5.0-477"
     cwd = os.getcwd()
     sync_gateway_config = cwd + "/resources/sync_gateway_configs/sync_gateway_default_cc.json"
@@ -24,7 +25,7 @@ def test_ce_ee_package(sg_ce, sg_type, sg_platform, sa_platform, platform_ext):
         skip_bucketcreation=False
     )
 
-    sync_gateway_base_url, sync_gateway_package_name, sg_accel_package_name = sg_config.sync_gateway_base_url_and_package(sg_ce, sg_platform, sa_platform)
+    sync_gateway_base_url, sync_gateway_package_name, sg_accel_package_name = sg_config.sync_gateway_base_url_and_package(sg_ce=sg_ce, sg_platform=sg_platform, sa_platform=sa_platform, sg_installer_type=sg_installer_type)
 
     assert sync_gateway_package_name == "couchbase-sync-gateway-{}_1.5.0-477_x86_64.{}".format(sg_type, platform_ext)
     assert sg_accel_package_name == "couchbase-sg-accel-enterprise_1.5.0-477_x86_64.{}".format(platform_ext)

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -93,7 +93,7 @@ def pytest_addoption(parser):
     parser.addoption("--sg-installer-type",
                      action="store",
                      help="Sync Gateway Installer type (ex. exe or msi)",
-                     default="exe")
+                     default="msi")
 
     parser.addoption("--sa-platform",
                      action="store",
@@ -115,6 +115,11 @@ def pytest_addoption(parser):
     parser.addoption("--no-conflicts",
                      action="store_true",
                      help="If set, allow_conflicts is set to false in sync-gateway config")
+
+    parser.addoption("--sg-ssl",
+                     action="store_true",
+                     help="If set, will enable SSL communication between Sync Gateway and CBL")
+
 
 
 # This will be called once for the at the beggining of the execution in the 'tests/' directory
@@ -142,6 +147,7 @@ def params_from_base_suite_setup(request):
     sg_ce = request.config.getoption("--sg-ce")
     use_sequoia = request.config.getoption("--sequoia")
     no_conflicts_enabled = request.config.getoption("--no-conflicts")
+    sg_ssl = request.config.getoption("--sg-ssl")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -161,6 +167,7 @@ def params_from_base_suite_setup(request):
     log_info("sg_lb: {}".format(sg_lb))
     log_info("sg_ce: {}".format(sg_ce))
     log_info("no conflicts enabled {}".format(no_conflicts_enabled))
+    log_info("sg_ssl: {}".format(sg_ssl))
 
     # sg-ce is invalid for di mode
     if mode == "di" and sg_ce:
@@ -188,6 +195,12 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running tests with load balancer disabled")
         persist_cluster_config_environment_prop(cluster_config, 'sg_lb_enabled', False)
+
+    if sg_ssl:
+        log_info("Enabling SSL on sync gateway")
+        persist_cluster_config_environment_prop(cluster_config, 'sync_gateway_ssl', True)
+    else:
+        persist_cluster_config_environment_prop(cluster_config, 'sync_gateway_ssl', False)
 
     if cbs_ssl:
         log_info("Running tests with cbs <-> sg ssl enabled")

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -90,6 +90,11 @@ def pytest_addoption(parser):
                      help="Sync Gateway Platform binary to install (ex. centos or windows)",
                      default="centos")
 
+    parser.addoption("--sg-installer-type",
+                     action="store",
+                     help="Sync Gateway Installer type (ex. exe or msi)",
+                     default="exe")
+
     parser.addoption("--sa-platform",
                      action="store",
                      help="Sync Gateway Accelerator Platform binary to install (ex. centos or windows)",
@@ -131,6 +136,7 @@ def params_from_base_suite_setup(request):
     cbs_ssl = request.config.getoption("--server-ssl")
     xattrs_enabled = request.config.getoption("--xattrs")
     sg_platform = request.config.getoption("--sg-platform")
+    sg_installer_type = request.config.getoption("--sg-installer-type")
     sa_platform = request.config.getoption("--sa-platform")
     sg_lb = request.config.getoption("--sg-lb")
     sg_ce = request.config.getoption("--sg-ce")
@@ -150,6 +156,7 @@ def params_from_base_suite_setup(request):
     log_info("race_enabled: {}".format(race_enabled))
     log_info("xattrs_enabled: {}".format(xattrs_enabled))
     log_info("sg_platform: {}".format(sg_platform))
+    log_info("sg_installer_type: {}".format(sg_installer_type))
     log_info("sa_platform: {}".format(sa_platform))
     log_info("sg_lb: {}".format(sg_lb))
     log_info("sg_ce: {}".format(sg_ce))
@@ -240,6 +247,7 @@ def params_from_base_suite_setup(request):
                 sync_gateway_config=sg_config,
                 race_enabled=race_enabled,
                 sg_platform=sg_platform,
+                sg_installer_type=sg_installer_type,
                 sa_platform=sa_platform,
                 sg_ce=sg_ce
             )

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -116,10 +116,6 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="If set, allow_conflicts is set to false in sync-gateway config")
 
-    parser.addoption("--sg-ssl",
-                     action="store_true",
-                     help="If set, will enable SSL communication between Sync Gateway and CBL")
-
 
 # This will be called once for the at the beggining of the execution in the 'tests/' directory
 # and will be torn down, (code after the yeild) when all the test session has completed.
@@ -146,7 +142,6 @@ def params_from_base_suite_setup(request):
     sg_ce = request.config.getoption("--sg-ce")
     use_sequoia = request.config.getoption("--sequoia")
     no_conflicts_enabled = request.config.getoption("--no-conflicts")
-    sg_ssl = request.config.getoption("--sg-ssl")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -166,7 +161,6 @@ def params_from_base_suite_setup(request):
     log_info("sg_lb: {}".format(sg_lb))
     log_info("sg_ce: {}".format(sg_ce))
     log_info("no conflicts enabled {}".format(no_conflicts_enabled))
-    log_info("sg_ssl: {}".format(sg_ssl))
 
     # sg-ce is invalid for di mode
     if mode == "di" and sg_ce:
@@ -194,12 +188,6 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running tests with load balancer disabled")
         persist_cluster_config_environment_prop(cluster_config, 'sg_lb_enabled', False)
-
-    if sg_ssl:
-        log_info("Enabling SSL on sync gateway")
-        persist_cluster_config_environment_prop(cluster_config, 'sync_gateway_ssl', True)
-    else:
-        persist_cluster_config_environment_prop(cluster_config, 'sync_gateway_ssl', False)
 
     if cbs_ssl:
         log_info("Running tests with cbs <-> sg ssl enabled")

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -121,7 +121,6 @@ def pytest_addoption(parser):
                      help="If set, will enable SSL communication between Sync Gateway and CBL")
 
 
-
 # This will be called once for the at the beggining of the execution in the 'tests/' directory
 # and will be torn down, (code after the yeild) when all the test session has completed.
 # IMPORTANT: Tests in 'tests/' should be executed in their own test run and should not be

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -100,6 +100,11 @@ def pytest_addoption(parser):
                      help="Sync Gateway Accelerator Platform binary to install (ex. centos or windows)",
                      default="centos")
 
+    parser.addoption("--sa-installer-type",
+                     action="store",
+                     help="Sync Gateway Accelerator Installer type (ex. exe or msi)",
+                     default="msi")
+
     parser.addoption("--sg-lb",
                      action="store_true",
                      help="If set, will enable load balancer for Sync Gateway")
@@ -138,6 +143,7 @@ def params_from_base_suite_setup(request):
     sg_platform = request.config.getoption("--sg-platform")
     sg_installer_type = request.config.getoption("--sg-installer-type")
     sa_platform = request.config.getoption("--sa-platform")
+    sa_installer_type = request.config.getoption("--sa-installer-type")
     sg_lb = request.config.getoption("--sg-lb")
     sg_ce = request.config.getoption("--sg-ce")
     use_sequoia = request.config.getoption("--sequoia")
@@ -157,6 +163,7 @@ def params_from_base_suite_setup(request):
     log_info("xattrs_enabled: {}".format(xattrs_enabled))
     log_info("sg_platform: {}".format(sg_platform))
     log_info("sg_installer_type: {}".format(sg_installer_type))
+    log_info("sa_installer_type: {}".format(sa_installer_type))
     log_info("sa_platform: {}".format(sa_platform))
     log_info("sg_lb: {}".format(sg_lb))
     log_info("sg_ce: {}".format(sg_ce))
@@ -249,6 +256,7 @@ def params_from_base_suite_setup(request):
                 sg_platform=sg_platform,
                 sg_installer_type=sg_installer_type,
                 sa_platform=sa_platform,
+                sa_installer_type=sa_installer_type,
                 sg_ce=sg_ce
             )
         except ProvisioningError:

--- a/testsuites/syncgateway/functional/topology_specific_tests/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/conftest.py
@@ -49,3 +49,13 @@ def pytest_addoption(parser):
     parser.addoption("--no-conflicts",
                      action="store_true",
                      help="If set, allow_conflicts is set to false in sync-gateway config")
+
+    parser.addoption("--sg-installer-type",
+                     action="store",
+                     help="Sync Gateway Installer type (ex. exe or msi)",
+                     default="msi")
+
+    parser.addoption("--sa-installer-type",
+                     action="store",
+                     help="Sync Gateway Accelerator Installer type (ex. exe or msi)",
+                     default="msi")

--- a/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
@@ -31,6 +31,8 @@ def params_from_base_suite_setup(request):
     sg_ce = request.config.getoption("--sg-ce")
     use_sequoia = request.config.getoption("--sequoia")
     no_conflicts_enabled = request.config.getoption("--no-conflicts")
+    sg_installer_type = request.config.getoption("--sg-installer-type")
+    sa_installer_type = request.config.getoption("--sa-installer-type")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -45,6 +47,8 @@ def params_from_base_suite_setup(request):
     log_info("sg_lb: {}".format(sg_lb))
     log_info("sg_ce: {}".format(sg_ce))
     log_info("no conflicts enabled {}".format(no_conflicts_enabled))
+    log_info("sg_installer_type: {}".format(sg_installer_type))
+    log_info("sa_installer_type: {}".format(sa_installer_type))
 
     # sg-ce is invalid for di mode
     if mode == "di" and sg_ce:
@@ -126,7 +130,9 @@ def params_from_base_suite_setup(request):
                 sync_gateway_version=sync_gateway_version,
                 sync_gateway_config=sg_config,
                 race_enabled=race_enabled,
-                sg_ce=sg_ce
+                sg_ce=sg_ce,
+                sg_installer_type=sg_installer_type,
+                sa_installer_type=sa_installer_type
             )
         except ProvisioningError:
             logging_helper = Logging()

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
@@ -32,6 +32,8 @@ def params_from_base_suite_setup(request):
     sg_ce = request.config.getoption("--sg-ce")
     use_sequoia = request.config.getoption("--sequoia")
     no_conflicts_enabled = request.config.getoption("--no-conflicts")
+    sg_installer_type = request.config.getoption("--sg-installer-type")
+    sa_installer_type = request.config.getoption("--sa-installer-type")
 
     log_info("server_version: {}".format(server_version))
     log_info("sync_gateway_version: {}".format(sync_gateway_version))
@@ -43,6 +45,8 @@ def params_from_base_suite_setup(request):
     log_info("sg_lb: {}".format(sg_lb))
     log_info("sg_ce: {}".format(sg_ce))
     log_info("no conflicts enabled {}".format(no_conflicts_enabled))
+    log_info("sg_installer_type: {}".format(sg_installer_type))
+    log_info("sa_installer_type: {}".format(sa_installer_type))
 
     # sg-ce is invalid for di mode
     if mode == "di" and sg_ce:
@@ -131,7 +135,9 @@ def params_from_base_suite_setup(request):
                 sync_gateway_version=sync_gateway_version,
                 sync_gateway_config=sg_config,
                 race_enabled=race_enabled,
-                sg_ce=sg_ce
+                sg_ce=sg_ce,
+                sg_installer_type=sg_installer_type,
+                sa_installer_type=sa_installer_type
             )
         except ProvisioningError:
             logging_helper = Logging()

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
@@ -34,6 +34,8 @@ def params_from_base_suite_setup(request):
     sg_ce = request.config.getoption("--sg-ce")
     use_sequoia = request.config.getoption("--sequoia")
     no_conflicts_enabled = request.config.getoption("--no-conflicts")
+    sg_installer_type = request.config.getoption("--sg-installer-type")
+    sa_installer_type = request.config.getoption("--sa-installer-type")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -48,6 +50,8 @@ def params_from_base_suite_setup(request):
     log_info("sg_lb: {}".format(sg_lb))
     log_info("sg_ce: {}".format(sg_ce))
     log_info("no conflicts enabled {}".format(no_conflicts_enabled))
+    log_info("sg_installer_type: {}".format(sg_installer_type))
+    log_info("sa_installer_type: {}".format(sa_installer_type))
 
     # sg-ce is invalid for di mode
     if mode == "di" and sg_ce:
@@ -129,6 +133,8 @@ def params_from_base_suite_setup(request):
                 sync_gateway_version=sync_gateway_version,
                 sync_gateway_config=sg_config,
                 race_enabled=race_enabled,
+                sg_installer_type=sg_installer_type,
+                sa_installer_type=sa_installer_type,
                 sg_ce=sg_ce
             )
         except ProvisioningError:

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -33,6 +33,8 @@ def params_from_base_suite_setup(request):
     sg_lb = request.config.getoption("--sg-lb")
     use_sequoia = request.config.getoption("--sequoia")
     no_conflicts_enabled = request.config.getoption("--no-conflicts")
+    sg_installer_type = request.config.getoption("--sg-installer-type")
+    sa_installer_type = request.config.getoption("--sa-installer-type")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -47,6 +49,8 @@ def params_from_base_suite_setup(request):
     log_info("sg_ce: {}".format(sg_ce))
     log_info("sg_lb: {}".format(sg_lb))
     log_info("no conflicts enabled {}".format(no_conflicts_enabled))
+    log_info("sg_installer_type: {}".format(sg_installer_type))
+    log_info("sa_installer_type: {}".format(sa_installer_type))
 
     # sg-ce is invalid for di mode
     if mode == "di" and sg_ce:
@@ -129,7 +133,9 @@ def params_from_base_suite_setup(request):
                 sync_gateway_version=sync_gateway_version,
                 sync_gateway_config=sg_config,
                 race_enabled=race_enabled,
-                sg_ce=sg_ce
+                sg_ce=sg_ce,
+                sg_installer_type=sg_installer_type,
+                sa_installer_type=sa_installer_type,
             )
         except ProvisioningError:
             logging_helper = Logging()


### PR DESCRIPTION
#### Fixes #1482 .

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:
- Switch SG/SGAccel installer to msi by default on windows
- Add an option to run exe as well.

Change has been tested through jenkins runs:
- Win 10: http://uberjenkins.sc.couchbase.com/job/win10-sync-gateway-functional-tests-base-cc-EXPERIMENTAL/218/
- CentOS7 - http://uberjenkins.sc.couchbase.com/job/cen7-sync-gateway-functional-tests-base-di/1264/

