### PR TITLE
add network security config to bypass cleartext support restriction on android 9+

### DIFF
--- a/CBLClient/Apps/CBLTestServer-Android/app/build.gradle
+++ b/CBLClient/Apps/CBLTestServer-Android/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 ext {
-    DEF_VERSION = "2.7.0-183"
+    DEF_VERSION = "2.7.0-188"
     COUCHBASE_LITE_VERSION = System.getProperty('version', DEF_VERSION)
 
     PROJECT_DIR = "${projectDir}"

--- a/CBLClient/Apps/CBLTestServer-Android/app/src/main/AndroidManifest.xml
+++ b/CBLClient/Apps/CBLTestServer-Android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
+        android:networkSecurityConfig="@xml/network_security_config"
         >
         <activity android:name=".MainActivity">
             <intent-filter>

--- a/CBLClient/Apps/CBLTestServer-Android/app/src/main/res/xml/network_security_config.xml
+++ b/CBLClient/Apps/CBLTestServer-Android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
add network security config to bypass cleartext support restriction on android 9+.

#### Fixes # cm-284.

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- added network_security_config.xml, set cleartextTrafficPermitted="true" in base-config, because the SGW machines are randomly assigned from the server pool, ip address per test job used is random.
- applied the config xml file to manifest.

