### PR TITLE
Fix/remove slow server call warning threshold config

### DIFF
--- a/mobile_testkit_tests/test_install_sync_gateway.py
+++ b/mobile_testkit_tests/test_install_sync_gateway.py
@@ -58,7 +58,6 @@ def test_get_buckets_from_sync_gateway_config_template_vars():
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": true,
     "log": ["CRUD+", "Cache+", "HTTP+", "Changes+"],
     "cluster_config": {

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_dcp_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_dcp_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_dcp_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_dcp_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_dcp_di.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_dcp_di.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_dcp_di.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_dcp_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_di.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets_di.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_false_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_false_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_false_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_false_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_false_di.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_false_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_true_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_true_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_true_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_true_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_true_di.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_true_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_all_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_all_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_all_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_all_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_all_di.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_all_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_restricted_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_restricted_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_restricted_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_restricted_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_restricted_di.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_restricted_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_invalid_db_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_invalid_db_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_invalid_db_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_invalid_db_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_invalid_db_di.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_invalid_db_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/custom_sync/access_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/access_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/access_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/access_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/custom_sync/access_di.json
+++ b/resources/sync_gateway_configs/custom_sync/access_di.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/custom_sync/access_di.json
+++ b/resources/sync_gateway_configs/custom_sync/access_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/custom_sync/grant_access_one_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/grant_access_one_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/grant_access_one_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/grant_access_one_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/custom_sync/grant_access_one_di.json
+++ b/resources/sync_gateway_configs/custom_sync/grant_access_one_di.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/custom_sync/grant_access_one_di.json
+++ b/resources/sync_gateway_configs/custom_sync/grant_access_one_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_access_sanity_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_access_sanity_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_access_sanity_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_access_sanity_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_access_sanity_di.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_access_sanity_di.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_access_sanity_di.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_access_sanity_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_di.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_di.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_di.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_one_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_one_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_one_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_one_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_one_di.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_one_di.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_one_di.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_one_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_require_roles_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_require_roles_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_require_roles_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_require_roles_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_require_roles_di.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_require_roles_di.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_require_roles_di.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_require_roles_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_role_sanity_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_role_sanity_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_role_sanity_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_role_sanity_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_role_sanity_di.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_role_sanity_di.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_role_sanity_di.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_role_sanity_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/custom_sync/wake_changes_access_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/wake_changes_access_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/wake_changes_access_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/wake_changes_access_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/custom_sync/wake_changes_access_di.json
+++ b/resources/sync_gateway_configs/custom_sync/wake_changes_access_di.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/custom_sync/wake_changes_access_di.json
+++ b/resources/sync_gateway_configs/custom_sync/wake_changes_access_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/custom_sync/wake_changes_roles_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/wake_changes_roles_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/wake_changes_roles_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/wake_changes_roles_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/custom_sync/wake_changes_roles_di.json
+++ b/resources/sync_gateway_configs/custom_sync/wake_changes_roles_di.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/custom_sync/wake_changes_roles_di.json
+++ b/resources/sync_gateway_configs/custom_sync/wake_changes_roles_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_2min_rev_cc.json
+++ b/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_2min_rev_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     {{ sslcert }}

--- a/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_2min_rev_di.1.json
+++ b/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_2min_rev_di.1.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_2min_rev_di.json
+++ b/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_2min_rev_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_enabled_cc.json
+++ b/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_enabled_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     {{ sslcert }}

--- a/resources/sync_gateway_configs/dist_index_config_local.json
+++ b/resources/sync_gateway_configs/dist_index_config_local.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     "cluster_config": {
         "server":"http://127.0.0.1:8091",
         "data_dir":".",

--- a/resources/sync_gateway_configs/dist_index_config_local.json
+++ b/resources/sync_gateway_configs/dist_index_config_local.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_di.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_no_conflicts_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_no_conflicts_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     {{ sslcert }}

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_no_conflicts_di.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_no_conflicts_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_revslimit_di.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_revslimit_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_user_di.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_user_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/listener_tests/multiple_sync_gateways_di.json
+++ b/resources/sync_gateway_configs/listener_tests/multiple_sync_gateways_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/listener_tests/three_sync_gateways_di.json
+++ b/resources/sync_gateway_configs/listener_tests/three_sync_gateways_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/log_redaction_cc.json
+++ b/resources/sync_gateway_configs/log_redaction_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "databases":{

--- a/resources/sync_gateway_configs/log_redaction_di.json
+++ b/resources/sync_gateway_configs/log_redaction_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/missing_num_shards_di.json
+++ b/resources/sync_gateway_configs/missing_num_shards_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/multiple_dbs_shared_data_shared_index_cc.json
+++ b/resources/sync_gateway_configs/multiple_dbs_shared_data_shared_index_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/multiple_dbs_shared_data_shared_index_cc.json
+++ b/resources/sync_gateway_configs/multiple_dbs_shared_data_shared_index_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases": {

--- a/resources/sync_gateway_configs/multiple_dbs_shared_data_shared_index_di.json
+++ b/resources/sync_gateway_configs/multiple_dbs_shared_data_shared_index_di.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/multiple_dbs_shared_data_shared_index_di.json
+++ b/resources/sync_gateway_configs/multiple_dbs_shared_data_shared_index_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_cc.json
+++ b/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_cc.json
+++ b/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases": {

--- a/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_di.json
+++ b/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_di.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_di.json
+++ b/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_x509_cc.json
+++ b/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_x509_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     "log": ["CRUD+", "Cache+", "HTTP+", "Changes+"],
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases": {

--- a/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_x509_cc.json
+++ b/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_x509_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     "log": ["CRUD+", "Cache+", "HTTP+", "Changes+"],
     "verbose":"true",

--- a/resources/sync_gateway_configs/performance/sync_gateway_default_performance_cc.json
+++ b/resources/sync_gateway_configs/performance/sync_gateway_default_performance_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": true,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/performance/sync_gateway_default_performance_di.json
+++ b/resources/sync_gateway_configs/performance/sync_gateway_default_performance_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": true,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/reject_all_cc.json
+++ b/resources/sync_gateway_configs/reject_all_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/reject_all_di.json
+++ b/resources/sync_gateway_configs/reject_all_di.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/reject_all_di.json
+++ b/resources/sync_gateway_configs/reject_all_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/sync_gateway_allow_conflicts_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_allow_conflicts_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_allow_conflicts_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_allow_conflicts_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/sync_gateway_blip_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_blip_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     {{ sslcert }}

--- a/resources/sync_gateway_configs/sync_gateway_blip_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_blip_di.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/sync_gateway_blip_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_blip_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/sync_gateway_bucketshadow_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_bucketshadow_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-     "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_bucketshadow_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_bucketshadow_di.json
@@ -4,7 +4,6 @@
   "maxIncomingConnections": 0,
   "maxCouchbaseConnections": 16,
   "maxFileDescriptors": 90000,
-  "slowServerCallWarningThreshold": 500,
   "compressResponses": false,
   {{ logging }}
   "cluster_config": {

--- a/resources/sync_gateway_configs/sync_gateway_bucketshadow_low_revs_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_bucketshadow_low_revs_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_bucketshadow_low_revs_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_bucketshadow_low_revs_di.json
@@ -4,7 +4,6 @@
   "maxIncomingConnections": 0,
   "maxCouchbaseConnections": 16,
   "maxFileDescriptors": 90000,
-  "slowServerCallWarningThreshold": 500,
   "compressResponses": false,
   {{ logging }}
   "cluster_config": {

--- a/resources/sync_gateway_configs/sync_gateway_default_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_default_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_di.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/sync_gateway_default_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_couchbase_protocol_withport_11210_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_couchbase_protocol_withport_11210_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_couchbase_protocol_withport_11210_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_couchbase_protocol_withport_11210_di.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     "cluster_config": {
         "server":"couchbase://{{ couchbase_server_primary_node }}:11210",
         "data_dir":".",

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_couchbase_protocol_withport_11210_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_couchbase_protocol_withport_11210_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_no_port_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_no_port_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_no_port_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_no_port_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_revslimit50_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_revslimit50_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_revslimit50_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_revslimit50_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/sync_gateway_default_low_revs_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_low_revs_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_default_low_revs_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_low_revs_di.json
@@ -4,7 +4,6 @@
   "maxIncomingConnections": 0,
   "maxCouchbaseConnections": 16,
   "maxFileDescriptors": 90000,
-  "slowServerCallWarningThreshold": 500,
   "compressResponses": false,
   {{ logging }}
   "cluster_config": {

--- a/resources/sync_gateway_configs/sync_gateway_guest_enabled_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_guest_enabled_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_guest_enabled_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_guest_enabled_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/sync_gateway_gzip_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_gzip_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": true,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_gzip_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_gzip_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": true,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_rev_cache_size5_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_rev_cache_size5_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_rev_cache_size5_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_rev_cache_size5_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/sync_gateway_revs_conflict_configurable_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_revs_conflict_configurable_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_revs_conflict_configurable_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_revs_conflict_configurable_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/sync_gateway_sg_replicate_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_sg_replicate_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_sg_replicate_continuous_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_sg_replicate_continuous_cc.json
@@ -4,7 +4,6 @@
   "maxIncomingConnections": 0,
   "maxCouchbaseConnections": 16,
   "maxFileDescriptors": 90000,
-  "slowServerCallWarningThreshold": 500,
   "compressResponses": false,
   {{ logging }}
   "replications": [

--- a/resources/sync_gateway_configs/sync_gateway_sg_replicate_continuous_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_sg_replicate_continuous_di.json
@@ -4,7 +4,6 @@
   "maxIncomingConnections": 0,
   "maxCouchbaseConnections": 16,
   "maxFileDescriptors": 90000,
-  "slowServerCallWarningThreshold": 500,
   "compressResponses": false,
   {{ logging }}
   "replications": [

--- a/resources/sync_gateway_configs/sync_gateway_sg_replicate_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_sg_replicate_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/sync_gateway_travel_sample_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_travel_sample_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     {{ sslcert }}

--- a/resources/sync_gateway_configs/sync_gateway_travel_sample_di.json
+++ b/resources/sync_gateway_configs/sync_gateway_travel_sample_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/sync_gateways_one_with_import_docs_cc.json
+++ b/resources/sync_gateway_configs/sync_gateways_one_with_import_docs_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateways_one_with_import_docs_di.json
+++ b/resources/sync_gateway_configs/sync_gateways_one_with_import_docs_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/user_views/user_views_cc.json
+++ b/resources/sync_gateway_configs/user_views/user_views_cc.json
@@ -4,7 +4,6 @@
   "maxIncomingConnections": 0,
   "maxCouchbaseConnections": 16,
   "maxFileDescriptors": 90000,
-  "slowServerCallWarningThreshold": 500,
   "compressResponses": false,
   {{ sslcert }}
   {{ sslkey }}

--- a/resources/sync_gateway_configs/user_views/user_views_di.json
+++ b/resources/sync_gateway_configs/user_views/user_views_di.json
@@ -4,7 +4,6 @@
   "maxIncomingConnections": 0,
   "maxCouchbaseConnections": 16,
   "maxFileDescriptors": 90000,
-  "slowServerCallWarningThreshold": 500,
   "compressResponses": false,
   {{ logging }}
   "cluster_config": {

--- a/resources/sync_gateway_configs/webhooks/webhook_offline_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_offline_cc.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/webhooks/webhook_offline_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_offline_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/webhooks/webhook_offline_di.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_offline_di.json
@@ -6,7 +6,6 @@
     "maxFileDescriptors": 90000,
     "compressResponses": false,
     {{ logging }}
-    "verbose":"true",
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/webhooks/webhook_offline_di.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_offline_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "verbose":"true",

--- a/resources/sync_gateway_configs/xattrs/mobile_opt_in_cc.json
+++ b/resources/sync_gateway_configs/xattrs/mobile_opt_in_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/xattrs/mobile_opt_in_di.json
+++ b/resources/sync_gateway_configs/xattrs/mobile_opt_in_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/xattrs/mobile_opt_in_no_import_cc.json
+++ b/resources/sync_gateway_configs/xattrs/mobile_opt_in_no_import_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/xattrs/mobile_opt_in_no_import_di.json
+++ b/resources/sync_gateway_configs/xattrs/mobile_opt_in_no_import_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/resources/sync_gateway_configs/xattrs/no_import_cc.json
+++ b/resources/sync_gateway_configs/xattrs/no_import_cc.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/xattrs/no_import_di.json
+++ b/resources/sync_gateway_configs/xattrs/no_import_di.json
@@ -4,7 +4,6 @@
     "maxIncomingConnections": 0,
     "maxCouchbaseConnections": 16,
     "maxFileDescriptors": 90000,
-    "slowServerCallWarningThreshold": 500,
     "compressResponses": false,
     {{ logging }}
     "cluster_config": {

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline.py
@@ -461,7 +461,7 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll(params_from_ba
     with concurrent.futures.ThreadPoolExecutor(max_workers=libraries.testkit.settings.MAX_REQUEST_WORKERS) as executor:
         futures = dict()
         futures[executor.submit(seth.start_longpoll_changes_tracking, termination_doc_id=None)] = "polling"
-        #  For windows, requiest is too slow, so have _offline request to start before creating docs
+        #  For windows, request is too slow, so have _offline request to start before creating docs
         if sg_platform == "windows":
             futures[executor.submit(sg_client.take_db_offline, cluster_conf, "db")] = "db_offline_task"
         time.sleep(5)

--- a/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
@@ -199,7 +199,7 @@ def test_log_nondefault_logKeys_set(params_from_base_test_setup, sg_conf_name):
     data = load_sync_gateway_config(sg_conf, cluster_hosts["couchbase_servers"][0], cluster_conf)
 
     # "FAKE" not valid area in logging
-    data['logging']["console"]["logKeys"] = ["HTTP", "FAKE"]
+    data['logging']["console"]["log_keys"] = ["HTTP", "FAKE"]
     # create temp config file in the same folder as sg_conf
     temp_conf = "/".join(sg_conf.split('/')[:-2]) + '/temp_conf.json'
 

--- a/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
@@ -19,7 +19,7 @@ def test_log_rotation_default_values(params_from_base_test_setup, sg_conf_name):
     """
     @summary
     Test to verify default values for rotation section:
-    maxsize = 100 MB
+    max_size = 100 MB
     MaxAge = 0(do not limit the number of MaxAge)
     MaxBackups = 0(do not limit the number of backups)
     """
@@ -373,7 +373,7 @@ def test_log_rotation_invalid_path(params_from_base_test_setup, sg_conf_name):
 def test_log_200mb(params_from_base_test_setup, sg_conf_name):
     """
     @summary
-    Test to check maxsize with value 200MB( 100Mb by default)
+    Test to check max_size with value 200MB( 100Mb by default)
     """
     cluster_conf = params_from_base_test_setup["cluster_config"]
     mode = params_from_base_test_setup["mode"]
@@ -423,7 +423,7 @@ def test_log_200mb(params_from_base_test_setup, sg_conf_name):
     # Set maxsize
     for log in SG_LOGS:
         log_section = log.split("_")[1]
-        data['logging'][log_section]["rotation"]["maxsize"] = 200
+        data['logging'][log_section]["rotation"]["max_size"] = 200
 
     # Create a temp config file in the same folder as sg_conf
     temp_conf = "/".join(sg_conf.split('/')[:-2]) + '/temp_conf.json'
@@ -456,7 +456,7 @@ def test_log_rotation_negative(params_from_base_test_setup, sg_conf_name):
     """
     @summary
     Test log rotation with negative values for:
-        "maxsize": -1,
+        "max_size": -1,
         "maxage": -30,
         "maxbackups": -2
     SG shouldn't start

--- a/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
@@ -541,8 +541,8 @@ def test_log_maxbackups_0(params_from_base_test_setup, sg_conf_name):
     sg_admin_url = cluster_hosts["sync_gateways"][0]["admin"]
     sg_ip = host_for_url(sg_admin_url)
 
-    if get_sync_gateway_version(sg_ip)[0] < "2.1":
-        pytest.skip("Continuous logging Test NA for SG < 2.1")
+    if get_sync_gateway_version(sg_ip)[0] < "2.1" and get_sync_gateway_version(sg_ip)[0] >= "2.6.0":
+        pytest.skip("Continuous logging Test NA for SG < 2.1 and backup config is removed 2.6.0 and up")
 
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
@@ -675,6 +675,6 @@ def send_request_to_sgw(sg_one_url, sg_admin_url, remote_executor, sg_platform="
 
     else:
         remote_executor.execute(
-            "for ((i=1;i <= 2000;i += 1)); do curl -s http://localhost:4984/ABCD/ > /dev/null; done")
+            "for ((i=1;i <= 3200;i += 1)); do curl -s http://localhost:4984/ABCD/ > /dev/null; done")
         remote_executor.execute(
             "for ((i=1;i <= 2000;i += 1)); do curl -s -H 'Accept: text/plain' http://localhost:4985/db/ > /dev/null; done")


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- modified and replaced with new configs which is valid for cobalt
-fixed tests with new changes in cobalt