### PR TITLE
add type handling and comparison tolerance to iOS platform for predictive queris

### DIFF
--- a/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Server/ValueSerializer.swift
+++ b/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Server/ValueSerializer.swift
@@ -93,7 +93,7 @@ public class ValueSerializer {
             let start = value!.index(value!.startIndex, offsetBy: 1)
             let end = value!.index(value!.endIndex, offsetBy: 0)
             let range = start..<end
-            return Float(value!.substring(with: range)) as? T
+            return Double(value!.substring(with: range)) as? T
            
         } else if value!.hasPrefix("D") {
             let start = value!.index(value!.startIndex, offsetBy: 1)

--- a/keywords/utils.py
+++ b/keywords/utils.py
@@ -322,7 +322,10 @@ def compare_generic_types(object1, object2, isPredictiveResult=False):
     elif isinstance(object1, float) and isinstance(object2, float):
         return object1 == object2
     elif isinstance(object1, float) and isinstance(object2, int):
-        return object1 == float(object2)
+        if isPredictiveResult:
+            return abs(object1 - object2) < 100
+        else:
+            return object1 == float(object2)
     elif isinstance(object1, int) and isinstance(object2, float):
         return object1 == int(float(object2))
     elif isinstance(object1, long) and isinstance(object2, int):


### PR DESCRIPTION
predictive queries tests handle data on platform specific. there was a previous checkin only fixed the problem on Android. this fix is for iOS especially.

#### Fixes #.

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- in iOS TestServer app, on 'F' (float indicator), convert to Double in response value.
- added comparison tolerance for float vs int comparison scenario

