### PR TITLE
add a new delete event name DocumentFlagsAccessRemoved 

### DIFF
--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication_eventing.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication_eventing.py
@@ -477,8 +477,9 @@ def test_replication_delete_event(params_from_base_test_setup, num_of_docs):
     replicator.stop(repl_delete)
     assert len(event_dict) != 0, "Replication listener didn't caught events. Check app logs for detailed info"
     for doc_id in event_dict:
-        assert event_dict[doc_id]["flags"] == "1" or event_dict[doc_id]["flags"] == "[DocumentFlagsDeleted]" or \
-            event_dict[doc_id]["flags"] == "Deleted" or event_dict[doc_id]["flags"] == "[DocumentFlagsAccessRemoved]", \
+        flags = event_dict[doc_id]["flags"]
+        assert flags == "1" or flags == "[DocumentFlagsDeleted]" or flags == "Deleted" or \
+            flags == "[DocumentFlagsAccessRemoved]" or flags == "AccessRemoved", \
             'Deleted flag is not tagged for document. Flag value: {}'.format(event_dict[doc_id]["flags"])
 
     # Verifying if the docs, for which access has be revoked, are purged

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication_eventing.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication_eventing.py
@@ -478,7 +478,7 @@ def test_replication_delete_event(params_from_base_test_setup, num_of_docs):
     assert len(event_dict) != 0, "Replication listener didn't caught events. Check app logs for detailed info"
     for doc_id in event_dict:
         assert event_dict[doc_id]["flags"] == "1" or event_dict[doc_id]["flags"] == "[DocumentFlagsDeleted]" or \
-            event_dict[doc_id]["flags"] == "Deleted", \
+            event_dict[doc_id]["flags"] == "Deleted" or event_dict[doc_id]["flags"] == "[DocumentFlagsAccessRemoved]", \
             'Deleted flag is not tagged for document. Flag value: {}'.format(event_dict[doc_id]["flags"])
 
     # Verifying if the docs, for which access has be revoked, are purged


### PR DESCRIPTION
fixing test cases:

test_replication_delete_event[10]
test_replication_delete_event[100]

#### Fixes #.

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- add a new delete event name DocumentFlagsAccessRemoved to be align with LiteCore


