### PR TITLE
Fix/cm-174 predictive queries basic input output

### DIFF
--- a/keywords/utils.py
+++ b/keywords/utils.py
@@ -4,6 +4,7 @@ import os
 import random
 import string
 import re
+import pdb
 
 from keywords.exceptions import FeatureSupportedError
 from keywords.constants import DATA_DIR
@@ -323,7 +324,7 @@ def compare_generic_types(object1, object2):
     elif isinstance(object1, int) and isinstance(object2, long):
         return object1 == int(object2)
     elif isinstance(object1, float) and isinstance(object2, long):
-        return object1 == float(object2)
+        return abs(object1 - object2) < 100
     elif isinstance(object1, long) and isinstance(object2, float):
         return object1 == long(float(object2))
     elif isinstance(object1, str) and isinstance(object2, unicode):

--- a/keywords/utils.py
+++ b/keywords/utils.py
@@ -299,7 +299,7 @@ def compare_docs(cbl_db, db, docs_dict):
         assert deep_dict_compare(doc["doc"], cbl_db_docs[key]), "mismatch in the dictionary"
 
 
-def compare_generic_types(object1, object2):
+def compare_generic_types(object1, object2, isPredictiveResult=False):
     if object1 is None and object2 is None:
         return True
     if isinstance(object1, str) and isinstance(object2, str):
@@ -323,7 +323,10 @@ def compare_generic_types(object1, object2):
     elif isinstance(object1, int) and isinstance(object2, long):
         return object1 == int(object2)
     elif isinstance(object1, float) and isinstance(object2, long):
-        return abs(object1 - object2) < 100
+        if isPredictiveResult:
+            return abs(object1 - object2) < 100
+        else:
+            return object1 == float(object2)
     elif isinstance(object1, long) and isinstance(object2, float):
         return object1 == long(float(object2))
     elif isinstance(object1, str) and isinstance(object2, unicode):
@@ -333,24 +336,24 @@ def compare_generic_types(object1, object2):
     return False
 
 
-def deep_list_compare(object1, object2):
+def deep_list_compare(object1, object2, isPredictiveResult=False):
     retval = True
     count = len(object1)
     object1 = sorted(object1)
     object2 = sorted(object2)
     for x in range(count):
         if isinstance(object1[x], dict) and isinstance(object2[x], dict):
-            retval = deep_dict_compare(object1[x], object2[x])
+            retval = deep_dict_compare(object1[x], object2[x], isPredictiveResult)
             if retval is False:
                 log_info("Unable to match element in dict {} and {}".format(object1, object2))
                 return False
         elif isinstance(object1[x], list) and isinstance(object2[x], list):
-            retval = deep_list_compare(object1[x], object2[x])
+            retval = deep_list_compare(object1[x], object2[x], isPredictiveResult)
             if retval is False:
                 log_info("Unable to match element in list {} and {}".format(object1[x], object2[x]))
                 return False
         else:
-            retval = compare_generic_types(object1[x], object2[x])
+            retval = compare_generic_types(object1[x], object2[x], isPredictiveResult)
             if retval is False:
                 log_info("Unable to match objects in generic {} and {}".format(object1[x], object2[x]))
                 return False
@@ -358,7 +361,7 @@ def deep_list_compare(object1, object2):
     return retval
 
 
-def deep_dict_compare(object1, object2):
+def deep_dict_compare(object1, object2, isPredictiveResult=False):
     retval = True
     if len(object1) != len(object2):
         log_info("lengths of sgw object and cbl object are different {} --- {}".format(len(object1), len(object2)))
@@ -369,18 +372,18 @@ def deep_dict_compare(object1, object2):
         obj1 = object1[k]
         obj2 = object2[k]
         if isinstance(obj1, list) and isinstance(obj2, list):
-            retval = deep_list_compare(obj1, obj2)
+            retval = deep_list_compare(obj1, obj2, isPredictiveResult)
             if retval is False:
                 log_info("mismatch between sgw: {} and cbl lists :{}".format(obj1, obj2))
                 return False
 
         elif isinstance(obj1, dict) and isinstance(obj2, dict):
-            retval = deep_dict_compare(obj1, obj2)
+            retval = deep_dict_compare(obj1, obj2, isPredictiveResult)
             if retval is False:
                 log_info("mismatch between sgw: {} and cbl dict :{}".format(obj1, obj2))
                 return False
         else:
-            retval = compare_generic_types(obj1, obj2)
+            retval = compare_generic_types(obj1, obj2, isPredictiveResult)
             if retval is False:
                 log_info("mismatch {} and {}".format(obj1, obj2))
                 return False

--- a/keywords/utils.py
+++ b/keywords/utils.py
@@ -4,7 +4,6 @@ import os
 import random
 import string
 import re
-import pdb
 
 from keywords.exceptions import FeatureSupportedError
 from keywords.constants import DATA_DIR

--- a/keywords/utils.py
+++ b/keywords/utils.py
@@ -300,6 +300,13 @@ def compare_docs(cbl_db, db, docs_dict):
 
 
 def compare_generic_types(object1, object2, isPredictiveResult=False):
+    """
+    @summary:
+    A method to compare generic type of objects with an option of making approximate comparison.
+    If isPredictiveResult flag is enabled, some large numbers are considered equal if the difference is tolerable.
+    @return:
+    true if equals, false otherwise
+    """
     if object1 is None and object2 is None:
         return True
     if isinstance(object1, str) and isinstance(object2, str):
@@ -337,6 +344,13 @@ def compare_generic_types(object1, object2, isPredictiveResult=False):
 
 
 def deep_list_compare(object1, object2, isPredictiveResult=False):
+    """
+    @summary:
+    A method to compare two lists with an option of forwarding 
+    an approximate comparison flag to compare_generic_types function
+    @return:
+    true if equals, false otherwise
+    """
     retval = True
     count = len(object1)
     object1 = sorted(object1)
@@ -362,6 +376,13 @@ def deep_list_compare(object1, object2, isPredictiveResult=False):
 
 
 def deep_dict_compare(object1, object2, isPredictiveResult=False):
+    """
+    @summary:
+    A method to compare two dictionaries with an option of forwarding 
+    an approximate comparison flag to compare_generic_types function.
+    @return:
+    true if equals, false otherwise
+    """
     retval = True
     if len(object1) != len(object2):
         log_info("lengths of sgw object and cbl object are different {} --- {}".format(len(object1), len(object2)))

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_predective_queries.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_predective_queries.py
@@ -62,6 +62,10 @@ def test_predictiveQueries_basicInputOutput(params_from_base_test_setup, doc_gen
 
     assert total_docs == len(result_set), "expected number of docs is {}, the actual number of docs is {}".format(total_docs, len(result_set))
     for result in result_set:
+        '''
+        call deep_dict_compare with isPredictiveResult enabled flag
+        this flag allows large numbers do approximate comparison instead of precise comparison.
+        '''
         assert deep_dict_compare(doc_body, result[result.keys()[0]], True)
 
     non_dict = "non_dict"

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_predective_queries.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_predective_queries.py
@@ -56,11 +56,13 @@ def test_predictiveQueries_basicInputOutput(params_from_base_test_setup, doc_gen
     else:
         doc_body = doc_generators.simple()
 
-    db.create_bulk_docs(2, "cbl-predictive", db=cbl_db, generator=doc_generator_type)
+    total_docs = 2
+    db.create_bulk_docs(total_docs, "cbl-predictive", db=cbl_db, generator=doc_generator_type)
     result_set = predictive_query.getPredictionQueryResult(model, doc_body, cbl_db)
 
+    assert total_docs == len(result_set), "expected number of docs is {}, the actual number of docs is {}".format(total_docs, len(result_set))
     for result in result_set:
-        assert deep_dict_compare(doc_body, result[result.keys()[0]])
+        assert deep_dict_compare(doc_body, result[result.keys()[0]], True)
 
     non_dict = "non_dict"
     error = predictive_query.queryNonDictionaryInput(model, non_dict, cbl_db)


### PR DESCRIPTION
#### Fixes cm-174.

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

[requirements]
predictive query results comparison need tolerant for small diff between long or float numbers. such as randomly generated float number 60082543713568.90625 may become a long number like 60082543713613 showing on predictive query result set. They are considered equal in this scenario. 
[fixes]
- add a flag to all compare functions with default value of isPredictiveResult=False
- implemented a tolerant compare for predictive result
- set the flag to True in predictive test case

