### PR TITLE
change the way to instantiate Gson object to keep items with a key has null value

### DIFF
--- a/CBLClient/Apps/CBLTestServer-Android/app/src/main/java/com/couchbase/CouchbaseLiteServ/server/ValueSerializer.java
+++ b/CBLClient/Apps/CBLTestServer-Android/app/src/main/java/com/couchbase/CouchbaseLiteServ/server/ValueSerializer.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.gson.GsonBuilder;
 import com.google.gson.Gson;
 
 
@@ -46,7 +47,8 @@ public class ValueSerializer {
                 String string = serialize(entry.getValue(), memory);
                 stringMap.put(key, string);
             }
-            return new Gson().toJson(stringMap);
+            Gson gson = new GsonBuilder().serializeNulls().create();
+            return gson.toJson(stringMap);
         }
         else if (value instanceof List) {
             List list = (List) value;
@@ -56,7 +58,8 @@ public class ValueSerializer {
                 String string = serialize(object, memory);
                 stringList.add(string);
             }
-            return new Gson().toJson(stringList);
+            Gson gson = new GsonBuilder().serializeNulls().create();
+            return gson.toJson(stringList);
         }
         else if (value instanceof String) {
             String string = (String) value;


### PR DESCRIPTION
#### Fixes cm-216 - test_delta_sync_nested_doc.

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- the way we instantiate Gson automatically filtered out items while a key has null value, the fix keeps it for item counting. Here are the details:

The Android TestServer calls cblite api to getDocuments object => serialize it to string => use Gson to convert to Json format before send HTTP response back to the test framework request. 

The original code instantiate Gson as
`new Gson().toJson(stringMap);`

doing this Gson will automatically filter out any key with a null value. For instance, if I have a set of key value pairs with size 3, {key1: "value1", key2:null, key3:null} with count=3, Gson will only return {key1: "value1"}, count=1. I need to do this

```
 Gson gson = new GsonBuilder().serializeNulls().create();
 return gson.toJson(stringMap);
```

then I will get count=3 with all elements even the value is null.


