### PR TITLE
Adding missing check for copying certs file

### DIFF
--- a/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config.yml
+++ b/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config.yml
@@ -25,7 +25,9 @@
     dest: /home/sync_gateway/
     remote_src: yes
     force: yes
+  when: x509_auth
   become: yes
+
 
 # unzip certs.zip
 - name: Unzipping certs.zip


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Adding missing check for copying certs file


