### PR TITLE
fix converting blob data type issue in database_getDocuments for all …

### DIFF
--- a/CBLClient/Apps/CBLTestServer-Android/app/src/main/java/com/couchbase/CouchbaseLiteServ/server/RequestHandler/DatabaseRequestHandler.java
+++ b/CBLClient/Apps/CBLTestServer-Android/app/src/main/java/com/couchbase/CouchbaseLiteServ/server/RequestHandler/DatabaseRequestHandler.java
@@ -98,7 +98,7 @@ public class DatabaseRequestHandler {
                 Map<String, Object> doc = document.toMap();
                 // looping through the document, replace the Blob with its properties
                 for (Map.Entry<String, Object> entry : doc.entrySet()) {
-                   if(entry.getValue() instanceof Map<?, ?>){
+                   if(entry.getValue() != null && entry.getValue() instanceof Map<?, ?>){
                         if(((Map) entry.getValue()).size() == 0){
                             continue;
                         }
@@ -106,7 +106,7 @@ public class DatabaseRequestHandler {
                         Map<?, ?> value = (Map<?, ?>)entry.getValue();
                         Map<String, Object> newVal = new HashMap<>();
                         for (Map.Entry<?, ?> item : value.entrySet()){
-                            if(item.getValue() instanceof Blob){
+                            if(item.getValue() != null && item.getValue() instanceof Blob){
                                 isBlob = true;
                                 Blob b = (Blob)item.getValue();
                                 newVal.put(item.getKey().toString(), b.getProperties());

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.iOS/AppDelegate.cs
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.iOS/AppDelegate.cs
@@ -30,7 +30,7 @@ namespace Couchbase.Lite.Testing.iOS
             Window.MakeKeyAndVisible();
 
             Couchbase.Lite.Support.iOS.Activate();
-			Database.SetLogLevel(Logging.LogDomain.All, Logging.LogLevel.Debug);
+            Database.Log.Console.Level = Logging.LogLevel.Verbose;
 
             TestServer.FilePathResolver = ResolvePath;
             var listener = new TestServer();

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/DatabaseMethods.cs
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/DatabaseMethods.cs
@@ -303,11 +303,11 @@ namespace Couchbase.Lite.Testing
                             {
                                 Dictionary<string, object> updatedValue = new Dictionary<string, object>();
                                 bool isBlob = false;
-                                if (item.Value.GetType() == typeof(Couchbase.Lite.DictionaryObject))
+                                if (item.Value != null && item.Value.GetType() == typeof(Couchbase.Lite.DictionaryObject))
                                 {
                                     foreach(KeyValuePair<String, object> innerVal in (Couchbase.Lite.DictionaryObject)item.Value)
                                     {
-                                        if(innerVal.Value.GetType() == typeof(Blob))
+                                        if(innerVal.Value != null && innerVal.Value.GetType() == typeof(Blob))
                                         {
                                             isBlob = true;
                                             Blob blob = (Blob)innerVal.Value;
@@ -319,10 +319,10 @@ namespace Couchbase.Lite.Testing
                                             updatedValue.Add(innerVal.Key, properties);
                                         }
                                     }
-                                }
-                                if (isBlob)
-                                {
-                                    preRetVal[item.Key] = updatedValue;
+                                    if (isBlob && updatedValue != null)
+                                    {
+                                        preRetVal[item.Key] = updatedValue;
+                                    }
                                 }
                             }
                             retVal[id] = preRetVal;

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/DatabaseMethods.cs
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/DatabaseMethods.cs
@@ -297,7 +297,35 @@ namespace Couchbase.Lite.Testing
                     {
                         using (var doc = db.GetDocument(id))
                         {
-                            retVal[id] = doc.ToDictionary();
+                            var preRetVal = doc.ToDictionary();
+
+                            foreach(KeyValuePair<String, object> item in doc)
+                            {
+                                Dictionary<string, object> updatedValue = new Dictionary<string, object>();
+                                bool isBlob = false;
+                                if (item.Value.GetType() == typeof(Couchbase.Lite.DictionaryObject))
+                                {
+                                    foreach(KeyValuePair<String, object> innerVal in (Couchbase.Lite.DictionaryObject)item.Value)
+                                    {
+                                        if(innerVal.Value.GetType() == typeof(Blob))
+                                        {
+                                            isBlob = true;
+                                            Blob blob = (Blob)innerVal.Value;
+                                            Dictionary<string, object> properties = new Dictionary<string, object>();
+                                            foreach(KeyValuePair<string, object> p in blob.Properties)
+                                            {
+                                                properties.Add(p.Key, p.Value);
+                                            }
+                                            updatedValue.Add(innerVal.Key, properties);
+                                        }
+                                    }
+                                }
+                                if (isBlob)
+                                {
+                                    preRetVal[item.Key] = updatedValue;
+                                }
+                            }
+                            retVal[id] = preRetVal;
                         }
                     }
 

--- a/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Server/DatabaseRequestHandler.swift
+++ b/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Server/DatabaseRequestHandler.swift
@@ -261,7 +261,18 @@ public class DatabaseRequestHandler {
 
             for id in ids {
                 let document: Document = database.document(withID: id)!
-                documents[id] = document.toDictionary()
+                
+                var dict = document.toDictionary()
+                for (key, value) in dict {
+                    if let list = value as? Dictionary<String, Blob> {
+                        var item = Dictionary<String, Any>()
+                        for (k, v) in list {
+                            item[k] = v.properties
+                        }
+                        dict[key] = item
+                    }
+                }
+                documents[id] = dict
             }
 
             return documents


### PR DESCRIPTION
…platforms

#### Fixes #.

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- added code to deal blob type conversion in TestServer app for all platforms. Blob type is used when attachments involved. 
- fixed console log enabling code, the original code was deprecated. 


