### PR TITLE
implemented a customized encoder function to load different Base64 package per platform

### DIFF
--- a/CBLClient/Apps/CBLTestServer-Android/app/src/main/java/com/couchbase/CouchbaseLiteServ/TestServerContext.java
+++ b/CBLClient/Apps/CBLTestServer-Android/app/src/main/java/com/couchbase/CouchbaseLiteServ/TestServerContext.java
@@ -9,6 +9,8 @@ import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 
+import android.util.Base64;
+
 import java.util.Enumeration;
 
 public class TestServerContext implements Context {
@@ -56,4 +58,9 @@ public class TestServerContext implements Context {
         return ip;
     }
 
+    @Override
+    public String customEncode(byte[] hashBytes){
+        // load android.util.Base64 in android app
+        return Base64.encodeToString(hashBytes, Base64.NO_WRAP);
+    }
 }

--- a/CBLClient/Apps/CBLTestServer-Android/app/src/main/java/com/couchbase/CouchbaseLiteServ/TestServerContext.java
+++ b/CBLClient/Apps/CBLTestServer-Android/app/src/main/java/com/couchbase/CouchbaseLiteServ/TestServerContext.java
@@ -59,7 +59,7 @@ public class TestServerContext implements Context {
     }
 
     @Override
-    public String customEncode(byte[] hashBytes){
+    public String encodeBase64(byte[] hashBytes){
         // load android.util.Base64 in android app
         return Base64.encodeToString(hashBytes, Base64.NO_WRAP);
     }

--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/Context.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/Context.java
@@ -8,4 +8,11 @@ public interface Context {
     InputStream getAsset(String name);
     String getPlatform();
     String getLocalIpAddress();
+
+    /** the customEncode method allows custom Base64 package
+     * is loaded by platform specific:
+     * java.util.Base64 in java standalone and web application
+     * android.util.Base64 in android apps
+     */
+    String customEncode(byte[] hashBytes);
 }

--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/Context.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/Context.java
@@ -9,10 +9,11 @@ public interface Context {
     String getPlatform();
     String getLocalIpAddress();
 
-    /** the customEncode method allows custom Base64 package
+    /*
+     * the customEncode method allows custom Base64 package
      * is loaded by platform specific:
      * java.util.Base64 in java standalone and web application
      * android.util.Base64 in android apps
      */
-    String customEncode(byte[] hashBytes);
+    String encodeBase64(byte[] hashBytes);
 }

--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/ReplicatorTcpClientConnection.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/ReplicatorTcpClientConnection.java
@@ -94,7 +94,7 @@ public final class ReplicatorTcpClientConnection extends ReplicatorTcpConnection
         Random random = new Random();
         random.nextBytes(keyBytes);
 
-        return RequestHandlerDispatcher.context.customEncode(keyBytes);
+        return RequestHandlerDispatcher.context.encodeBase64(keyBytes);
     }
 
 }

--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/ReplicatorTcpClientConnection.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/ReplicatorTcpClientConnection.java
@@ -17,6 +17,8 @@ package com.couchbase.mobiletestkit.javacommon.RequestHandler;
 //
 
 
+import com.couchbase.mobiletestkit.javacommon.RequestHandlerDispatcher;
+
 import java.io.IOException;
 import java.net.Socket;
 import java.net.URI;
@@ -91,8 +93,8 @@ public final class ReplicatorTcpClientConnection extends ReplicatorTcpConnection
         byte[] keyBytes = new byte[16];
         Random random = new Random();
         random.nextBytes(keyBytes);
-        //return Base64.encodeToString(keyBytes, Base64.NO_WRAP); TODO - NEED TO REVISIT AND VERIFY IF VALUE STILL CORRECT WITHNOT NO_WRAP
-        return Base64.getEncoder().encodeToString(keyBytes);
+
+        return RequestHandlerDispatcher.context.customEncode(keyBytes);
     }
 
 }

--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/ReplicatorTcpConnection.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/ReplicatorTcpConnection.java
@@ -173,6 +173,6 @@ public abstract class ReplicatorTcpConnection implements MessageEndpointConnecti
         }
 
         byte[] hashBytes = md.digest(longKey.getBytes(StandardCharsets.US_ASCII));
-        return RequestHandlerDispatcher.context.customEncode(hashBytes);
+        return RequestHandlerDispatcher.context.encodeBase64(hashBytes);
     }
 }

--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/ReplicatorTcpConnection.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/ReplicatorTcpConnection.java
@@ -25,10 +25,10 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.couchbase.mobiletestkit.javacommon.RequestHandlerDispatcher;
 import com.couchbase.mobiletestkit.javacommon.util.Log;
 import com.couchbase.lite.Message;
 import com.couchbase.lite.MessageEndpointConnection;
@@ -173,7 +173,6 @@ public abstract class ReplicatorTcpConnection implements MessageEndpointConnecti
         }
 
         byte[] hashBytes = md.digest(longKey.getBytes(StandardCharsets.US_ASCII));
-        //return Base64.encodeToString(hashBytes, Base64.NO_WRAP); TODO - NEED TO REVISIT AND SEE IF IT WORKS WITHOUT NO_WRAP FORMAT
-        return Base64.getEncoder().encodeToString(hashBytes);
+        return RequestHandlerDispatcher.context.customEncode(hashBytes);
     }
 }


### PR DESCRIPTION
#### Fixes cm-309 Android P2P app is crashing during replication

https://issues.couchbase.com/browse/CM-309

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

java.util.Base64 is not able to be loaded to Android runtime properly. to address this issue:

- Added a method definition to context interface, which allows upcoming java desktop and java web service application to load Base64 package by need
- implemented android platform specific encoder function to load android.util.Base64.

