### PR TITLE
Fix/p2p testserver ios dotnet for message endpoint connections

### DIFF
--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/P2PMethods.cs
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/P2PMethods.cs
@@ -72,7 +72,7 @@ namespace Couchbase.Lite.Testing
             }
             else{
                 TcpMessageEndpointDelegate endpointDelegate = new TcpMessageEndpointDelegate();
-                var _endpoint = new MessageEndpoint("something", host, ProtocolType.ByteStream, endpointDelegate);
+                var _endpoint = new MessageEndpoint(dbUrl.AbsoluteUri, dbUrl, ProtocolType.ByteStream, endpointDelegate);
                 config = new ReplicatorConfiguration(db, _endpoint);
             }
 

--- a/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Server/ReplicatorTcpServerConnection.swift
+++ b/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Server/ReplicatorTcpServerConnection.swift
@@ -80,7 +80,7 @@ public class ReplicatorTcpServerConnection : ReplicatorTcpConnection {
         
         // Validate path:
         let url = CFHTTPMessageCopyRequestURL(request)?.takeRetainedValue() as URL?
-        guard let path = url?.path, path.hasPrefix("/"), path.hasSuffix("/_blipsync") else {
+        guard let path = url?.path, path.hasPrefix("/") else {
             sendFailureResponse(code: 404, message: "Not Found")
             return
         }
@@ -95,7 +95,13 @@ public class ReplicatorTcpServerConnection : ReplicatorTcpConnection {
         
         // Accept the connection per database:
         let begin = path.index(after: path.startIndex)
-        let end = path.index(path.startIndex, offsetBy: path.count - 11)
+        var end: String.Index!
+        if (path.hasSuffix("/_blipsync")) {
+            end = path.index(path.startIndex, offsetBy: path.count - 11)
+        } else {
+            end = path.index(before: path.endIndex)//path.endIndex
+        }
+
         let db = String(path[begin...end])
         if !(listener!.accept(connection: self, database: db)) {
             response = nil


### PR DESCRIPTION
#### Fixes #.

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- added url and db name to testserver on dotnet platform for p2p message endpoint connection
- added logic to deal with missing blip indicator on ios platform for p2p message endpoint connection

