### PR TITLE
test covered for dbworker crash which fixed in 2.5.2

### DIFF
--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_delta_sync.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_delta_sync.py
@@ -614,7 +614,7 @@ def test_delta_sync_dbWorker(params_from_base_test_setup):
     update_docs(replication_type, cbl_db, db, sg_client, sg_docs, sg_url, sg_db, number_of_updates, session, channels)
     sg_client.add_docs(url=sg_url, db=sg_db, number=num_of_docs, id_prefix="db_worker2", channels=channels, auth=session)
 
-    # 4. Do push/pull replication
+    # 4. Do pull replication
     repl = replicator.configure_and_replicate(source_db=cbl_db,
                                               target_url=sg_blip_url,
                                               continuous=False,

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_delta_sync.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_delta_sync.py
@@ -554,14 +554,11 @@ def test_delta_sync_nested_doc(params_from_base_test_setup, num_of_docs, replica
 @pytest.mark.listener
 @pytest.mark.syncgateway
 @pytest.mark.replication
-@pytest.mark.parametrize("num_of_docs, replication_type", [
-    (1, "pull")
-])
-def test_delta_sync_dbWorker(params_from_base_test_setup, num_of_docs, replication_type):
+def test_delta_sync_dbWorker(params_from_base_test_setup):
     '''
     @summary:
     1. Add docs in SGW
-    2. Do push_pull replication
+    2. Do pull replication
     3. update docs in SGW
     4. Do push/pull replication
     5. Verify docs after replication matching in SGW and CBL
@@ -585,6 +582,8 @@ def test_delta_sync_dbWorker(params_from_base_test_setup, num_of_docs, replicati
     username = "autotest"
     password = "password"
     number_of_updates = 3
+    num_of_docs = 100
+    replication_type = "pull"
 
     # Reset cluster to ensure no data in system
     c = cluster.Cluster(config=cluster_config)
@@ -596,10 +595,10 @@ def test_delta_sync_dbWorker(params_from_base_test_setup, num_of_docs, replicati
     cookie, session_id = sg_client.create_session(sg_admin_url, sg_db, username)
     session = cookie, session_id
 
-    # add docs in SGW
-    sg_client.add_docs(url=sg_url, db=sg_db, number=100, id_prefix="db_worker", channels=channels, auth=session)
+    # 1. add docs in SGW
+    sg_client.add_docs(url=sg_url, db=sg_db, number=num_of_docs, id_prefix="db_worker", channels=channels, auth=session)
 
-    # 3. Do pull replication to SGW
+    # 2. Do pull replication to SGW
     replicator = Replication(base_url)
     authenticator = Authenticator(base_url)
     replicator_authenticator = authenticator.authentication(session_id, cookie, authentication_type="session")
@@ -610,19 +609,19 @@ def test_delta_sync_dbWorker(params_from_base_test_setup, num_of_docs, replicati
                                               replication_type="pull")
     replicator.stop(repl)
 
-    # 4. update docs in SGW/CBL
+    # 3. update docs in SGW/CBL
     sg_docs = sg_client.get_all_docs(url=sg_admin_url, db=sg_db, include_docs=True)["rows"]
     update_docs(replication_type, cbl_db, db, sg_client, sg_docs, sg_url, sg_db, number_of_updates, session, channels)
-    sg_client.add_docs(url=sg_url, db=sg_db, number=100, id_prefix="db_worker2", channels=channels, auth=session)
+    sg_client.add_docs(url=sg_url, db=sg_db, number=num_of_docs, id_prefix="db_worker2", channels=channels, auth=session)
 
-    # 5. replicate docs using pull replication
+    # 4. Do push/pull replication
     repl = replicator.configure_and_replicate(source_db=cbl_db,
                                               target_url=sg_blip_url,
                                               continuous=False,
                                               replicator_authenticator=replicator_authenticator,
                                               replication_type=replication_type)
 
-    # 7. Verify the body of nested doc matches with sgw and cbl
+    # 5. Verify docs after replication matching in SGW and CBL
     sg_docs = sg_client.get_all_docs(url=sg_admin_url, db=sg_db, include_docs=True)["rows"]
     compare_docs(cbl_db, db, sg_docs)
 


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Added test for GitHub 792: DBWorker crashes in Fleece Encoder (writePointer) which fixed for 2.5.2


