### PR TITLE
Fix/fix mercury x509 tests

### DIFF
--- a/libraries/testkit/admin.py
+++ b/libraries/testkit/admin.py
@@ -86,13 +86,13 @@ class Admin:
 
         return User(target, db, name, password, channels)
 
-    def register_bulk_users(self, target, db, name_prefix, number, password, channels=list(), roles=list()):
+    def register_bulk_users(self, target, db, name_prefix, number, password, channels=list(), roles=list(), num_of_workers=settings.MAX_REQUEST_WORKERS):
 
         if type(channels) is not list:
             raise ValueError("Channels needs to be a list")
 
         users = []
-        with concurrent.futures.ThreadPoolExecutor(max_workers=settings.MAX_REQUEST_WORKERS) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_of_workers) as executor:
             futures = [executor.submit(self.register_user, target=target, db=db, name="{}_{}".format(name_prefix, i), password=password, channels=channels, roles=roles) for i in range(number)]
             for future in concurrent.futures.as_completed(futures):
                 try:

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
@@ -16,7 +16,7 @@ from concurrent.futures import ThreadPoolExecutor
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
 from keywords import document, attachment
 from libraries.testkit import cluster
-from utilities.cluster_config_utils import persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 @pytest.fixture(scope="function")
@@ -66,6 +66,7 @@ def test_replication_configuration_valid_values(params_from_base_test_setup, num
     sg_config = params_from_base_test_setup["sg_config"]
     db = params_from_base_test_setup["db"]
     cbl_db = params_from_base_test_setup["source_db"]
+    mode = params_from_base_test_setup["mode"]
     sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
 
     if sync_gateway_version < "2.0.0":
@@ -80,9 +81,9 @@ def test_replication_configuration_valid_values(params_from_base_test_setup, num
 
     # Reset cluster to ensure no data in system
     if x509_cert_auth:
-        persist_cluster_config_environment_prop(cluster_config, 'x509_certs', True)
-    else:
-        persist_cluster_config_environment_prop(cluster_config, 'x509_certs', False)
+        temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_config = temp_cluster_config
     c = cluster.Cluster(config=cluster_config)
     c.reset(sg_config_path=sg_config)
 
@@ -636,6 +637,7 @@ def test_CBL_tombstone_doc(params_from_base_test_setup, num_of_docs, x509_cert_a
     sg_config = params_from_base_test_setup["sg_config"]
     db = params_from_base_test_setup["db"]
     cbl_db = params_from_base_test_setup["source_db"]
+    mode = params_from_base_test_setup["mode"]
 
     if sync_gateway_version < "2.0":
         pytest.skip('--no-conflicts is enabled and does not work with sg < 2.0 , so skipping the test')
@@ -645,9 +647,9 @@ def test_CBL_tombstone_doc(params_from_base_test_setup, num_of_docs, x509_cert_a
 
     # Modify sync-gateway config to use no-conflicts config
     if x509_cert_auth:
-        persist_cluster_config_environment_prop(cluster_config, 'x509_certs', True)
-    else:
-        persist_cluster_config_environment_prop(cluster_config, 'x509_certs', False)
+        temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_config = temp_cluster_config
     c = cluster.Cluster(config=cluster_config)
     c.reset(sg_config_path=sg_config)
 

--- a/testsuites/syncgateway/functional/tests/test_bulk_get_compression.py
+++ b/testsuites/syncgateway/functional/tests/test_bulk_get_compression.py
@@ -12,7 +12,7 @@ from libraries.testkit.admin import Admin
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
 from keywords.utils import log_info
 from keywords.tklogging import Logging
-from utilities.cluster_config_utils import persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 uncompressed_size = 6320500
@@ -184,7 +184,10 @@ def test_bulk_get_compression(params_from_base_test_setup, sg_conf_name, num_doc
     log_info("Using accept_encoding: {}".format(accept_encoding))
     log_info("Using x_accept_part_encoding: {}".format(x_accept_part_encoding))
 
-    persist_cluster_config_environment_prop(cluster_config, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_config = temp_cluster_config
 
     cluster = Cluster(config=cluster_config)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_changes.py
+++ b/testsuites/syncgateway/functional/tests/test_changes.py
@@ -6,7 +6,7 @@ from requests import Session
 from keywords.utils import log_info
 from keywords.SyncGateway import SyncGateway
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
-from utilities.cluster_config_utils import persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 @pytest.mark.sanity
@@ -34,7 +34,10 @@ def test_deleted_docs_from_changes_active_only(params_from_base_test_setup, sg_c
     mode = params_from_base_test_setup["mode"]
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
 
-    persist_cluster_config_environment_prop(cluster_config, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_config = temp_cluster_config
 
     cluster = Cluster(cluster_config)
     cluster.reset(sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_changes_backfill.py
+++ b/testsuites/syncgateway/functional/tests/test_changes_backfill.py
@@ -6,7 +6,7 @@ from keywords.utils import log_info
 from libraries.testkit.cluster import Cluster
 from keywords.MobileRestClient import MobileRestClient
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
-from utilities.cluster_config_utils import persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 
 from keywords import userinfo
 from keywords import document
@@ -53,7 +53,10 @@ def test_backfill_channels_oneshot_changes(params_from_base_test_setup, sg_conf_
 
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
 
-    persist_cluster_config_environment_prop(cluster_config, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_config = temp_cluster_config
 
     cluster = Cluster(cluster_config)
     cluster.reset(sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_channels.py
+++ b/testsuites/syncgateway/functional/tests/test_channels.py
@@ -7,7 +7,7 @@ from libraries.testkit.cluster import Cluster
 from keywords.MobileRestClient import MobileRestClient
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
 from keywords.SyncGateway import SyncGateway
-from utilities.cluster_config_utils import persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 
 import keywords.exceptions
 from keywords import userinfo
@@ -127,7 +127,10 @@ def test_remove_add_channels_to_doc(params_from_base_test_setup, sg_conf_name, x
 
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
 
-    persist_cluster_config_environment_prop(cluster_config, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_config = temp_cluster_config
 
     cluster = Cluster(cluster_config)
     cluster.reset(sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_conflicts.py
+++ b/testsuites/syncgateway/functional/tests/test_conflicts.py
@@ -217,7 +217,10 @@ def test_winning_conflict_branch_revisions(params_from_base_test_setup, sg_conf_
 
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
 
-    persist_cluster_config_environment_prop(cluster_config, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_config = temp_cluster_config
 
     c = cluster.Cluster(cluster_config)
     c.reset(sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_continuous.py
+++ b/testsuites/syncgateway/functional/tests/test_continuous.py
@@ -96,7 +96,7 @@ def test_continuous_changes_parametrized(params_from_base_test_setup, sg_conf_na
 @pytest.mark.parametrize("sg_conf_name, num_docs, num_revisions, x509_cert_auth", [
     ("sync_gateway_default_functional_tests", 10, 10, True),
     ("sync_gateway_default_functional_tests_no_port", 10, 10, False),
-    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 10, 10, True)
+    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 10, 10, False)
 ])
 def test_continuous_changes_sanity(params_from_base_test_setup, sg_conf_name, num_docs, num_revisions, x509_cert_auth):
 

--- a/testsuites/syncgateway/functional/tests/test_continuous.py
+++ b/testsuites/syncgateway/functional/tests/test_continuous.py
@@ -10,7 +10,7 @@ from libraries.testkit.verify import verify_same_docs
 
 from keywords.utils import log_info
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
-from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 @pytest.mark.syncgateway
@@ -124,7 +124,10 @@ def test_continuous_changes_sanity(params_from_base_test_setup, sg_conf_name, nu
     log_info("num_docs: {}".format(num_docs))
     log_info("num_revisions: {}".format(num_revisions))
 
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_crud.py
+++ b/testsuites/syncgateway/functional/tests/test_crud.py
@@ -12,7 +12,7 @@ from keywords.utils import host_for_url, log_info
 from libraries.testkit.cluster import Cluster
 from keywords.userinfo import UserInfo
 from keywords.exceptions import TimeoutException
-from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 @pytest.mark.sanity
@@ -99,7 +99,10 @@ def test_document_resurrection(params_from_base_test_setup, sg_conf_name, deleti
     cbs_host = host_for_url(cbs_url)
 
     num_docs_per_client = 10
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
 
     # Reset cluster
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline.py
@@ -15,7 +15,7 @@ from requests.exceptions import HTTPError
 from keywords.utils import log_info
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
 from keywords.MobileRestClient import MobileRestClient
-from utilities.cluster_config_utils import persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 
 NUM_ENDPOINTS = 13
 
@@ -47,7 +47,10 @@ def test_online_default_rest(params_from_base_test_setup, sg_conf_name, num_docs
     log_info("Using sg_conf: {}".format(sg_conf))
     log_info("Using num_docs: {}".format(num_docs))
 
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline_resync.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline_resync.py
@@ -13,7 +13,7 @@ from libraries.testkit.parallelize import in_parallel
 from keywords.utils import log_info
 from keywords.utils import log_error
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
-from utilities.cluster_config_utils import persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 @pytest.mark.sanity
@@ -45,7 +45,10 @@ def test_bucket_online_offline_resync_sanity(params_from_base_test_setup, sg_con
 
     start = time.time()
 
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, test_mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline_webhooks.py
@@ -12,7 +12,7 @@ from keywords.MobileRestClient import MobileRestClient
 
 
 # implements scenarios: 18 and 19
-from utilities.cluster_config_utils import persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 @pytest.mark.sanity
@@ -44,7 +44,10 @@ def test_db_online_offline_webhooks_offline(params_from_base_test_setup, sg_conf
     log_info("Using num_docs: {}".format(num_docs))
     log_info("Using num_revisions: {}".format(num_revisions))
 
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_log_redaction.py
+++ b/testsuites/syncgateway/functional/tests/test_log_redaction.py
@@ -62,7 +62,6 @@ def test_log_redaction_config(params_from_base_test_setup, remove_tmp_sg_redacti
                                             property_name_check=False)
 
     if x509_cert_auth:
-        temp_cluster_config = copy_to_temp_conf(temp_cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
 
     cluster = Cluster(config=temp_cluster_config)
@@ -124,7 +123,6 @@ def test_sgCollect1(params_from_base_test_setup, remove_tmp_sg_redaction_logs, s
     persist_cluster_config_environment_prop(temp_cluster_config, 'redactlevel', "partial", property_name_check=False)
 
     if x509_cert_auth:
-        temp_cluster_config = copy_to_temp_conf(temp_cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
 
     cluster = Cluster(config=temp_cluster_config)
@@ -192,7 +190,6 @@ def test_sgCollect_restApi(params_from_base_test_setup, remove_tmp_sg_redaction_
     persist_cluster_config_environment_prop(temp_cluster_config, 'redactlevel', "partial", property_name_check=False)
 
     if x509_cert_auth:
-        temp_cluster_config = copy_to_temp_conf(temp_cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
 
     cluster = Cluster(config=temp_cluster_config)
@@ -304,7 +301,6 @@ def test_sgCollectRestApi_errorMessages(params_from_base_test_setup, remove_tmp_
     persist_cluster_config_environment_prop(temp_cluster_config, 'redactlevel', "partial", property_name_check=False)
 
     if x509_cert_auth:
-        temp_cluster_config = copy_to_temp_conf(temp_cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
 
     cluster = Cluster(config=temp_cluster_config)

--- a/testsuites/syncgateway/functional/tests/test_log_redaction.py
+++ b/testsuites/syncgateway/functional/tests/test_log_redaction.py
@@ -61,7 +61,9 @@ def test_log_redaction_config(params_from_base_test_setup, remove_tmp_sg_redacti
     persist_cluster_config_environment_prop(temp_cluster_config, 'redactlevel', redaction_level,
                                             property_name_check=False)
 
-    persist_cluster_config_environment_prop(cluster_config, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(temp_cluster_config, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
 
     cluster = Cluster(config=temp_cluster_config)
     cluster.reset(sg_config_path=sg_conf)
@@ -121,7 +123,9 @@ def test_sgCollect1(params_from_base_test_setup, remove_tmp_sg_redaction_logs, s
     temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
     persist_cluster_config_environment_prop(temp_cluster_config, 'redactlevel', "partial", property_name_check=False)
 
-    persist_cluster_config_environment_prop(cluster_config, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(temp_cluster_config, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
 
     cluster = Cluster(config=temp_cluster_config)
     cluster.reset(sg_config_path=sg_conf)
@@ -187,7 +191,9 @@ def test_sgCollect_restApi(params_from_base_test_setup, remove_tmp_sg_redaction_
     temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
     persist_cluster_config_environment_prop(temp_cluster_config, 'redactlevel', "partial", property_name_check=False)
 
-    persist_cluster_config_environment_prop(cluster_config, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(temp_cluster_config, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
 
     cluster = Cluster(config=temp_cluster_config)
     cluster.reset(sg_config_path=sg_conf)
@@ -297,7 +303,9 @@ def test_sgCollectRestApi_errorMessages(params_from_base_test_setup, remove_tmp_
     temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
     persist_cluster_config_environment_prop(temp_cluster_config, 'redactlevel', "partial", property_name_check=False)
 
-    persist_cluster_config_environment_prop(cluster_config, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(temp_cluster_config, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
 
     cluster = Cluster(config=temp_cluster_config)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_log_rotation.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation.py
@@ -11,7 +11,7 @@ from keywords.SyncGateway import SyncGateway, sync_gateway_config_path_for_mode,
 from keywords.utils import log_info, add_cbs_to_sg_config_server_field, host_for_url
 from libraries.testkit.cluster import Cluster
 from utilities.cluster_config_utils import is_cbs_ssl_enabled, get_sg_replicas, get_sg_use_views, get_sg_version, \
-    persist_cluster_config_environment_prop
+    persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 def load_sync_gateway_config(sync_gateway_config, mode, server_url, xattrs_enabled, cluster_config):
@@ -93,7 +93,10 @@ def test_log_rotation_default_values(params_from_base_test_setup, sg_conf_name, 
     log_info("Using cluster_conf: {}".format(cluster_conf))
     log_info("Using sg_conf: {}".format(sg_conf))
 
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
@@ -9,7 +9,7 @@ from keywords.SyncGateway import SyncGateway, sync_gateway_config_path_for_mode,
 from keywords.utils import log_info, host_for_url
 from libraries.testkit.cluster import Cluster
 from keywords.exceptions import ProvisioningError
-from utilities.cluster_config_utils import load_cluster_config_json, persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import load_cluster_config_json, persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 @pytest.mark.sanity
@@ -42,7 +42,10 @@ def test_log_rotation_default_values(params_from_base_test_setup, sg_conf_name, 
     if get_sync_gateway_version(sg_ip)[0] < "2.1":
         pytest.skip("Continuous logging Test NA for SG < 2.1")
 
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_longpoll.py
+++ b/testsuites/syncgateway/functional/tests/test_longpoll.py
@@ -99,7 +99,7 @@ def test_longpoll_changes_parametrized(params_from_base_test_setup, sg_conf_name
 @pytest.mark.parametrize("sg_conf_name, num_docs, num_revisions, x509_cert_auth", [
     ("sync_gateway_default_functional_tests", 10, 10, True),
     ("sync_gateway_default_functional_tests_no_port", 10, 10, False),
-    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 10, 10, True)
+    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 10, 10, False)
 ])
 def test_longpoll_changes_sanity(params_from_base_test_setup, sg_conf_name, num_docs, num_revisions, x509_cert_auth):
 

--- a/testsuites/syncgateway/functional/tests/test_longpoll.py
+++ b/testsuites/syncgateway/functional/tests/test_longpoll.py
@@ -13,7 +13,7 @@ from libraries.testkit.verify import verify_same_docs
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
 from keywords.utils import log_info
 from keywords.MobileRestClient import MobileRestClient
-from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop, copy_to_temp_conf
 
 from keywords import document
 from keywords import userinfo
@@ -126,7 +126,10 @@ def test_longpoll_changes_sanity(params_from_base_test_setup, sg_conf_name, num_
     log_info("num_docs: {}".format(num_docs))
     log_info("num_revisions: {}".format(num_revisions))
 
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_multiple_dbs.py
+++ b/testsuites/syncgateway/functional/tests/test_multiple_dbs.py
@@ -8,7 +8,7 @@ from libraries.testkit.verify import verify_changes
 
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
 from keywords.utils import log_info
-from utilities.cluster_config_utils import is_x509_auth, persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import is_x509_auth, persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 @pytest.mark.syncgateway
@@ -94,7 +94,10 @@ def test_multiple_db_single_data_bucket_single_index_bucket(params_from_base_tes
     log_info("Using num_users: {}".format(num_users))
     log_info("Using num_docs_per_user: {}".format(num_docs_per_user))
 
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
 
     # 2 dbs share the same data and index bucket
     cluster = Cluster(config=cluster_conf)

--- a/testsuites/syncgateway/functional/tests/test_multiple_users_multiple_channels_multiple_revisions.py
+++ b/testsuites/syncgateway/functional/tests/test_multiple_users_multiple_channels_multiple_revisions.py
@@ -10,7 +10,7 @@ from libraries.testkit.parallelize import in_parallel
 from keywords.utils import log_info
 from keywords.utils import log_error
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
-from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 # Scenario-2:
@@ -59,7 +59,10 @@ def test_mulitple_users_mulitiple_channels_mulitple_revisions(params_from_base_t
 
     start = time.time()
 
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
+++ b/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
@@ -11,7 +11,7 @@ import requests
 
 from keywords.utils import log_info
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
-from utilities.cluster_config_utils import persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 @pytest.mark.sanity
@@ -61,7 +61,10 @@ def test_overloaded_channel_cache(params_from_base_test_setup, sg_conf_name, num
     log_info("Using filter: {}".format(filter))
     log_info("Using limit: {}".format(limit))
 
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)
@@ -70,11 +73,11 @@ def test_overloaded_channel_cache(params_from_base_test_setup, sg_conf_name, num
 
     admin = Admin(target_sg)
 
-    users = admin.register_bulk_users(target_sg, "db", "user", 1000, "password", [user_channels])
+    users = admin.register_bulk_users(target_sg, "db", "user", 1000, "password", [user_channels], num_of_workers=10)
     assert len(users) == 1000
 
     doc_pusher = admin.register_user(target_sg, "db", "abc_doc_pusher", "password", ["ABC"])
-    doc_pusher.add_docs(num_docs, bulk=True)
+    doc_pusher.add_docs(num_docs)
 
     # Give a few seconds to let changes register
     time.sleep(2)

--- a/testsuites/syncgateway/functional/tests/test_resync.py
+++ b/testsuites/syncgateway/functional/tests/test_resync.py
@@ -10,7 +10,7 @@ from keywords.utils import log_info
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
 from libraries.provision.ansible_runner import AnsibleRunner
 from keywords.exceptions import CollectionError
-from utilities.cluster_config_utils import persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 @pytest.mark.sanity
@@ -42,7 +42,10 @@ def test_resync(params_from_base_test_setup, sg_conf_name, x509_cert_auth):
     mode = params_from_base_test_setup["mode"]
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
 
-    persist_cluster_config_environment_prop(cluster_config, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_config = temp_cluster_config
 
     cluster = Cluster(cluster_config)
     cluster.reset(sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_roles.py
+++ b/testsuites/syncgateway/functional/tests/test_roles.py
@@ -6,7 +6,7 @@ from libraries.testkit.verify import verify_changes
 
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
 from keywords.utils import log_info
-from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 @pytest.mark.sanity
@@ -45,7 +45,10 @@ def test_roles_sanity(params_from_base_test_setup, sg_conf_name, x509_cert_auth)
     log_info("cluster_conf: {}".format(cluster_conf))
     log_info("sg_conf: {}".format(sg_conf))
 
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_roles.py
+++ b/testsuites/syncgateway/functional/tests/test_roles.py
@@ -19,7 +19,7 @@ from utilities.cluster_config_utils import get_sg_version, persist_cluster_confi
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
     ("sync_gateway_default_functional_tests", True),
     ("sync_gateway_default_functional_tests_no_port", False),
-    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", True)
+    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", False)
 ])
 def test_roles_sanity(params_from_base_test_setup, sg_conf_name, x509_cert_auth):
 

--- a/testsuites/syncgateway/functional/tests/test_rollback.py
+++ b/testsuites/syncgateway/functional/tests/test_rollback.py
@@ -12,7 +12,7 @@ from keywords import userinfo
 from keywords import document
 import time
 
-from utilities.cluster_config_utils import persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 @pytest.mark.sanity
@@ -59,7 +59,10 @@ def test_rollback_server_reset(params_from_base_test_setup, sg_conf_name, x509_c
         pytest.skip("Rollback not supported in channel cache mode")
 
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
-    persist_cluster_config_environment_prop(cluster_config, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_config = temp_cluster_config
     cluster = Cluster(cluster_config)
     cluster.reset(sg_conf)
 

--- a/testsuites/syncgateway/functional/tests/test_seq.py
+++ b/testsuites/syncgateway/functional/tests/test_seq.py
@@ -8,7 +8,7 @@ from libraries.testkit.verify import verify_changes
 
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
 from keywords.utils import log_info
-from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 @pytest.mark.sanity
@@ -49,7 +49,10 @@ def test_seq(params_from_base_test_setup, sg_conf_name, num_users, num_docs, num
     log_info("num_docs: {}".format(num_docs))
     log_info("num_revisions: {}".format(num_revisions))
 
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_single_user_single_channel_doc_updates.py
+++ b/testsuites/syncgateway/functional/tests/test_single_user_single_channel_doc_updates.py
@@ -8,7 +8,7 @@ from libraries.testkit.verify import verify_changes
 import libraries.testkit.settings
 
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
-from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop, copy_to_temp_conf
 
 import logging
 log = logging.getLogger(libraries.testkit.settings.LOGGER)
@@ -58,7 +58,10 @@ def test_single_user_single_channel_doc_updates(params_from_base_test_setup, sg_
     log.info("num_revisions: {}".format(num_revisions))
 
     start = time.time()
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)
     num_docs = num_docs

--- a/testsuites/syncgateway/functional/tests/test_sync.py
+++ b/testsuites/syncgateway/functional/tests/test_sync.py
@@ -20,7 +20,7 @@ from keywords.SyncGateway import sync_gateway_config_path_for_mode
 
 
 # https://github.com/couchbase/sync_gateway/issues/1524
-from utilities.cluster_config_utils import persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 @pytest.mark.syncgateway
@@ -124,7 +124,10 @@ def test_sync_access_sanity(params_from_base_test_setup, sg_conf_name, x509_cert
     log_info("Running 'sync_access_sanity'")
     log_info("Using cluster_conf: {}".format(cluster_conf))
     log_info("Using sg_conf: {}".format(sg_conf))
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)
     admin = Admin(cluster.sync_gateways[0])

--- a/testsuites/syncgateway/functional/tests/test_user_views.py
+++ b/testsuites/syncgateway/functional/tests/test_user_views.py
@@ -10,7 +10,7 @@ from keywords.SyncGateway import sync_gateway_config_path_for_mode
 from keywords.utils import log_info
 from libraries.testkit.cluster import Cluster
 from keywords.MobileRestClient import MobileRestClient
-from utilities.cluster_config_utils import persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 @pytest.mark.sanity
@@ -35,7 +35,10 @@ def test_user_views_sanity(params_from_base_test_setup, sg_conf_name, x509_cert_
     log_info("Running 'single_user_multiple_channels'")
     log_info("cluster_conf: {}".format(cluster_conf))
     log_info("conf: {}".format(sg_conf))
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)
 

--- a/testsuites/syncgateway/functional/tests/test_users_channels.py
+++ b/testsuites/syncgateway/functional/tests/test_users_channels.py
@@ -9,7 +9,7 @@ from keywords.MobileRestClient import MobileRestClient
 
 from keywords.SyncGateway import sync_gateway_config_path_for_mode
 from keywords.utils import log_info
-from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop, copy_to_temp_conf
 from requests import Session
 from keywords.utils import log_r
 
@@ -47,7 +47,10 @@ def test_multiple_users_multiple_channels(params_from_base_test_setup, sg_conf_n
     log_info("Running 'multiple_users_multiple_channels'")
     log_info("cluster_conf: {}".format(cluster_conf))
     log_info("conf: {}".format(sg_conf))
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)
 

--- a/testsuites/syncgateway/functional/tests/test_users_channels.py
+++ b/testsuites/syncgateway/functional/tests/test_users_channels.py
@@ -22,7 +22,7 @@ from keywords.utils import log_r
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
     ("sync_gateway_default_functional_tests", True),
     ("sync_gateway_default_functional_tests_no_port", False),
-    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", True)
+    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", False)
 ])
 def test_multiple_users_multiple_channels(params_from_base_test_setup, sg_conf_name, x509_cert_auth):
 

--- a/testsuites/syncgateway/functional/tests/test_views.py
+++ b/testsuites/syncgateway/functional/tests/test_views.py
@@ -10,7 +10,7 @@ from keywords.SyncGateway import SyncGateway, sync_gateway_config_path_for_mode
 from keywords.userinfo import UserInfo
 from keywords.utils import log_info
 from libraries.testkit.cluster import Cluster
-from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 @pytest.mark.sanity
@@ -56,7 +56,10 @@ def test_view_backfill_for_deletes(params_from_base_test_setup, sg_conf_name,
     log_info('sg_url: {}'.format(sg_url))
     log_info('cbs_url: {}'.format(cbs_url))
     log_info('validate_changes_before_restart: {}'.format(validate_changes_before_restart))
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)
 

--- a/testsuites/syncgateway/functional/tests/test_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_webhooks.py
@@ -14,7 +14,7 @@ from libraries.testkit.parallelize import in_parallel
 from libraries.testkit.web_server import WebServer
 from keywords.exceptions import TimeoutError
 from keywords.constants import CLIENT_REQUEST_TIMEOUT
-from utilities.cluster_config_utils import persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
 @pytest.mark.sanity
@@ -51,7 +51,10 @@ def test_webhooks(params_from_base_test_setup, sg_conf_name, num_users, num_chan
     log_info("Using num_channels: {}".format(num_channels))
     log_info("Using num_docs: {}".format(num_docs))
     log_info("Using num_revisions: {}".format(num_revisions))
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_conf)
 

--- a/testsuites/syncgateway/functional/tests/test_xattrs.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs.py
@@ -425,7 +425,7 @@ def test_on_demand_import_of_external_updates(params_from_base_test_setup, sg_co
 @pytest.mark.parametrize('sg_conf_name, x509_cert_auth', [
     ('sync_gateway_default_functional_tests', True),
     ('sync_gateway_default_functional_tests_no_port', False),
-    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", True)
+    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", False)
 ])
 def test_offline_processing_of_external_updates(params_from_base_test_setup, sg_conf_name, x509_cert_auth):
     """

--- a/testsuites/syncgateway/functional/tests/test_xattrs.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs.py
@@ -23,7 +23,7 @@ from keywords.userinfo import UserInfo
 from keywords.utils import host_for_url, log_info
 from libraries.testkit.cluster import Cluster
 from keywords.ChangesTracker import ChangesTracker
-from utilities.cluster_config_utils import get_sg_use_views, get_sg_version, persist_cluster_config_environment_prop
+from utilities.cluster_config_utils import get_sg_use_views, get_sg_version, persist_cluster_config_environment_prop, copy_to_temp_conf
 from keywords.constants import SDK_TIMEOUT
 
 # Since sdk is quicker to update docs we need to have it sleep longer
@@ -355,7 +355,10 @@ def test_on_demand_import_of_external_updates(params_from_base_test_setup, sg_co
     log_info('sg_admin_url: {}'.format(sg_admin_url))
     log_info('sg_url: {}'.format(sg_url))
     log_info('cbs_url: {}'.format(cbs_url))
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)
 
@@ -473,7 +476,10 @@ def test_offline_processing_of_external_updates(params_from_base_test_setup, sg_
     log_info('sg_admin_url: {}'.format(sg_admin_url))
     log_info('sg_url: {}'.format(sg_url))
     log_info('cbs_url: {}'.format(cbs_url))
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)
 
@@ -745,7 +751,10 @@ def test_purge(params_from_base_test_setup, sg_conf_name, use_multiple_channels,
     log_info('sg_conf: {}'.format(sg_conf))
     log_info('sg_admin_url: {}'.format(sg_admin_url))
     log_info('sg_url: {}'.format(sg_url))
-    persist_cluster_config_environment_prop(cluster_conf, 'x509_certs', x509_cert_auth)
+    if x509_cert_auth:
+        temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        cluster_conf = temp_cluster_config
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)
 

--- a/utilities/cluster_config_utils.py
+++ b/utilities/cluster_config_utils.py
@@ -251,7 +251,7 @@ def is_delta_sync_enabled(cluster_config):
 
 
 def copy_to_temp_conf(cluster_config, mode):
-    # Creating temporary cluster config and json files to add revs limit dynamically
+    # Creating temporary cluster config and json files to add configuration dynamically
     temp_cluster_config = "resources/cluster_configs/temp_cluster_config_{}".format(mode)
     temp_cluster_config_json = "resources/cluster_configs/temp_cluster_config_{}.json".format(mode)
     cluster_config_json = "{}.json".format(cluster_config)


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Cluster config which is common file to all the tests is modified and enabled x509. This effects the tests which should not run with x509 enabled.
- I modified to enable x509 to temporary cluster config and use that config to deploy SGW.
I ran the tests on Jenkins with this fix and it worked fine  and got 0 test failures now 
http://uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-functional-tests-base-cc/2667/

