### PR TITLE
Fix/cm-193 reset_checkpoint failure

### DIFF
--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
@@ -652,7 +652,12 @@ def test_CBL_tombstone_doc(params_from_base_test_setup, num_of_docs):
 
     if sync_gateway_version >= "2.5.0":
         expvars = sg_client.get_expvars(sg_admin_url)
-        assert chan_cache_tombstone_revs < expvars["syncgateway"]["per_db"][sg_db]["cache"]["chan_cache_tombstone_revs"], "chan cache tombstone revs did not get incremented"
+        if sync_gateway_version >= "2.6.0":
+            # chan_cache_tombstone_revs remains no change while tombstone a doc because of the cache initialization feature in 2.6
+            assert chan_cache_tombstone_revs == expvars["syncgateway"]["per_db"][sg_db]["cache"]["chan_cache_tombstone_revs"], "chan cache tombstone revs did not get incremented"
+        else:
+            # chan_cache_tombstone_revs increases while tombstone a doc with Iridium release
+            assert chan_cache_tombstone_revs < expvars["syncgateway"]["per_db"][sg_db]["cache"]["chan_cache_tombstone_revs"], "chan cache tombstone revs did not get incremented"
         assert chan_cache_removal_revs < expvars["syncgateway"]["per_db"][sg_db]["cache"]["chan_cache_removal_revs"], "chan_cache_removal_revs did not get incremented"
 
 

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
@@ -2982,10 +2982,10 @@ def test_resetCheckpointFailure(params_from_base_test_setup):
     with pytest.raises(Exception) as he:
         replicator.resetCheckPoint(repl)
     if liteserv_platform.lower() == "android":
-        assert 'Attempt to reset the checkpoint for a replicator that is not stopped.' in he.value.message
+        assert 'Attempt to reset the checkpoint for a replicator that is not stopped.' in he.value.message, "Reset the checkpoint should have thrown exception to inform that replicator is not stopped."
     else:
         assert 'Replicator is not stopped.' in he.value.message
-        assert 'Resetting checkpoint is only allowed when the replicator is in the stopped state' in he.value.message
+        assert 'Resetting checkpoint is only allowed when the replicator is in the stopped state' in he.value.message, "Reset the checkpoint should have thrown exception to inform that replicator is not stopped."
     replicator.stop(repl)
 
 


### PR DESCRIPTION
#### Fixes #.

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- android exception error message is different than .net platform, deal with the message per platform


