### PR TITLE
add --use-local-testserver flag to CBL topology test suite

### DIFF
--- a/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -34,6 +34,11 @@ def pytest_addoption(parser):
                      help="Skip cluster provisioning at setup",
                      default=False)
 
+    parser.addoption("--use-local-testserver",
+                     action="store_true",
+                     help="Skip download and launch TestServer, use local debug build",
+                     default=False)
+
     parser.addoption("--server-version",
                      action="store",
                      help="server-version: Couchbase Server version to install (ex. 4.5.0 or 4.5.0-2601)")
@@ -135,6 +140,7 @@ def params_from_base_suite_setup(request):
     liteserv_port = request.config.getoption("--liteserv-port")
 
     skip_provisioning = request.config.getoption("--skip-provisioning")
+    use_local_testserver = request.config.getoption("--use-local-testserver")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
     mode = request.config.getoption("--mode")
 
@@ -163,15 +169,16 @@ def params_from_base_suite_setup(request):
                                           community_enabled=community_enabled,
                                           debug_mode=debug_mode)
 
-    log_info("Downloading TestServer ...")
-    # Download TestServer app
-    testserver.download()
+    if not use_local_testserver:
+        log_info("Downloading TestServer ...")
+        # Download TestServer app
+        testserver.download()
 
-    # Install TestServer app
-    if device_enabled:
-        testserver.install_device()
-    else:
-        testserver.install()
+        # Install TestServer app
+        if device_enabled:
+            testserver.install_device()
+        else:
+            testserver.install()
 
     base_url = "http://{}:{}".format(liteserv_host, liteserv_port)
     cluster_config = "{}/multiple_sync_gateways_{}".format(CLUSTER_CONFIGS_DIR, mode)
@@ -388,7 +395,9 @@ def params_from_base_suite_setup(request):
     utils_obj = Utils(base_url)
     utils_obj.flushMemory()
     log_info("Stopping the test server")
-    testserver.stop()
+    if not use_local_testserver:
+        log_info("Stopping the test server per suite")
+        testserver.stop()
 
     # Delete png files under resources/data
     clear_resources_pngs()
@@ -424,6 +433,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     delta_sync_enabled = params_from_base_suite_setup["delta_sync_enabled"]
     encryption_password = params_from_base_suite_setup["encryption_password"]
     enable_encryption = params_from_base_suite_setup["enable_encryption"]
+    use_local_testserver = request.config.getoption("--use-local-testserver")
     source_db = None
     cbl_db = None
     db_config = None
@@ -432,12 +442,13 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     # Start LiteServ and delete any databases
     log_info("Starting TestServer...")
     test_name_cp = test_name.replace("/", "-")
-    if device_enabled:
-        testserver.start_device("{}/logs/{}-{}-{}.txt".format(RESULTS_DIR, type(testserver).__name__, test_name_cp, datetime.datetime.now()))
-    else:
-        testserver.start("{}/logs/{}-{}-{}.txt".format(RESULTS_DIR, type(testserver).__name__, test_name_cp, datetime.datetime.now()))
-    # sleep for some time to reach cbl
-    time.sleep(5)
+    if not use_local_testserver:
+        if device_enabled:
+            testserver.start_device("{}/logs/{}-{}-{}.txt".format(RESULTS_DIR, type(testserver).__name__, test_name_cp, datetime.datetime.now()))
+        else:
+            testserver.start("{}/logs/{}-{}-{}.txt".format(RESULTS_DIR, type(testserver).__name__, test_name_cp, datetime.datetime.now()))
+        # sleep for some time to reach cbl
+        time.sleep(5)
 
     cluster_helper = ClusterKeywords(cluster_config)
     cluster_hosts = cluster_helper.get_cluster_topology(cluster_config=cluster_config)


### PR DESCRIPTION
#### Fixes #.

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- add --use-local-testserver flag to CBL topology conftest file, it's convince for debugging and local run


