### PR TITLE
fix test case to deal with cobalt change for doc id is null scenario

### DIFF
--- a/testsuites/CBLTester/CBL_Functional_tests/APITests/test_database.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/APITests/test_database.py
@@ -16,7 +16,7 @@ class TestDatabase(object):
         if self.liteserv_version >= "2.6.0":
             err_msg = "db name may not be empty"
         log_info("check for error message: {}".format(err_msg))
-        
+
         if self.liteserv_platform != "android" and db_name == "":
             pytest.skip("Test not applicable for ios")
 

--- a/testsuites/CBLTester/CBL_Functional_tests/APITests/test_database.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/APITests/test_database.py
@@ -13,6 +13,10 @@ class TestDatabase(object):
         """
         @summary: Checking for the Exception handling in database create API
         """
+        if self.liteserv_version >= "2.6.0":
+            err_msg = "db name may not be empty"
+        log_info("check for error message: {}".format(err_msg))
+        
         if self.liteserv_platform != "android" and db_name == "":
             pytest.skip("Test not applicable for ios")
 


### PR DESCRIPTION
#### Fixes #.

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- fix the test case to deal with below situation:
   - pre-cobalt, when id is null, cblite will return "id cannot be null"
   - cobalt, when is is null, cblite will return "db name may not be empty"

ticket for this issue can be found https://issues.couchbase.com/browse/CM-212

