### PR TITLE
allow android run on device for system test

### DIFF
--- a/testsuites/CBLTester/System_test_multiple_device/conftest.py
+++ b/testsuites/CBLTester/System_test_multiple_device/conftest.py
@@ -191,7 +191,7 @@ def params_from_base_suite_setup(request):
         testserver.download()
 
         # Install TestServer app
-        if device_enabled and platform == "ios":
+        if device_enabled and (platform == "ios" or platform == "android"):
             testserver.install_device()
         else:
             testserver.install()


### PR DESCRIPTION
#### Fixes #.

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- allow system test run on (real) android device

