### PR TITLE
Prevent running setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,11 @@
 # 3. Installs all pip packages required by this repo
 # 4. Adds custom library paths to your PYTHONPATH
 
+if [[ $_ == $0 ]]; then
+    echo "Source this script!  Do not run it!"
+    exit 1
+fi
+
 version=$(python -c 'import sys; print "{}.{}.{}".format(sys.version_info.major, sys.version_info.minor, sys.version_info.micro)')
 
 if [[ $version == 2.7.* ]]; then


### PR DESCRIPTION
setup.sh does the wrong thing if it is run (`./setup.sh`) instead of being sourced (`. setup.sh`).
1) change permissions so that it cannot be executed
2) add check for execution vs sourceing
