### PR TITLE
CBL-239: Add retrieving log endpoint. The response can be either regular text f…

### DIFF
--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/FileLoggingMehtod.cs
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/FileLoggingMehtod.cs
@@ -156,6 +156,26 @@ namespace Couchbase.Lite.Testing
 
         }
 
+        public static void GetLogsInByteArray([NotNull] NameValueCollection args,
+                                [NotNull] IReadOnlyDictionary<string, object> postBody,
+                                [NotNull] HttpListenerResponse response)
+        {
+            var path = Database.Log.File.Config?.Directory;
+            if (path == null) {
+                response.WriteEmptyBody();
+                return;
+            }
+            string[] filePaths = Directory.GetFiles(@path);
+            var content = new List<byte>();
+            foreach (var f in filePaths) {
+                var stream = File.Open(f, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                var bytesReader = new BinaryReader(stream);
+                content.AddRange(bytesReader.ReadBytes((int)stream.Length));
+
+            }
+            response.WriteBody(Convert.ToBase64String(content.ToArray()));
+        }
+
         public static void SetLogLevel([NotNull] NameValueCollection args,
                                 [NotNull] IReadOnlyDictionary<string, object> postBody,
                                 [NotNull] HttpListenerResponse response)

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/Router.cs
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/Router.cs
@@ -257,7 +257,7 @@ namespace Couchbase.Lite.Testing
                 ["logging_setMaxSize"] = FileLoggingMehtod.SetMaxSize,
                 ["logging_setLogLevel"] = FileLoggingMehtod.SetLogLevel,
                 ["logging_setConfig"] = FileLoggingMehtod.SetConfig,
-                ["logging_getLogsInByteArray"] = FileLoggingMehtod.GetLogsInByteArray,
+                ["logging_getLogsInZip"] = FileLoggingMehtod.GetLogsInZip,
                 ["blob_create"] = BlobMethods.Create,
                 ["blob_createImageContent"] = BlobMethods.CreateImageContent,
                 ["blob_digest"] = BlobMethods.Digest,

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/Router.cs
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/Router.cs
@@ -257,6 +257,7 @@ namespace Couchbase.Lite.Testing
                 ["logging_setMaxSize"] = FileLoggingMehtod.SetMaxSize,
                 ["logging_setLogLevel"] = FileLoggingMehtod.SetLogLevel,
                 ["logging_setConfig"] = FileLoggingMehtod.SetConfig,
+                ["logging_getLogsInByteArray"] = FileLoggingMehtod.GetLogsInByteArray,
                 ["blob_create"] = BlobMethods.Create,
                 ["blob_createImageContent"] = BlobMethods.CreateImageContent,
                 ["blob_digest"] = BlobMethods.Digest,


### PR DESCRIPTION
Add retrieving log endpoint. The response can be either regular text format or binary format. Need to enable the file logger first in order to get the logs, otherwise the response will be an empty string.