### PR TITLE
Fix/cm-303 security policy support for Xamarin-Android

### DIFF
--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/Properties/AndroidManifest.xml
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/Properties/AndroidManifest.xml
@@ -5,5 +5,5 @@
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_WIFI_STATE"></uses-permission>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <application android:networkSecurityConfig="@xml/network_security_config" />
+	<application android:networkSecurityConfig="@xml/network_security_config" />
 </manifest>

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/Properties/AndroidManifest.xml
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/Properties/AndroidManifest.xml
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="TestServer.Android" android:versionCode="1" android:versionName="1.0" android:installLocation="auto">
-	<uses-sdk android:minSdkVersion="21" />
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="28" />
 	<application android:allowBackup="true" android:label="@string/app_name"></application>
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_WIFI_STATE"></uses-permission>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <application android:networkSecurityConfig="@xml/network_security_config" />
 </manifest>

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/Resources/Resource.Designer.cs
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/Resources/Resource.Designer.cs
@@ -44,8 +44,8 @@ namespace TestServer.Android
 		public partial class Layout
 		{
 			
-			// aapt resource value: 0x7f020000
-			public const int Main = 2130837504;
+			// aapt resource value: 0x7F010000
+			public const int Main = 2130771968;
 			
 			static Layout()
 			{
@@ -60,8 +60,8 @@ namespace TestServer.Android
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f030000
-			public const int app_name = 2130903040;
+			// aapt resource value: 0x7F020000
+			public const int app_name = 2130837504;
 			
 			static String()
 			{

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/Resources/Resource.Designer.cs
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/Resources/Resource.Designer.cs
@@ -72,6 +72,22 @@ namespace TestServer.Android
 			{
 			}
 		}
+		
+		public partial class Xml
+		{
+			
+			// aapt resource value: 0x7F030000
+			public const int network_security_config = 2130903040;
+			
+			static Xml()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Xml()
+			{
+			}
+		}
 	}
 }
 #pragma warning restore 1591

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/Resources/xml/network_security_config.xml
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/Resources/xml/network_security_config.xml
@@ -1,0 +1,1 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/Resources/xml/network_security_config.xml
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/Resources/xml/network_security_config.xml
@@ -1,1 +1,7 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="true">10.0.2.2</domain> <!-- Debug port -->
+    <domain includeSubdomains="true">xamarin.com</domain>
+  </domain-config>
+</network-security-config>

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/TestServer.Android.csproj
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/TestServer.Android.csproj
@@ -68,6 +68,10 @@
       <SubType>Designer</SubType>
     </AndroidResource>
     <AndroidResource Include="Resources\values\Strings.xml" />
+    <AndroidResource Include="Resources\xml\network_security_config.xml">
+      <SubType></SubType>
+      <Generator></Generator>
+    </AndroidResource>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\drawable\" />
@@ -76,6 +80,7 @@
     <Folder Include="Resources\mipmap-xhdpi\" />
     <Folder Include="Resources\mipmap-xxhdpi\" />
     <Folder Include="Resources\mipmap-xxxhdpi\" />
+    <Folder Include="Resources\xml\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TestServer\TestServer.csproj">

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/TestServer.Android.csproj
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/TestServer.Android.csproj
@@ -90,7 +90,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Couchbase.Lite.Enterprise.Support.Android">
-      <Version>2.5.0-b0191</Version>
+      <Version>2.7.0-b0075</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/TestServer.csproj
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/TestServer.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
-    <PackageReference Include="Couchbase.Lite.Enterprise" Version="2.5.2-b0003" />
+    <PackageReference Include="Couchbase.Lite.Enterprise" Version="2.7.0-b0075" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION

#### Changes proposed in this pull request:

- Added security policy support for Xamarin-Android for Android Pie(9.0)

Followed the process from here - https://devblogs.microsoft.com/xamarin/cleartext-http-android-network-security/

