### PR TITLE
deal with chan_cache_tombstone_revs with sgw cobalt caching feature

### DIFF
--- a/keywords/MobileRestClient.py
+++ b/keywords/MobileRestClient.py
@@ -1956,28 +1956,6 @@ class MobileRestClient:
         log_info("Found {} changes".format(len(resp_obj["results"])))
         return resp_obj
 
-    def post_changes(self, url, db, auth, body_elements=None):
-        """
-        This method handles a POST _changes request to Sync Gateway in a generic manner
-        if url points to Public APIs, auth method/value is required.
-        if url points to Admin APIs, no auth is needed. Caller is responsible for matching the url with the auth.
-        body_elements is key-value pairs included in body of the request
-        """
-        auth_type = get_auth_type(auth)
-        body = {}
-        if body_elements is not None:
-            for key, value in body_elements.iteritems():
-                body[key] = value
-
-        if auth_type == AuthType.session:
-            resp = self._session.post("{}/{}/_changes".format(url, db), data=json.dumps(body), cookies=dict(SyncGatewaySession=auth[1]), stream=True)
-        elif auth_type == AuthType.http_basic:
-            resp = self._session.post("{}/{}/_changes".format(url, db), data=json.dumps(body), auth=auth, stream=True)
-        else:
-            resp = self._session.post("{}/{}/_changes".format(url, db), data=json.dumps(body))
-
-        return resp
-
     def verify_doc_id_in_changes(self, url, db, expected_doc_id, auth=None):
         """ Verifies 'expected_doc_id' shows up in the changes feed starting with a since of 0
         if the doc is not found before CLIENT_REQUEST_TIMEOUT, an exception is raised. If it is found,

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
@@ -639,10 +639,13 @@ def test_CBL_tombstone_doc(params_from_base_test_setup, num_of_docs):
     replicator.stop(repl)
 
     # 2.5. call POST _changes admin API to apply changes to all channels.
-    body = dict(doc_ids=db.getDocIds(cbl_db))
-    # {"doc_ids", db.getDocIds(cbl_db)}
-    # body["doc_ids"] = db.getDocIds(cbl_db)
-    sg_client.post_changes(url=sg_admin_url, db=sg_db, auth=None, body_elements=body)
+    sg_client.stream_continuous_changes(
+        url=sg_admin_url,
+        db=sg_db,
+        since=0,
+        auth=None,
+        filter_type=None,
+        filter_channels=None)
 
     # 3. tombstone doc in SG.
     doc_id = "sg_docs_6"

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
@@ -638,6 +638,12 @@ def test_CBL_tombstone_doc(params_from_base_test_setup, num_of_docs):
     replicator.wait_until_replicator_idle(repl)
     replicator.stop(repl)
 
+    # 2.5. call POST _changes admin API to apply changes to all channels.
+    body = dict(doc_ids=db.getDocIds(cbl_db))
+    # {"doc_ids", db.getDocIds(cbl_db)}
+    # body["doc_ids"] = db.getDocIds(cbl_db)
+    sg_client.post_changes(url=sg_admin_url, db=sg_db, auth=None, body_elements=body)
+
     # 3. tombstone doc in SG.
     doc_id = "sg_docs_6"
     doc = sg_client.get_doc(url=sg_url, db=sg_db, doc_id=doc_id, auth=session)
@@ -652,12 +658,7 @@ def test_CBL_tombstone_doc(params_from_base_test_setup, num_of_docs):
 
     if sync_gateway_version >= "2.5.0":
         expvars = sg_client.get_expvars(sg_admin_url)
-        if sync_gateway_version >= "2.6.0":
-            # chan_cache_tombstone_revs remains no change while tombstone a doc because of the cache initialization feature in 2.6
-            assert chan_cache_tombstone_revs == expvars["syncgateway"]["per_db"][sg_db]["cache"]["chan_cache_tombstone_revs"], "chan cache tombstone revs should not be incremented with the lazy cache initialization feature"
-        else:
-            # chan_cache_tombstone_revs increases while tombstone a doc with Iridium release
-            assert chan_cache_tombstone_revs < expvars["syncgateway"]["per_db"][sg_db]["cache"]["chan_cache_tombstone_revs"], "chan cache tombstone revs did not get incremented"
+        assert chan_cache_tombstone_revs < expvars["syncgateway"]["per_db"][sg_db]["cache"]["chan_cache_tombstone_revs"], "chan cache tombstone revs did not get incremented"
         assert chan_cache_removal_revs < expvars["syncgateway"]["per_db"][sg_db]["cache"]["chan_cache_removal_revs"], "chan_cache_removal_revs did not get incremented"
 
 

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
@@ -652,7 +652,12 @@ def test_CBL_tombstone_doc(params_from_base_test_setup, num_of_docs):
 
     if sync_gateway_version >= "2.5.0":
         expvars = sg_client.get_expvars(sg_admin_url)
-        assert chan_cache_tombstone_revs < expvars["syncgateway"]["per_db"][sg_db]["cache"]["chan_cache_tombstone_revs"], "chan cache tombstone revs did not get incremented"
+        if sync_gateway_version >= "2.6.0":
+            # chan_cache_tombstone_revs remains no change while tombstone a doc because of the cache initialization feature in 2.6
+            assert chan_cache_tombstone_revs == expvars["syncgateway"]["per_db"][sg_db]["cache"]["chan_cache_tombstone_revs"], "chan cache tombstone revs did not get incremented"
+        else:
+            # chan_cache_tombstone_revs increases while tombstone a doc with Iridium release
+            assert chan_cache_tombstone_revs < expvars["syncgateway"]["per_db"][sg_db]["cache"]["chan_cache_tombstone_revs"], "chan cache tombstone revs did not get incremented"
         assert chan_cache_removal_revs < expvars["syncgateway"]["per_db"][sg_db]["cache"]["chan_cache_removal_revs"], "chan_cache_removal_revs did not get incremented"
 
 

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
@@ -654,7 +654,7 @@ def test_CBL_tombstone_doc(params_from_base_test_setup, num_of_docs):
         expvars = sg_client.get_expvars(sg_admin_url)
         if sync_gateway_version >= "2.6.0":
             # chan_cache_tombstone_revs remains no change while tombstone a doc because of the cache initialization feature in 2.6
-            assert chan_cache_tombstone_revs == expvars["syncgateway"]["per_db"][sg_db]["cache"]["chan_cache_tombstone_revs"], "chan cache tombstone revs did not get incremented"
+            assert chan_cache_tombstone_revs == expvars["syncgateway"]["per_db"][sg_db]["cache"]["chan_cache_tombstone_revs"], "chan cache tombstone revs should not be incremented with the lazy cache initialization feature"
         else:
             # chan_cache_tombstone_revs increases while tombstone a doc with Iridium release
             assert chan_cache_tombstone_revs < expvars["syncgateway"]["per_db"][sg_db]["cache"]["chan_cache_tombstone_revs"], "chan cache tombstone revs did not get incremented"


### PR DESCRIPTION
#### Fixes #.

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- add sgw version handling which behave differently w/o cobalt cache enhancement feature


