### PR TITLE
Fix/clean up sanity

### DIFF
--- a/keywords/SyncGateway.py
+++ b/keywords/SyncGateway.py
@@ -243,7 +243,7 @@ def load_sync_gateway_config(sg_conf, server_url, cluster_config):
                 redact_level = get_redact_level(cluster_config)
                 logging_prop = '{}, "redaction_level": "{}" {},'.format(logging_config, redact_level, "}")
             except KeyError as ex:
-                log_info("Keyerror in getting logging{}".format(ex.message))
+                log_info("Keyerror in getting logging{}".format(ex.args))
                 logging_prop = '{} {},'.format(logging_config, "}")
 
             num_replicas = get_sg_replicas(cluster_config)
@@ -405,7 +405,7 @@ class SyncGateway(object):
                 redact_level = get_redact_level(cluster_config)
                 playbook_vars["logging"] = '{}, "redaction_level": "{}" {},'.format(logging_config, redact_level, "}")
             except KeyError as ex:
-                log_info("Keyerror in getting logging{}".format(ex.message))
+                log_info("Keyerror in getting logging{}".format(ex.args))
                 playbook_vars["logging"] = '{} {},'.format(logging_config, "}")
 
             if get_sg_use_views(cluster_config):
@@ -599,7 +599,7 @@ class SyncGateway(object):
                 redact_level = get_redact_level(cluster_config)
                 playbook_vars["logging"] = '{}, "redaction_level": "{}" {},'.format(logging_config, redact_level, "}")
             except KeyError as ex:
-                log_info("Keyerror in getting logging{}".format(ex.message))
+                log_info("Keyerror in getting logging{}".format(ex.args))
                 playbook_vars["logging"] = '{} {},'.format(logging_config, "}")
 
             if not get_sg_use_views(cluster_config) and cbs_version >= "5.5.0":
@@ -697,7 +697,7 @@ class SyncGateway(object):
                 redact_level = get_redact_level(cluster_config)
                 playbook_vars["logging"] = '{}, "redaction_level": "{}" {},'.format(logging_config, redact_level, "}")
             except KeyError as ex:
-                log_info("Keyerror in getting logging{}".format(ex.message))
+                log_info("Keyerror in getting logging{}".format(ex.args))
                 playbook_vars["logging"] = '{} {},'.format(logging_config, "}")
 
             if get_sg_use_views(cluster_config):

--- a/keywords/TestServerAndroid.py
+++ b/keywords/TestServerAndroid.py
@@ -90,7 +90,7 @@ class TestServerAndroid(TestServerBase):
                 output = subprocess.check_output(["adb", "-e", "install", "-r", apk_path])
                 break
             except Exception as e:
-                if "INSTALL_FAILED_ALREADY_EXISTS" in e.message or "INSTALL_FAILED_UPDATE_INCOMPATIBLE" in e.message:
+                if "INSTALL_FAILED_ALREADY_EXISTS" in e.args[0] or "INSTALL_FAILED_UPDATE_INCOMPATIBLE" in e.message:
                     # Apk may be installed, remove and retry install
                     log_info("Trying to remove....")
                     self.remove()
@@ -128,7 +128,7 @@ class TestServerAndroid(TestServerBase):
                 output = subprocess.check_output(["adb", "-d", "install", "-r", apk_path])
                 break
             except Exception as e:
-                if "INSTALL_FAILED_ALREADY_EXISTS" in e.message or "INSTALL_FAILED_UPDATE_INCOMPATIBLE" in e.message:
+                if "INSTALL_FAILED_ALREADY_EXISTS" in e.args[0] or "INSTALL_FAILED_UPDATE_INCOMPATIBLE" in e.message:
                     # Apk may be installed, remove and retry install
                     log_info("Trying to remove....")
                     self.remove()

--- a/libraries/provision/install_sync_gateway.py
+++ b/libraries/provision/install_sync_gateway.py
@@ -191,7 +191,7 @@ def install_sync_gateway(cluster_config, sync_gateway_config, sg_ce=False,
             redact_level = get_redact_level(cluster_config)
             playbook_vars["logging"] = '{}, "redaction_level": "{}" {},'.format(logging_config, redact_level, "}")
         except KeyError as ex:
-            log_info("Keyerror in getting logging{}".format(ex.message))
+            log_info("Keyerror in getting logging{}".format(ex.args))
             playbook_vars["logging"] = '{} {},'.format(logging_config, "}")
 
         if get_sg_use_views(cluster_config):

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -196,7 +196,7 @@ class Cluster:
                 redact_level = get_redact_level(self._cluster_config)
                 playbook_vars["logging"] = '{}, "redaction_level": "{}" {},'.format(logging_config, redact_level, "}")
             except KeyError as ex:
-                log_info("Keyerror in getting logging{}".format(ex.message))
+                log_info("Keyerror in getting logging{}".format(ex.args))
                 playbook_vars["logging"] = '{} {},'.format(logging_config, "}")
             if get_sg_use_views(self._cluster_config):
                 playbook_vars["sg_use_views"] = '"use_views": true,'

--- a/libraries/testkit/sgaccel.py
+++ b/libraries/testkit/sgaccel.py
@@ -74,7 +74,7 @@ class SgAccel:
                 redact_level = get_redact_level(self.cluster_config)
                 playbook_vars["logging"] = '{}, "redaction_level": "{}" {},'.format(logging_config, redact_level, "}")
             except KeyError as ex:
-                log_info("Keyerror in getting logging{}".format(ex.message))
+                log_info("Keyerror in getting logging{}".format(ex.args))
                 playbook_vars["logging"] = '{} {},'.format(logging_config, "}")
             if get_sg_use_views(self.cluster_config):
                 playbook_vars["sg_use_views"] = '"use_views": true,'

--- a/libraries/testkit/syncgateway.py
+++ b/libraries/testkit/syncgateway.py
@@ -105,7 +105,7 @@ class SyncGateway:
                 redact_level = get_redact_level(self.cluster_config)
                 playbook_vars["logging"] = '{}, "redaction_level": "{}" {},'.format(logging_config, redact_level, "}")
             except KeyError as ex:
-                log_info("Keyerror in getting logging{}".format(ex.message))
+                log_info("Keyerror in getting logging{}".format(ex.args))
                 playbook_vars["logging"] = '{} {},'.format(logging_config, "}")
 
             if get_sg_use_views(self.cluster_config):
@@ -223,7 +223,7 @@ class SyncGateway:
                 redact_level = get_redact_level(self.cluster_config)
                 playbook_vars["logging"] = '{}, "redaction_level": "{}" {},'.format(logging_config, redact_level, "}")
             except KeyError as ex:
-                log_info("Keyerror in getting logging{}".format(ex.message))
+                log_info("Keyerror in getting logging{}".format(ex.args))
                 playbook_vars["logging"] = '{} {},'.format(logging_config, "}")
             if get_sg_use_views(self.cluster_config):
                 playbook_vars["sg_use_views"] = '"use_views": true,'

--- a/pytest.ini
+++ b/pytest.ini
@@ -49,3 +49,6 @@ markers =
     rollback:      test that exercises Sync Gateway rollback handling
     bulkops:       test that exercises Sync Gateway bulk_docs / bulk_get
     xattrs:        test that Sync Gateway interop with sdk
+    logredaction:  test that covers log redaction on Sync gateway
+    noconflicts:   test that covers no conflicts scenarios
+    views:          test that covers view i.e non GSI scenarios

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ olefile==0.44
 packaging==16.8
 paramiko==2.1.5
 Pillow==4.0.0
-py==1.4.31
+py==1.5.1
 pyasn1==0.2.3
 pycodestyle==2.3.1
 pycparser==2.17
@@ -41,7 +41,7 @@ pyflakes==1.5.0
 PyJWT==1.4.0
 pylint==1.6.4
 pyparsing==2.2.0
-pytest==3.0.2
+pytest==4.6.9
 pytest-html==1.10.0
 pytest-timeout==1.0.0
 python-dateutil==2.5.1

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_cbl_log_redaction.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_cbl_log_redaction.py
@@ -11,13 +11,12 @@ from libraries.testkit import cluster
 from keywords.utils import log_info
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.replication
 @pytest.mark.parametrize("password", [
-    "auto-password",
-    "auto password",
-    "validpassword",
+    pytest.param("auto-password", marks=pytest.mark.sanity),
+    ("auto password"),
+    ("validpassword"),
 ])
 def test_mask_password_in_logs(params_from_base_test_setup, password):
     """
@@ -72,7 +71,6 @@ def test_mask_password_in_logs(params_from_base_test_setup, password):
     verify_password_masked(liteserv_platform, log_file, password, test_cbllog)
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.replication
 @pytest.mark.parametrize("invalid_password", [

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_cbl_logging.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_cbl_logging.py
@@ -12,7 +12,6 @@ log_level_dict = {
 }
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.database
 @pytest.mark.parametrize("log_level, plain_text, max_size, max_rotate_count", [
@@ -26,7 +25,7 @@ log_level_dict = {
     ("info", True, 5 * 512 * 1000, 5),
     ("warning", True, 6 * 512 * 1000, 6),
     ("error", True, 7 * 512 * 1000, 7),
-    ("verbose", True, 1000 * 512 * 1000, 1000)
+    pytest.param("verbose", True, 1000 * 512 * 1000, 1000, marks=pytest.mark.sanity)
 ])
 def test_file_logging(params_from_base_test_setup, log_level, plain_text, max_size, max_rotate_count):
     base_url = params_from_base_test_setup["base_url"]

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_custom_conflicts.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_custom_conflicts.py
@@ -11,13 +11,12 @@ from keywords.MobileRestClient import MobileRestClient
 from testsuites.CBLTester.CBL_Functional_tests.TestSetup_FunctionalTests.test_delta_sync import property_updater
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.custom_conflict
 @pytest.mark.replication
 @pytest.mark.parametrize("replicator_type", [
-    "pull",
-    "push_pull"
+    ("pull"),
+    pytest.param("push_pull", marks=pytest.mark.sanity)
 ])
 def test_local_wins_custom_conflicts(params_from_base_test_setup, replicator_type):
     """
@@ -137,7 +136,6 @@ def test_local_wins_custom_conflicts(params_from_base_test_setup, replicator_typ
                                                                      "with local win"
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.custom_conflict
 @pytest.mark.replication

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_database.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_database.py
@@ -5,13 +5,12 @@ from CBLClient.Database import Database
 from CBLClient.DatabaseConfiguration import DatabaseConfiguration
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.database
 @pytest.mark.parametrize(
     'password',
     [
-        ('encrypting-password'),
+        pytest.param('encrypting-password', marks=pytest.mark.sanity),
         ('123'),
         ('****&&&'),
         ('1*rt')
@@ -61,7 +60,7 @@ def test_databaseEncryption(params_from_base_test_setup, password):
     else:
         with pytest.raises(Exception) as he:
             db.create(cbl_db_name, db_config)
-        assert he.value.message.startswith('400 Client Error: Bad Request for url:')
+        assert he.value.args[0].startswith('400 Client Error: Bad Request for url:')
 
     # 6. Verify that database can be accessed with password
     db_config1 = db.configure(password=password)
@@ -73,7 +72,6 @@ def test_databaseEncryption(params_from_base_test_setup, password):
     db.deleteDB(cbl_db3)
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.database
 @pytest.mark.parametrize(
@@ -117,7 +115,7 @@ def test_invalidEncryption(params_from_base_test_setup, password):
     else:
         with pytest.raises(Exception) as he:
             db.create(cbl_db_name, db_config_without_password)
-        assert he.value.message.startswith('400 Client Error: Bad Request for url:')
+        assert he.value.args[0].startswith('400 Client Error: Bad Request for url:')
 
     # 4. access database with invalid password
     # 5. Verify database cannot be accessed
@@ -129,10 +127,9 @@ def test_invalidEncryption(params_from_base_test_setup, password):
         with pytest.raises(Exception) as he:
             invalid_key_db_config = db_configure.setEncryptionKey(db_config, password=password)
             db.create(cbl_db_name, invalid_key_db_config)
-        assert he.value.message.startswith('400 Client Error: Bad Request for url:')
+        assert he.value.args[0].startswith('400 Client Error: Bad Request for url:')
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.database
 def test_updateDBEncryptionKey(params_from_base_test_setup):
@@ -177,10 +174,9 @@ def test_updateDBEncryptionKey(params_from_base_test_setup):
     else:
         with pytest.raises(Exception) as he:
             db.create(cbl_db_name, db_config)
-        assert he.value.message.startswith('400 Client Error: Bad Request for url:')
+        assert he.value.args[0].startswith('400 Client Error: Bad Request for url:')
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.database
 def test_DBEncryptionKey_withCompact(params_from_base_test_setup):
@@ -228,7 +224,6 @@ def test_DBEncryptionKey_withCompact(params_from_base_test_setup):
         assert doc_id in cbl_doc_ids1, "cbl doc is in first list does not exist in second list"
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.database
 def test_removeDBEncryptionKey(params_from_base_test_setup):
@@ -276,7 +271,7 @@ def test_removeDBEncryptionKey(params_from_base_test_setup):
     else:
         with pytest.raises(Exception) as he:
             db.create(cbl_db_name, db_config)
-        assert he.value.message.startswith('400 Client Error: Bad Request for url:')
+        assert he.value.args[0].startswith('400 Client Error: Bad Request for url:')
 
     # 5. Verify database can be accessed without password.
     print "starting the database access without password"

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_delta_sync.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_delta_sync.py
@@ -12,13 +12,12 @@ from keywords.SyncGateway import sync_gateway_config_path_for_mode
 from libraries.testkit import cluster
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.syncgateway
 @pytest.mark.replication
 @pytest.mark.parametrize("num_of_docs, replication_type, file_attachment, continuous", [
     (10, "pull", None, True),
-    (10, "pull", "sample_text.txt", True),
+    pytest.param(10, "pull", "sample_text.txt", True, marks=pytest.mark.sanity),
     (1, "push", "golden_gate_large.jpg", True),
     (10, "push", None, True)
 ])

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_no_conflicts_cbl.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_no_conflicts_cbl.py
@@ -84,10 +84,9 @@ def test_no_conflicts_enabled(params_from_base_test_setup):
         with pytest.raises(HTTPError) as he:
             sg_client.add_conflict(url=sg_url, db=sg_db, doc_id=doc["id"], parent_revisions=doc["value"]["rev"], new_revision="2-foo",
                                    auth=session)
-        assert he.value.message.startswith('409 Client Error: Conflict for url:')
+        assert he.value.args[0].startswith('409 Client Error: Conflict for url:')
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.parametrize("sg_conf_name, num_of_docs, revs_limit", [
     ('sync_gateway_revs_conflict_configurable', 10, 1),
@@ -169,7 +168,7 @@ def test_no_conflicts_enabled_with_revs_limit(params_from_base_test_setup, sg_co
             with pytest.raises(HTTPError) as he:
                 sg_client.add_conflict(url=sg_url, db=sg_db, doc_id=doc["id"], parent_revisions=doc["value"]["rev"], new_revision="2-foo",
                                        auth=session)
-            assert he.value.message.startswith('409 Client Error: Conflict for url:')
+            assert he.value.args[0].startswith('409 Client Error: Conflict for url:')
         else:
             conflicted_rev = sg_client.add_conflict(url=sg_url, db=sg_db, doc_id=doc["id"], parent_revisions=doc["value"]["rev"], new_revision="2-foo",
                                                     auth=session)
@@ -189,7 +188,6 @@ def test_no_conflicts_enabled_with_revs_limit(params_from_base_test_setup, sg_co
         assert len(num_of_revs) == revs_limit, "Number of revisions in history is more than revs_limit set in sg config"
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.conflicts
 @pytest.mark.noconflicts
@@ -270,7 +268,7 @@ def test_no_conflicts_update_with_revs_limit(params_from_base_test_setup, sg_con
             with pytest.raises(HTTPError) as he:
                 sg_client.add_conflict(url=sg_url, db=sg_db, doc_id=doc["id"], parent_revisions=doc["value"]["rev"], new_revision="2-2B",
                                        auth=session)
-            assert he.value.message.startswith('409 Client Error: Conflict for url:')
+            assert he.value.args[0].startswith('409 Client Error: Conflict for url:')
             time.sleep(1)
         else:
             conflicted_rev = sg_client.add_conflict(url=sg_url, db=sg_db, doc_id=doc["id"], parent_revisions=doc["value"]["rev"], new_revision="2-2B",
@@ -308,7 +306,6 @@ def test_no_conflicts_update_with_revs_limit(params_from_base_test_setup, sg_con
     replicator.stop(repl)
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.conflicts
 @pytest.mark.noconflicts
@@ -401,7 +398,7 @@ def test_migrate_conflicts_to_noConflicts_CBL(params_from_base_test_setup, sg_co
         with pytest.raises(HTTPError) as he:
             sg_client.add_conflict(url=sg_url, db=sg_db, doc_id=doc["id"], parent_revisions=doc["value"]["rev"], new_revision="3-2B",
                                    auth=session)
-        assert he.value.message.startswith('409 Client Error: Conflict for url:')
+        assert he.value.args[0].startswith('409 Client Error: Conflict for url:')
 
     total_updates = (revs_limit + 5) / 2
     for i in xrange(total_updates):
@@ -521,7 +518,7 @@ def test_cbl_no_conflicts_sgAccel_added(params_from_base_test_setup, sg_conf_nam
         with pytest.raises(HTTPError) as he:
             sg_client.add_conflict(url=sg_url, db=sg_db, doc_id=doc["id"], parent_revisions=doc["value"]["rev"], new_revision="2-foo1",
                                    auth=session)
-        assert he.value.message.startswith('409 Client Error: Conflict for url:')
+        assert he.value.args[0].startswith('409 Client Error: Conflict for url:')
 
     db.update_bulk_docs(database=cbl_db, number_of_updates=3)
     replicator.wait_until_replicator_idle(repl)
@@ -530,10 +527,9 @@ def test_cbl_no_conflicts_sgAccel_added(params_from_base_test_setup, sg_conf_nam
         with pytest.raises(HTTPError) as he:
             sg_client.add_conflict(url=sg_url, db=sg_db, doc_id=doc["id"], parent_revisions=doc["value"]["rev"], new_revision="2-foo1",
                                    auth=session)
-        assert he.value.message.startswith('409 Client Error: Conflict for url:')
+        assert he.value.args[0].startswith('409 Client Error: Conflict for url:')
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.noconflicts
 @pytest.mark.replication
@@ -647,7 +643,7 @@ def test_sg_CBL_updates_concurrently(params_from_base_test_setup, sg_conf_name, 
             with pytest.raises(HTTPError) as he:
                 sg_client.add_conflict(url=sg_url, db=sg_db, doc_id=doc["id"], parent_revisions=doc["value"]["rev"], new_revision="2-foo",
                                        auth=session)
-            assert he.value.message.startswith('409 Client Error: Conflict for url:')
+            assert he.value.args[0].startswith('409 Client Error: Conflict for url:')
     else:
         for doc in sg_docs:
             conflicted_rev = sg_client.add_conflict(url=sg_url, db=sg_db, doc_id=doc["id"], parent_revisions=doc["value"]["rev"], new_revision="2-foo",
@@ -815,7 +811,7 @@ def test_multiple_cbls_updates_concurrently_with_push(params_from_base_test_setu
             with pytest.raises(HTTPError) as he:
                 sg_client.add_conflict(url=sg_url, db=sg_db, doc_id=doc["id"], parent_revisions=doc["value"]["rev"], new_revision="2-2B",
                                        auth=session)
-            assert he.value.message.startswith('409 Client Error: Conflict for url:')
+            assert he.value.args[0].startswith('409 Client Error: Conflict for url:')
 
 
 @pytest.mark.listener
@@ -1138,7 +1134,7 @@ def test_CBL_push_without_pull(params_from_base_test_setup, sg_conf_name, num_of
             with pytest.raises(HTTPError) as he:
                 sg_client.add_conflict(url=sg_url, db=sg_db, doc_id=doc["id"], parent_revisions=doc["value"]["rev"], new_revision="2-2B",
                                        auth=session)
-            assert he.value.message.startswith('409 Client Error: Conflict for url:')
+            assert he.value.args[0].startswith('409 Client Error: Conflict for url:')
     else:
         for doc in sg_docs:
             conflicted_rev = sg_client.add_conflict(url=sg_url, db=sg_db, doc_id=doc["id"], parent_revisions=doc["value"]["rev"], new_revision="2-2B",

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_predective_queries.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_predective_queries.py
@@ -7,12 +7,11 @@ from libraries.testkit import cluster
 from keywords.utils import deep_dict_compare
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.parametrize(
     'doc_generator_type',
     [
-        ('four_k'),
+        pytest.param('four_k', marks=pytest.mark.sanity),
         ('simple_user'),
         ('complex_doc'),
         ('simple')
@@ -73,7 +72,6 @@ def test_predictiveQueries_basicInputOutput(params_from_base_test_setup, doc_gen
     assert "Parameter of prediction() must be a dictionary" in error
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.predictivequeries
 @pytest.mark.parametrize("coordinates, euclidean_result, squareEuclidean_result, cosine_result",

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
@@ -38,14 +38,12 @@ def setup_teardown_test(params_from_base_test_setup):
     db.deleteDB(cbl_db)
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.replication
 @pytest.mark.parametrize("num_of_docs, continuous, x509_cert_auth", [
     (10, True, True),
-    (100, True, False),
-    (1000, True, True),
-    (1000, False, False)
+    pytest.param(100, True, False, marks=pytest.mark.sanity),
+    (1000, True, True)
 ])
 def test_replication_configuration_valid_values(params_from_base_test_setup, num_of_docs, continuous, x509_cert_auth):
     """
@@ -134,7 +132,6 @@ def test_replication_configuration_valid_values(params_from_base_test_setup, num
     assert total == completed, "total is not equal to completed"
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.replication
 @pytest.mark.parametrize("authenticator_type, attachments_generator", [
@@ -223,7 +220,6 @@ def test_replication_configuration_with_pull_replication(params_from_base_test_s
                 "attachment_pull_bytes did not get incremented"
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.replication
 @pytest.mark.parametrize("authenticator_type, attachments_generator", [
@@ -607,7 +603,6 @@ def test_replication_configuration_with_headers(params_from_base_test_setup):
         assert doc in sg_ids
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.noconflicts
 @pytest.mark.parametrize("num_of_docs, x509_cert_auth", [
@@ -1056,7 +1051,6 @@ def test_CBL_push_pull_with_sgAccel_down(params_from_base_test_setup, sg_conf_na
         assert cbl_db_docs[doc]["updates-cbl"] == number_of_updates, "updates-cbl did not get updated"
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.noconflicts
 @pytest.mark.parametrize("sg_conf_name, num_of_docs", [
@@ -1383,12 +1377,12 @@ def test_replication_wrong_blip(params_from_base_test_setup):
         replicator.configure(cbl_db, sg_blip_url, continuous=True, channels=channels,
                              replicator_authenticator=replicator_authenticator)
     if liteserv_platform == "ios":
-        assert "Invalid scheme for URLEndpoint url (ht2tp" in ex.value.message
-        assert "must be either 'ws:' or 'wss:'" in ex.value.message
+        assert "Invalid scheme for URLEndpoint url (ht2tp" in str(ex.value)
+        assert "must be either 'ws:' or 'wss:'" in str(ex.value)
     else:
-        assert ex.value.message.startswith('400 Client Error: Bad Request for url:')
-        assert "unsupported" in ex.value.message or "Invalid" in ex.value.message
-    assert "ws" in ex.value.message and "wss" in ex.value.message
+        assert str(ex.value).startswith('400 Client Error: Bad Request for url:')
+        assert "unsupported" in str(ex.value) or "Invalid" in str(ex.value)
+    assert "ws" in str(ex.value) and "wss" in str(ex.value)
 
 
 @pytest.mark.listener
@@ -1855,7 +1849,7 @@ def test_default_conflict_with_two_conflictsAndTomstone(params_from_base_test_se
         with pytest.raises(KeyError) as ke:
             cbl_docs[id]["updates"]
 
-        assert ke.value.message.startswith('updates')
+        assert ke.value.args[0].startswith('updates')
     replicator.stop(repl)
 
 
@@ -2621,7 +2615,6 @@ def test_replication_withChannels1_withMultipleSgDBs(params_from_base_test_setup
     replicator.stop(repl2)
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.replication
 @pytest.mark.parametrize("topology_type", [
@@ -2957,7 +2950,6 @@ def test_replication_multipleChannels_withFilteredDocIds(params_from_base_test_s
         assert doc_id not in cbl_doc_ids, "Non filtered doc id is replicated to cbl"
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.replication
 @pytest.mark.parametrize("replication_type, target_db", [

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication_eventing.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication_eventing.py
@@ -9,13 +9,12 @@ from libraries.testkit import cluster
 from libraries.data import doc_generators
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.replication
 @pytest.mark.parametrize("num_of_docs", [
-    10,
-    100,
-    1000,
+    (10),
+    pytest.param(100, marks=pytest.mark.sanity),
+    (1000),
 ])
 def test_replication_eventing_status(params_from_base_test_setup, num_of_docs):
     """

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication_filtering.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication_filtering.py
@@ -9,12 +9,11 @@ from CBLClient.Replication import Replication
 from libraries.testkit import cluster
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.replication
 @pytest.mark.parametrize("num_of_docs", [
     10,
-    100,
+    pytest.param(100, marks=pytest.mark.sanity),
     1000
 ])
 def test_replication_push_filtering(params_from_base_test_setup, num_of_docs):
@@ -125,7 +124,6 @@ def test_replication_push_filtering(params_from_base_test_setup, num_of_docs):
                    "new_field_3" not in sg_doc.keys(), "updated key found in doc. Push filter is not working"
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.replication
 @pytest.mark.parametrize("num_of_docs", [
@@ -231,7 +229,6 @@ def test_replication_pull_filtering(params_from_base_test_setup, num_of_docs):
                    "new_field_3" not in cbl_doc.keys(), "updated key found in doc. Pull filter is not working"
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.replication
 @pytest.mark.parametrize("num_of_docs", [
@@ -334,7 +331,6 @@ def test_replication_filter_deleted_document(params_from_base_test_setup, num_of
         assert doc_id in sg_doc_ids, "CBL deleted docs got replicated to CBL"
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.replication
 @pytest.mark.parametrize("num_of_docs", [
@@ -440,7 +436,6 @@ def test_replication_filter_access_revoke_document(params_from_base_test_setup, 
                    "new_field_3" in cbl_docs[doc_id]
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.replication
 @pytest.mark.parametrize("num_of_docs", [

--- a/testsuites/CBLTester/System_test_multiple_device/test_system_testing.py
+++ b/testsuites/CBLTester/System_test_multiple_device/test_system_testing.py
@@ -13,7 +13,6 @@ from libraries.data.doc_generators import simple, four_k, simple_user, complex_d
 from datetime import datetime, timedelta
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.replication
 def test_system(params_from_base_suite_setup):

--- a/testsuites/CBLTester/p2p_tests/test_p2p_custom_conflict_resolution.py
+++ b/testsuites/CBLTester/p2p_tests/test_p2p_custom_conflict_resolution.py
@@ -7,7 +7,6 @@ from keywords.utils import random_string, log_info
 from testsuites.CBLTester.CBL_Functional_tests.TestSetup_FunctionalTests.test_delta_sync import property_updater
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.custom_conflict
 @pytest.mark.replication
@@ -126,7 +125,6 @@ def test_p2p_local_wins_custom_conflicts(params_from_base_test_setup, server_set
             assert "client_random" in server_cbl_doc, "CCR failed to resolve conflict with local win"
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.custom_conflict
 @pytest.mark.replication
@@ -134,7 +132,7 @@ def test_p2p_local_wins_custom_conflicts(params_from_base_test_setup, server_set
     ("pull", "URLEndPoint"),
     ("pull", "MessageEndPoint"),
     ("push_pull", "URLEndPoint"),
-    ("push_pull", "MessageEndPoint")
+    pytest.param("push_pull", "MessageEndPoint", marks=pytest.mark.sanity)
 ])
 def test_p2p_remote_wins_custom_conflicts(params_from_base_test_setup, server_setup, replicator_type, endpoint_type):
     """

--- a/testsuites/CBLTester/p2p_tests/test_p2p_replication_eventing.py
+++ b/testsuites/CBLTester/p2p_tests/test_p2p_replication_eventing.py
@@ -7,7 +7,6 @@ from CBLClient.PeerToPeer import PeerToPeer
 from keywords.utils import get_event_changes, meet_supported_version
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.parametrize("num_of_docs, continuous, replicator_type, attachments, endpoint_type", [
     (10, True, "push_pull", False, "URLEndPoint"),
@@ -16,7 +15,7 @@ from keywords.utils import get_event_changes, meet_supported_version
     (100, False, "push_pull", False, "URLEndPoint"),
     (10, True, "push_pull", False, "MessageEndPoint"),
     (10, False, "push_pull", False, "MessageEndPoint"),
-    (10, False, "push_pull", True, "MessageEndPoint"),
+    pytest.param(10, False, "push_pull", True, "MessageEndPoint", marks=pytest.mark.sanity),
     (100, False, "push_pull", False, "MessageEndPoint"),
 
 ])

--- a/testsuites/CBLTester/p2p_tests/test_p2p_replication_filtering.py
+++ b/testsuites/CBLTester/p2p_tests/test_p2p_replication_filtering.py
@@ -8,13 +8,12 @@ from CBLClient.Replication import Replication
 from CBLClient.PeerToPeer import PeerToPeer
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.parametrize("num_of_docs, replicator_type, attachments, endpoint_type", [
     (10, "push", False, "URLEndPoint"),
     (10, "pull", False, "URLEndPoint"),
     (10, "push", False, "MessageEndPoint"),
-    (10, "pull", False, "MessageEndPoint"),
+    pytest.param(10, "pull", False, "MessageEndPoint", marks=pytest.mark.sanity),
     (100, "push", True, "URLEndPoint"),
     (100, "pull", True, "URLEndPoint"),
     (100, "push", True, "MessageEndPoint"),

--- a/testsuites/CBLTester/p2p_tests/test_peer_to_peer.py
+++ b/testsuites/CBLTester/p2p_tests/test_peer_to_peer.py
@@ -10,12 +10,11 @@ from CBLClient.Replication import Replication
 from CBLClient.PeerToPeer import PeerToPeer
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.parametrize("num_of_docs, continuous, replicator_type, attachments, endPointType", [
     (10, True, "push_pull", False, "URLEndPoint"),
     (100, True, "push_pull", True, "MessageEndPoint"),
-    (10, True, "push_pull", False, "MessageEndPoint"),
+    pytest.param(10, True, "push_pull", False, "MessageEndPoint", marks=pytest.mark.sanity),
     (100, False, "push", False, "URLEndPoint"),
 ])
 def test_peer_to_peer_1to1_valid_values(params_from_base_test_setup, server_setup, num_of_docs, continuous, replicator_type, attachments, endPointType):
@@ -64,7 +63,6 @@ def test_peer_to_peer_1to1_valid_values(params_from_base_test_setup, server_setu
     replicator.stop(repl)
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.parametrize("num_of_docs, continuous, endPointType, attachments", [
     (10, True, "MessageEndPoint", False),
@@ -116,7 +114,6 @@ def test_peer_to_peer2_1to1_pull_replication(params_from_base_test_setup, server
     replicator.stop(repl)
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.parametrize("num_of_docs, continuous, replicator_type, endPointType", [
     (10, True, "push_pull", "MessageEndPoint"),
@@ -196,11 +193,10 @@ def test_peer_to_peer_concurrent_replication(params_from_base_test_setup, server
     replicator.stop(repl)
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.parametrize("num_of_docs, continuous, replicator_type, endPointType", [
     (10, True, "push_pull", "URLEndPoint"),
-    (10, False, "push_pull", "MessageEndPoint"),
+    pytest.param(10, False, "push_pull", "MessageEndPoint", marks=pytest.mark.sanity),
     (100, False, "push", "URLEndPoint"),
     (100, True, "push", "MessageEndPoint"),
 ])
@@ -265,7 +261,6 @@ def test_peer_to_peer_oneClient_toManyServers(params_from_base_test_setup, num_o
     peerToPeer_server2.server_stop(replicatorTcpListener2)
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.parametrize("num_of_docs, continuous, replicator_type, endPointType", [
     (10, True, "push_pull", "MessageEndPoint"),
@@ -326,12 +321,11 @@ def test_peer_to_peer_oneServer_toManyClients(params_from_base_test_setup, serve
     client_replicator2.stop(repl2)
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.parametrize("num_of_docs, replicator_type, endPointType", [
     (10, "push_pull", "MessageEndPoint"),
     (100, "push", "MessageEndPoint"),
-    (10, "push_pull", "URLEndPoint"),
+    pytest.param(10, "push_pull", "URLEndPoint", marks=pytest.mark.sanity),
     (100, "push", "URLEndPoint")
 ])
 def test_peer_to_peer_filter_docs_ids(params_from_base_test_setup, server_setup, num_of_docs, replicator_type, endPointType):
@@ -381,7 +375,6 @@ def test_peer_to_peer_filter_docs_ids(params_from_base_test_setup, server_setup,
     replicator.stop(repl)
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.parametrize("num_of_docs, replicator_type, endPointType", [
     (10, "push_pull", "MessageEndPoint"),
@@ -442,10 +435,9 @@ def test_peer_to_peer_delete_docs(params_from_base_test_setup, server_setup, num
     replicator.stop(repl)
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.parametrize("num_of_docs, continuous, replicator_type, endPointType", [
-    (10, True, "push_pull", "MessageEndPoint"),
+    pytest.param(10, True, "push_pull", "MessageEndPoint", marks=pytest.mark.sanity),
     (10, False, "push_pull", "URLEndPoint"),
     (100, True, "push", "MessageEndPoint"),
     (100, True, "push", "URLEndPoint"),
@@ -519,7 +511,6 @@ def test_peer_to_peer_with_server_down(params_from_base_test_setup, server_setup
     replicator.stop(repl)
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.parametrize("num_of_docs, continuous, replicator_type, endPointType", [
     (10, True, "push_pull", "URLEndPoint"),
@@ -589,7 +580,6 @@ def test_peer_to_peer_resetCheckPoint(params_from_base_test_setup, server_setup,
     replicator.stop(repl)
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.parametrize("num_of_docs, continuous, replicator_type, endPointType", [
     (10, True, "push_pull", "URLEndPoint"),
@@ -684,7 +674,6 @@ def test_peer_to_peer_replication_with_multiple_dbs(params_from_base_test_setup,
     peerToPeer_server.server_stop(replicatorTcpListener3)
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.parametrize("num_of_docs, continuous, replicator_type, endPointType", [
     (10, True, "push_pull", "MessageEndPoint"),

--- a/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/test_replication_multiple_sgs.py
+++ b/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/test_replication_multiple_sgs.py
@@ -12,11 +12,10 @@ from keywords.constants import CLUSTER_CONFIGS_DIR
 from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.replication
 @pytest.mark.parametrize("sg_conf_name, num_of_docs", [
-    ('listener_tests/multiple_sync_gateways', 10),
+    pytest.param('listener_tests/multiple_sync_gateways', 10, marks=pytest.mark.sanity),
     ('listener_tests/multiple_sync_gateways', 100),
     ('listener_tests/multiple_sync_gateways', 1000)
 ])
@@ -154,11 +153,10 @@ def test_multiple_sgs_with_differrent_revs_limit(params_from_base_test_setup, se
         assert len(revs) == revs_limit2
 
 
-@pytest.mark.sanity
 @pytest.mark.listener
 @pytest.mark.replication
 @pytest.mark.parametrize("sg_conf_name, num_of_docs", [
-    ('listener_tests/multiple_sync_gateways', 10),
+    pytest.param('listener_tests/multiple_sync_gateways', 10, marks=pytest.mark.sanity),
     ('listener_tests/multiple_sync_gateways', 100),
     ('listener_tests/multiple_sync_gateways', 1000)
 ])

--- a/testsuites/syncgateway/functional/tests/test_bulk_get_compression.py
+++ b/testsuites/syncgateway/functional/tests/test_bulk_get_compression.py
@@ -150,7 +150,6 @@ def verify_response_size(user_agent, accept_encoding, x_accept_part_encoding, re
         raise ValueError("Unsupported user agent")
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.channel
 @pytest.mark.basicauth
@@ -166,7 +165,7 @@ def verify_response_size(user_agent, accept_encoding, x_accept_part_encoding, re
     ("sync_gateway_gzip", 300, None, None, "CouchbaseLite/1.2", False),
     ("sync_gateway_gzip", 300, "gzip", None, "CouchbaseLite/1.2", True),
     ("sync_gateway_gzip", 300, None, "gzip", "CouchbaseLite/1.2", True),
-    ("sync_gateway_gzip", 300, "gzip", "gzip", "CouchbaseLite/1.2", False)
+    pytest.param("sync_gateway_gzip", 300, "gzip", "gzip", "CouchbaseLite/1.2", False, marks=pytest.mark.sanity)
 ])
 def test_bulk_get_compression(params_from_base_test_setup, sg_conf_name, num_docs, accept_encoding,
                               x_accept_part_encoding, user_agent, x509_cert_auth):

--- a/testsuites/syncgateway/functional/tests/test_changes.py
+++ b/testsuites/syncgateway/functional/tests/test_changes.py
@@ -13,7 +13,6 @@ from utilities.cluster_config_utils import persist_cluster_config_environment_pr
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
-    ("sync_gateway_default", True),
     ("sync_gateway_default", False),
 ])
 def test_deleted_docs_from_changes_active_only(params_from_base_test_setup, sg_conf_name, x509_cert_auth):

--- a/testsuites/syncgateway/functional/tests/test_changes_backfill.py
+++ b/testsuites/syncgateway/functional/tests/test_changes_backfill.py
@@ -13,7 +13,6 @@ from keywords import document
 from keywords import exceptions
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.session
@@ -23,7 +22,7 @@ from keywords import exceptions
 @pytest.mark.backfill
 @pytest.mark.parametrize("sg_conf_name, grant_type, x509_cert_auth", [
     ("custom_sync/access", "CHANNEL-REST", True),
-    ("custom_sync/access", "CHANNEL-SYNC", False),
+    pytest.param("custom_sync/access", "CHANNEL-SYNC", False, marks=pytest.mark.sanity),
     ("custom_sync/access", "ROLE-REST", False),
     ("custom_sync/access", "ROLE-SYNC", True),
     ("custom_sync/access", "CHANNEL-TO-ROLE-REST", True),

--- a/testsuites/syncgateway/functional/tests/test_channels.py
+++ b/testsuites/syncgateway/functional/tests/test_channels.py
@@ -112,7 +112,6 @@ def test_channels_view_after_restart(params_from_base_test_setup, sg_conf_name):
 @pytest.mark.basicauth
 @pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
-    ("sync_gateway_default", True),
     ("sync_gateway_default", False),
 ])
 def test_remove_add_channels_to_doc(params_from_base_test_setup, sg_conf_name, x509_cert_auth):

--- a/testsuites/syncgateway/functional/tests/test_conflicts.py
+++ b/testsuites/syncgateway/functional/tests/test_conflicts.py
@@ -178,14 +178,13 @@ def test_non_winning_revisions(params_from_base_test_setup, sg_conf_name):
     assert len(changes_5["results"]) == 0
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.conflicts
 @pytest.mark.changes
 @pytest.mark.basicauth
 @pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
-    ("sync_gateway_default_functional_tests", True),
+    pytest.param("sync_gateway_default_functional_tests", True, marks=pytest.mark.sanity),
     ("sync_gateway_default_functional_tests", False)
 ])
 def test_winning_conflict_branch_revisions(params_from_base_test_setup, sg_conf_name, x509_cert_auth):

--- a/testsuites/syncgateway/functional/tests/test_continuous.py
+++ b/testsuites/syncgateway/functional/tests/test_continuous.py
@@ -88,14 +88,13 @@ def test_continuous_changes_parametrized(params_from_base_test_setup, sg_conf_na
     verify_changes(abc_doc_pusher, expected_num_docs=num_docs, expected_num_revisions=num_revisions, expected_docs=abc_doc_pusher.cache)
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.basicauth
 @pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name, num_docs, num_revisions, x509_cert_auth", [
     ("sync_gateway_default_functional_tests", 10, 10, True),
-    ("sync_gateway_default_functional_tests_no_port", 10, 10, False),
+    pytest.param("sync_gateway_default_functional_tests_no_port", 10, 10, False, marks=pytest.mark.sanity),
     ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 10, 10, False)
 ])
 def test_continuous_changes_sanity(params_from_base_test_setup, sg_conf_name, num_docs, num_revisions, x509_cert_auth):

--- a/testsuites/syncgateway/functional/tests/test_crud.py
+++ b/testsuites/syncgateway/functional/tests/test_crud.py
@@ -386,10 +386,10 @@ def verify_sg_deletes(sg_client, sg_url, sg_db, expected_deleted_ids, sg_auth):
         he = None
         with pytest.raises(HTTPError) as he:
             sg_client.get_doc(url=sg_url, db=sg_db, doc_id=doc_id, auth=sg_auth)
-        log_info("HTTP error message is {}".format(he.value.message))
+        log_info("HTTP error message is {}".format(he.value.args[0]))
         assert he is not None
-        log_info(he.value.message)
-        assert he.value.message.startswith('403 Client Error: Forbidden for url:')
+        log_info(he.value.args[0])
+        assert he.value.args[0].startswith('403 Client Error: Forbidden for url:')
 
 
 def verify_sg_purges(sg_client, sg_url, sg_db, expected_deleted_ids, sg_auth):
@@ -398,8 +398,8 @@ def verify_sg_purges(sg_client, sg_url, sg_db, expected_deleted_ids, sg_auth):
         with pytest.raises(HTTPError) as he:
             sg_client.get_doc(url=sg_url, db=sg_db, doc_id=doc_id, auth=sg_auth)
         assert he is not None
-        log_info(he.value.message)
-        assert he.value.message.startswith('404 Client Error: Not Found for url:')
+        log_info(he.value.args[0])
+        assert he.value.args[0].startswith('404 Client Error: Not Found for url:')
 
 
 def verify_sdk_deletes(sdk_client, expected_deleted_ids):
@@ -408,5 +408,5 @@ def verify_sdk_deletes(sdk_client, expected_deleted_ids):
         with pytest.raises(NotFoundError) as nfe:
             sdk_client.get(doc_id)
         assert nfe is not None
-        log_info(nfe.value.message)
+        log_info(str(nfe))
         assert 'The key does not exist on the server' in str(nfe)

--- a/testsuites/syncgateway/functional/tests/test_crud.py
+++ b/testsuites/syncgateway/functional/tests/test_crud.py
@@ -15,7 +15,6 @@ from keywords.exceptions import TimeoutException
 from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
 @pytest.mark.changes
@@ -24,7 +23,7 @@ from utilities.cluster_config_utils import get_sg_version, persist_cluster_confi
     ('sync_gateway_default_functional_tests', 'tombstone', False),
     ('sync_gateway_default_functional_tests', 'purge', True),
     ('sync_gateway_default_functional_tests_no_port', 'tombstone', True),
-    ('sync_gateway_default_functional_tests_no_port', 'purge', False),
+    pytest.param('sync_gateway_default_functional_tests_no_port', 'purge', False, marks=pytest.mark.sanity),
     ('sync_gateway_default_functional_tests_couchbase_protocol_withport_11210', 'purge', False)
 ])
 def test_document_resurrection(params_from_base_test_setup, sg_conf_name, deletion_type, x509_cert_auth):

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline.py
@@ -30,7 +30,6 @@ NUM_ENDPOINTS = 13
 @pytest.mark.bulkops
 @pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name, num_docs, x509_cert_auth", [
-    ("bucket_online_offline/bucket_online_offline_default", 100, True),
     ("bucket_online_offline/bucket_online_offline_default", 100, False)
 ])
 def test_online_default_rest(params_from_base_test_setup, sg_conf_name, num_docs, x509_cert_auth):

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline_resync.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline_resync.py
@@ -16,14 +16,13 @@ from keywords.SyncGateway import sync_gateway_config_path_for_mode
 from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
 @pytest.mark.basicauth
 @pytest.mark.channel
 @pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name, num_users, num_docs, num_revisions, x509_cert_auth", [
-    ("bucket_online_offline/db_online_offline_access_all", 5, 100, 10, True),
+    pytest.param("bucket_online_offline/db_online_offline_access_all", 5, 100, 10, True, marks=pytest.mark.sanity),
     ("bucket_online_offline/db_online_offline_access_all", 5, 100, 10, False)
 ])
 def test_bucket_online_offline_resync_sanity(params_from_base_test_setup, sg_conf_name, num_users, num_docs,

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline_webhooks.py
@@ -15,12 +15,11 @@ from keywords.MobileRestClient import MobileRestClient
 from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
 @pytest.mark.webhooks
 @pytest.mark.parametrize("sg_conf_name, num_users, num_channels, num_docs, num_revisions, x509_cert_auth", [
-    ("webhooks/webhook_offline", 5, 1, 1, 2, False),
+    pytest.param("webhooks/webhook_offline", 5, 1, 1, 2, False, marks=pytest.mark.sanity),
     ("webhooks/webhook_offline", 5, 1, 1, 2, True)
 ])
 def test_db_online_offline_webhooks_offline(params_from_base_test_setup, sg_conf_name, num_users, num_channels,

--- a/testsuites/syncgateway/functional/tests/test_log_redaction.py
+++ b/testsuites/syncgateway/functional/tests/test_log_redaction.py
@@ -372,7 +372,7 @@ def verify_log_redaction(cluster_config, log_redaction_level, mode):
                 if log_redaction_level == "none":
                     continue
                 else:
-                    assert False, le.message
+                    assert False, str(le)
 
     # verify starting and ending ud tags are equal
     num_ud_tags = subprocess.check_output("find {} -name '*.log' | xargs grep '<ud>' | wc -l".format(temp_log_path), shell=True)

--- a/testsuites/syncgateway/functional/tests/test_log_redaction.py
+++ b/testsuites/syncgateway/functional/tests/test_log_redaction.py
@@ -20,11 +20,10 @@ from keywords import document, attachment
 from libraries.provision.ansible_runner import AnsibleRunner
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.logredaction
 @pytest.mark.parametrize("sg_conf_name, redaction_level, x509_cert_auth", [
-    ("log_redaction", "partial", False),
+    pytest.param("log_redaction", "partial", False, marks=pytest.mark.sanity),
     ("log_redaction", "none", True)
 ])
 def test_log_redaction_config(params_from_base_test_setup, remove_tmp_sg_redaction_logs,
@@ -83,12 +82,11 @@ def test_log_redaction_config(params_from_base_test_setup, remove_tmp_sg_redacti
     verify_log_redaction(temp_cluster_config, redaction_level, mode)
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.logredaction
 @pytest.mark.parametrize("sg_conf_name, redaction_level, redaction_salt, x509_cert_auth", [
     ("log_redaction", "partial", False, True),
-    ("log_redaction", "none", False, False),
+    pytest.param("log_redaction", "none", False, False, marks=pytest.mark.sanity),
     ("log_redaction", "partial", True, True)
 ])
 def test_sgCollect1(params_from_base_test_setup, remove_tmp_sg_redaction_logs, sg_conf_name,
@@ -146,7 +144,6 @@ def test_sgCollect1(params_from_base_test_setup, remove_tmp_sg_redaction_logs, s
     log_verification_withsgCollect(redaction_level, user_name, password, zip_file_name)
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.logredaction
 @pytest.mark.parametrize("sg_conf_name, redaction_level, redaction_salt, output_dir, x509_cert_auth", [
@@ -265,12 +262,10 @@ def test_sgCollect_restApi(params_from_base_test_setup, remove_tmp_sg_redaction_
     log_verification_withsgCollect(redaction_level, user_name, password)
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.logredaction
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
-    ("log_redaction", False),
-    ("log_redaction", True)
+    ("log_redaction", False)
 ])
 def test_sgCollectRestApi_errorMessages(params_from_base_test_setup, remove_tmp_sg_redaction_logs, sg_conf_name, x509_cert_auth):
     """

--- a/testsuites/syncgateway/functional/tests/test_log_rotation.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation.py
@@ -68,8 +68,7 @@ def load_sync_gateway_config(sync_gateway_config, mode, server_url, xattrs_enabl
 @pytest.mark.syncgateway
 @pytest.mark.logging
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
-    ("log_rotation", True),
-    ("log_rotation", False)
+    ("log_rotation", True)
 ])
 def test_log_rotation_default_values(params_from_base_test_setup, sg_conf_name, x509_cert_auth):
     """Test to verify default values for rotation section:

--- a/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
@@ -16,7 +16,6 @@ from utilities.cluster_config_utils import load_cluster_config_json, persist_clu
 @pytest.mark.syncgateway
 @pytest.mark.logging
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
-    ("log_rotation_new", True),
     ("log_rotation_new", False)
 ])
 def test_log_rotation_default_values(params_from_base_test_setup, sg_conf_name, x509_cert_auth):

--- a/testsuites/syncgateway/functional/tests/test_longpoll.py
+++ b/testsuites/syncgateway/functional/tests/test_longpoll.py
@@ -91,13 +91,12 @@ def test_longpoll_changes_parametrized(params_from_base_test_setup, sg_conf_name
     verify_same_docs(expected_num_docs=num_docs, doc_dict_one=docs_in_changes, doc_dict_two=abc_doc_pusher.cache)
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.basicauth
 @pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name, num_docs, num_revisions, x509_cert_auth", [
-    ("sync_gateway_default_functional_tests", 10, 10, True),
+    pytest.param("sync_gateway_default_functional_tests", 10, 10, True, marks=pytest.mark.sanity),
     ("sync_gateway_default_functional_tests_no_port", 10, 10, False),
     ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 10, 10, False)
 ])

--- a/testsuites/syncgateway/functional/tests/test_longpoll.py
+++ b/testsuites/syncgateway/functional/tests/test_longpoll.py
@@ -604,7 +604,7 @@ def test_longpoll_awaken_channels(params_from_base_test_setup, sg_conf_name):
     for user_auth in [adam_auth, traun_auth, andy_auth]:
         with pytest.raises(requests.exceptions.HTTPError) as excinfo:
             client.get_doc(url=sg_url, db=sg_db, doc_id=doc_id, auth=user_auth)
-        assert "403 Client Error: Forbidden for url:" in excinfo.value.message
+        assert "403 Client Error: Forbidden for url:" in excinfo.value.args[0]
 
     ############################################################
     # changes feed wakes with Channel Grant via Sync function

--- a/testsuites/syncgateway/functional/tests/test_mobile_opt_in.py
+++ b/testsuites/syncgateway/functional/tests/test_mobile_opt_in.py
@@ -127,7 +127,7 @@ def test_mobile_opt_in(params_from_base_test_setup, sg_conf_name):
     with pytest.raises(HTTPError) as he:
         sg_client.get_doc(url=sg_url, db=sg_db, doc_id=doc_id2, auth=test_auth_session)
     log_info(he.value)
-    assert he.value.message.startswith('404 Client Error: Not Found for url:')
+    assert str(he.value).startswith('404 Client Error: Not Found for url:')
 
     # Create third sg doc with mobile opt in  and update via sdk. Case #3
     doc_id3 = 'mobile_opt_in_sg_doc'
@@ -152,12 +152,12 @@ def test_mobile_opt_in(params_from_base_test_setup, sg_conf_name):
     with pytest.raises(HTTPError) as he:
         sg_client.get_doc(url=sg_url, db=sg_db, doc_id=doc_id4, auth=test_auth_session)
     log_info(he.value)
-    assert he.value.message.startswith('404 Client Error: Not Found for url:')
+    assert str(he.value).startswith('404 Client Error: Not Found for url:')
     # update via SG
     with pytest.raises(HTTPError) as he:
         sg_client.put_doc(url=sg_url, db=sg_db, doc_id=doc_id4, doc_body={'sg_rewrite': 'True'}, rev=rev, auth=test_auth_session)
     log_info(he.value)
-    assert he.value.message.startswith('409 Client Error: Conflict for url:')
+    assert str(he.value).startswith('409 Client Error: Conflict for url:')
     # Create same doc again to verify there is not existing key error covers case #8
     doc_body = document.create_doc(doc_id=doc_id4, channels=['mobileOptIn'], prop_generator=update_non_mobile_prop)
     sg_get_doc4_1 = sg_client.add_doc(url=sg_url, db=sg_db, doc=doc_body, auth=test_auth_session)
@@ -201,7 +201,7 @@ def test_mobile_opt_in(params_from_base_test_setup, sg_conf_name):
     with pytest.raises(HTTPError) as he:
         sg_get_doc7 = sg_client.get_doc(url=sg_url, db=sg_db, doc_id=doc_id7, auth=test_auth_session)
     log_info(he.value)
-    assert he.value.message.startswith('404 Client Error: Not Found for url:')
+    assert str(he.value).startswith('404 Client Error: Not Found for url:')
     # TODO : verify _changes that it shows tombstone revisions -> it will happen on 2.0
 
     # Create eighth sdk doc with import disabled and add mobile property and update via sg. Case #7
@@ -216,7 +216,7 @@ def test_mobile_opt_in(params_from_base_test_setup, sg_conf_name):
     with pytest.raises(HTTPError) as he:
         sg_client.add_doc(url=sg_url, db=sg_db, doc=doc_body, auth=test_auth_session)
     log_info(he.value)
-    assert he.value.message.startswith('409 Client Error: Conflict for url:')
+    assert str(he.value).startswith('409 Client Error: Conflict for url:')
     sg_client.update_doc(url=sg_url, db=sg_db, doc_id=doc_id8, number_updates=1, auth=test_auth_session)
     sg_get_doc8 = sg_client.get_doc(url=sg_url, db=sg_db, doc_id=doc_id8, auth=test_auth_session)
     assert sg_get_doc8['_rev'].startswith('2-') and sg_get_doc8['_id'] == doc_id8

--- a/testsuites/syncgateway/functional/tests/test_multiple_dbs.py
+++ b/testsuites/syncgateway/functional/tests/test_multiple_dbs.py
@@ -70,14 +70,13 @@ def test_multiple_db_unique_data_bucket_unique_index_bucket(params_from_base_tes
 
 
 # Kind of an edge case in that most users would not point multiple dbs at the same server bucket
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.basicauth
 @pytest.mark.channel
 @pytest.mark.bulkops
 @pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name, num_users, num_docs_per_user, x509_cert_auth", [
-    ("multiple_dbs_shared_data_shared_index", 10, 500, False),
+    pytest.param("multiple_dbs_shared_data_shared_index", 10, 500, False, marks=pytest.mark.sanity),
     ("multiple_dbs_shared_data_shared_index", 10, 500, True)
 ])
 def test_multiple_db_single_data_bucket_single_index_bucket(params_from_base_test_setup, sg_conf_name, num_users,

--- a/testsuites/syncgateway/functional/tests/test_multiple_users_multiple_channels_multiple_revisions.py
+++ b/testsuites/syncgateway/functional/tests/test_multiple_users_multiple_channels_multiple_revisions.py
@@ -17,7 +17,6 @@ from utilities.cluster_config_utils import get_sg_version, persist_cluster_confi
 # Single User Single Channel: Create Unique docs and update docs verify all num docs present in changes feed.
 # Verify all revisions in changes feed
 # https://docs.google.com/spreadsheets/d/1nlba3SsWagDrnAep3rDZHXHIDmRH_FFDeTaYJms_55k/edit#gid=598127796
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.basicauth
 @pytest.mark.channel
@@ -25,7 +24,7 @@ from utilities.cluster_config_utils import get_sg_version, persist_cluster_confi
 @pytest.mark.parametrize("sg_conf_name, num_users, num_channels, num_docs, num_revisions, x509_cert_auth", [
     ("sync_gateway_default_functional_tests", 10, 3, 10, 10, False),
     ("sync_gateway_default_functional_tests_no_port", 10, 3, 10, 10, True),
-    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 10, 3, 10, 10, False)
+    pytest.param("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 10, 3, 10, 10, False, marks=pytest.mark.sanity)
 ])
 def test_mulitple_users_mulitiple_channels_mulitple_revisions(params_from_base_test_setup, sg_conf_name, num_users,
                                                               num_channels, num_docs, num_revisions, x509_cert_auth):

--- a/testsuites/syncgateway/functional/tests/test_no_conflicts.py
+++ b/testsuites/syncgateway/functional/tests/test_no_conflicts.py
@@ -71,7 +71,7 @@ def test_no_conflicts_enabled(params_from_base_test_setup, sg_conf_name, num_of_
         with pytest.raises(HTTPError) as he:
             sg_client.add_conflict(url=sg_url, db=sg_db, doc_id=doc["id"], parent_revisions=doc["rev"], new_revision="2-foo",
                                    auth=autouser_session)
-        assert he.value.message.startswith('409 Client Error: Conflict for url:')
+        assert str(he.value).startswith('409 Client Error: Conflict for url:')
 
     # 6. Update the docs 1 more time
     sg_client.update_docs(url=sg_url, db=sg_db, docs=sg_docs, number_updates=1, delay=None, auth=autouser_session, channels=channels)
@@ -145,7 +145,7 @@ def test_no_conflicts_with_revs_limit(params_from_base_test_setup, sg_conf_name,
         with pytest.raises(HTTPError) as he:
             sg_client.add_conflict(url=sg_url, db=sg_db, doc_id=doc["id"], parent_revisions=doc["rev"], new_revision="2-foo",
                                    auth=autouser_session)
-        assert he.value.message.startswith('409 Client Error: Conflict for url:')
+        assert str(he.value).startswith('409 Client Error: Conflict for url:')
 
     # 5. Get number of revisions and verify length is equal to revs_limit set to
     for doc in sg_docs:
@@ -424,7 +424,7 @@ def test_migrate_conflicts_to_noConflicts(params_from_base_test_setup, sg_conf_n
         with pytest.raises(HTTPError) as he:
             sg_client.add_conflict(url=sg_url, db=sg_db, doc_id=doc["id"], parent_revisions=doc["rev"], new_revision="2-foo1",
                                    auth=autouser_session)
-        assert he.value.message.startswith('409 Client Error: Conflict for url:')
+        assert str(he.value).startswith('409 Client Error: Conflict for url:')
 
     # 8. update docs few number of times.
     update_sg_docs = sg_client.update_docs(url=sg_url, db=sg_db, docs=sg_docs, number_updates=additional_updates,
@@ -544,7 +544,7 @@ def sg_doc_updates(sg_client, sg_url, sg_db, sg_docs, number_updates, auth, chan
         try:
             sg_client.update_doc(sg_url, sg_db, doc['id'], number_updates, auth=auth, channels=channels)
         except HTTPError as e:
-            if e.response.status_code == 409 and e.message.startswith('409 Client Error: Conflict for url:'):
+            if e.response.status_code == 409 and str(e).startswith('409 Client Error: Conflict for url:'):
                 log_info("Got conflict with sdk update, skip it")
 
 

--- a/testsuites/syncgateway/functional/tests/test_openid_connect.py
+++ b/testsuites/syncgateway/functional/tests/test_openid_connect.py
@@ -112,12 +112,11 @@ def discover_authenticate_endpoint(sg_url, sg_db, provider, ipv6):
     return parser.form_action
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.oidc
 @pytest.mark.parametrize("sg_conf_name, is_admin_port, expect_signed_id_token", [
     ("sync_gateway_openid_connect", False, True),
-    ("sync_gateway_openid_connect", True, True),
+    pytest.param("sync_gateway_openid_connect", True, True, marks=pytest.mark.sanity),
     ("sync_gateway_openid_connect_unsigned", False, False)
 ])
 def test_openidconnect_basic_test(params_from_base_test_setup, sg_conf_name, is_admin_port, expect_signed_id_token):

--- a/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
+++ b/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
@@ -14,7 +14,6 @@ from keywords.SyncGateway import sync_gateway_config_path_for_mode
 from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.basicauth
 @pytest.mark.channel
@@ -22,7 +21,7 @@ from utilities.cluster_config_utils import persist_cluster_config_environment_pr
 @pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name, num_docs, user_channels, filter, limit, x509_cert_auth", [
     ("sync_gateway_channel_cache", 5000, "*", True, 50, False),
-    ("sync_gateway_channel_cache", 1000, "*", True, 50, True),
+    pytest.param("sync_gateway_channel_cache", 1000, "*", True, 50, True, marks=pytest.mark.sanity),
     ("sync_gateway_channel_cache", 1000, "ABC", False, 50, True),
     ("sync_gateway_channel_cache", 1000, "ABC", True, 50, False),
 ])

--- a/testsuites/syncgateway/functional/tests/test_resync.py
+++ b/testsuites/syncgateway/functional/tests/test_resync.py
@@ -17,8 +17,7 @@ from utilities.cluster_config_utils import persist_cluster_config_environment_pr
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
-    ("custom_sync/grant_access_one", False),
-    ("custom_sync/grant_access_one", True)
+    ("custom_sync/grant_access_one", False)
 ])
 def test_resync(params_from_base_test_setup, sg_conf_name, x509_cert_auth):
     """

--- a/testsuites/syncgateway/functional/tests/test_roles.py
+++ b/testsuites/syncgateway/functional/tests/test_roles.py
@@ -9,7 +9,6 @@ from keywords.utils import log_info
 from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.role
 @pytest.mark.basicauth
@@ -18,7 +17,7 @@ from utilities.cluster_config_utils import get_sg_version, persist_cluster_confi
 @pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
     ("sync_gateway_default_functional_tests", True),
-    ("sync_gateway_default_functional_tests_no_port", False),
+    pytest.param("sync_gateway_default_functional_tests_no_port", False, marks=pytest.mark.sanity),
     ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", False)
 ])
 def test_roles_sanity(params_from_base_test_setup, sg_conf_name, x509_cert_auth):

--- a/testsuites/syncgateway/functional/tests/test_rollback.py
+++ b/testsuites/syncgateway/functional/tests/test_rollback.py
@@ -23,7 +23,6 @@ from utilities.cluster_config_utils import persist_cluster_config_environment_pr
 @pytest.mark.rollback
 @pytest.mark.bulkops
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
-    ("sync_gateway_default", True),
     ("sync_gateway_default", False)
 ])
 def test_rollback_server_reset(params_from_base_test_setup, sg_conf_name, x509_cert_auth):

--- a/testsuites/syncgateway/functional/tests/test_seq.py
+++ b/testsuites/syncgateway/functional/tests/test_seq.py
@@ -11,7 +11,6 @@ from keywords.utils import log_info
 from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.basicauth
 @pytest.mark.channel
@@ -20,7 +19,7 @@ from utilities.cluster_config_utils import get_sg_version, persist_cluster_confi
 @pytest.mark.parametrize("sg_conf_name, num_users, num_docs, num_revisions, x509_cert_auth", [
     ("sync_gateway_default_functional_tests", 10, 500, 1, False),
     ("sync_gateway_default_functional_tests_no_port", 10, 500, 1, True),
-    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 10, 500, 1, False)
+    pytest.param("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 10, 500, 1, False, marks=pytest.mark.sanity)
 ])
 def test_seq(params_from_base_test_setup, sg_conf_name, num_users, num_docs, num_revisions, x509_cert_auth):
 

--- a/testsuites/syncgateway/functional/tests/test_single_user_single_channel_doc_updates.py
+++ b/testsuites/syncgateway/functional/tests/test_single_user_single_channel_doc_updates.py
@@ -18,13 +18,12 @@ log = logging.getLogger(libraries.testkit.settings.LOGGER)
 # Single User Single Channel: Create Unique docs and update docs verify all num docs present in changes feed.
 # Verify all revisions in changes feed
 # https://docs.google.com/spreadsheets/d/1nlba3SsWagDrnAep3rDZHXHIDmRH_FFDeTaYJms_55k/edit#gid=598127796
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.basicauth
 @pytest.mark.channel
 @pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name, num_docs, num_revisions, x509_cert_auth", [
-    ("sync_gateway_default_functional_tests", 100, 100, False),
+    pytest.param("sync_gateway_default_functional_tests", 100, 100, False, marks=pytest.mark.sanity),
     ("sync_gateway_default_functional_tests_no_port", 100, 100, True),
     ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 100, 100, False)
 

--- a/testsuites/syncgateway/functional/tests/test_sync.py
+++ b/testsuites/syncgateway/functional/tests/test_sync.py
@@ -552,4 +552,4 @@ def test_sync_20mb(params_from_base_test_setup, sg_conf_name):
     try:
         sg_client.add_doc(url=sg_url, db=sg_db, doc=doc, auth=session)
     except HTTPError as h:
-        assert "413 Client Error: Request Entity Too Large for url" in h.message, "did not throw 413 client error"
+        assert "413 Client Error: Request Entity Too Large for url" in str(h), "did not throw 413 client error"

--- a/testsuites/syncgateway/functional/tests/test_sync.py
+++ b/testsuites/syncgateway/functional/tests/test_sync.py
@@ -109,7 +109,6 @@ def test_issue_1524(params_from_base_test_setup, sg_conf_name, num_docs):
 @pytest.mark.channel
 @pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
-    ("custom_sync/sync_gateway_custom_sync_access_sanity", False),
     ("custom_sync/sync_gateway_custom_sync_access_sanity", True)
 ])
 def test_sync_access_sanity(params_from_base_test_setup, sg_conf_name, x509_cert_auth):
@@ -159,7 +158,6 @@ def test_sync_access_sanity(params_from_base_test_setup, sg_conf_name, x509_cert
     verify_changes(seth, expected_num_docs=0, expected_num_revisions=0, expected_docs={})
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sync
 @pytest.mark.channel
@@ -228,7 +226,6 @@ def test_sync_channel_sanity(params_from_base_test_setup, sg_conf_name):
     # TODO Push more docs to channel and make sure they do not show up in the users changes feed.
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sync
 @pytest.mark.role
@@ -358,7 +355,6 @@ def test_sync_sanity(params_from_base_test_setup, sg_conf_name):
     verify_changes(dj_0, expected_num_docs=number_of_docs_per_pusher, expected_num_revisions=0, expected_docs=kdwb_docs)
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sync
 @pytest.mark.basicauth

--- a/testsuites/syncgateway/functional/tests/test_ttl.py
+++ b/testsuites/syncgateway/functional/tests/test_ttl.py
@@ -50,15 +50,14 @@ Test suite for Sync Gateway's expiry feature.
 """
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.ttl
 @pytest.mark.session
 @pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name", [
-    "sync_gateway_default_functional_tests",
-    "sync_gateway_default_functional_tests_no_port",
-    "sync_gateway_default_functional_tests_couchbase_protocol_withport_11210"
+    pytest.param("sync_gateway_default_functional_tests", marks=pytest.mark.sanity),
+    ("sync_gateway_default_functional_tests_no_port"),
+    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210")
 ])
 def test_numeric_expiry_as_ttl(params_from_base_test_setup, sg_conf_name):
     """

--- a/testsuites/syncgateway/functional/tests/test_user_views.py
+++ b/testsuites/syncgateway/functional/tests/test_user_views.py
@@ -23,7 +23,6 @@ from utilities.cluster_config_utils import persist_cluster_config_environment_pr
 @pytest.mark.attachments
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
     ("user_views/user_views", False),
-    ("user_views/user_views", True)
 ])
 def test_user_views_sanity(params_from_base_test_setup, sg_conf_name, x509_cert_auth):
 

--- a/testsuites/syncgateway/functional/tests/test_users_channels.py
+++ b/testsuites/syncgateway/functional/tests/test_users_channels.py
@@ -14,14 +14,13 @@ from requests import Session
 from keywords.utils import log_r
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.basicauth
 @pytest.mark.channel
 @pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
     ("sync_gateway_default_functional_tests", True),
-    ("sync_gateway_default_functional_tests_no_port", False),
+    pytest.param("sync_gateway_default_functional_tests_no_port", False, marks=pytest.mark.sanity),
     ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", False)
 ])
 def test_multiple_users_multiple_channels(params_from_base_test_setup, sg_conf_name, x509_cert_auth):

--- a/testsuites/syncgateway/functional/tests/test_views.py
+++ b/testsuites/syncgateway/functional/tests/test_views.py
@@ -13,12 +13,11 @@ from libraries.testkit.cluster import Cluster
 from utilities.cluster_config_utils import get_sg_version, persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.views
 @pytest.mark.session
 @pytest.mark.parametrize('sg_conf_name, validate_changes_before_restart, x509_cert_auth', [
-    ('sync_gateway_default_functional_tests', False, False),
+    pytest.param('sync_gateway_default_functional_tests', False, False, marks=pytest.mark.sanity),
     ('sync_gateway_default_functional_tests', True, True),
     ('sync_gateway_default_functional_tests_no_port', False, True),
     ('sync_gateway_default_functional_tests_no_port', True, False)

--- a/testsuites/syncgateway/functional/tests/test_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_webhooks.py
@@ -17,14 +17,13 @@ from keywords.constants import CLIENT_REQUEST_TIMEOUT
 from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
 @pytest.mark.webhooks
 @pytest.mark.basicauth
 @pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name, num_users, num_channels, num_docs, num_revisions, x509_cert_auth", [
-    ("webhooks/webhook_offline", 5, 1, 1, 2, True),
+    pytest.param("webhooks/webhook_offline", 5, 1, 1, 2, True, marks=pytest.mark.sanity),
     ("webhooks/webhook_offline", 5, 1, 1, 2, False)
 ])
 def test_webhooks(params_from_base_test_setup, sg_conf_name, num_users, num_channels, num_docs,

--- a/testsuites/syncgateway/functional/tests/test_xattrs.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs.py
@@ -317,7 +317,6 @@ def test_on_demand_doc_processing(params_from_base_test_setup, sg_conf_name, num
 @pytest.mark.xattrs
 @pytest.mark.session
 @pytest.mark.parametrize('sg_conf_name, x509_cert_auth', [
-    ('xattrs/no_import', True),
     ('xattrs/no_import', False)
 ])
 def test_on_demand_import_of_external_updates(params_from_base_test_setup, sg_conf_name, x509_cert_auth):
@@ -421,12 +420,11 @@ def test_on_demand_import_of_external_updates(params_from_base_test_setup, sg_co
     assert sg_updated_rev.startswith("3-")
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
 @pytest.mark.session
 @pytest.mark.parametrize('sg_conf_name, x509_cert_auth', [
-    ('sync_gateway_default_functional_tests', True),
+    pytest.param('sync_gateway_default_functional_tests', True, marks=pytest.mark.sanity),
     ('sync_gateway_default_functional_tests_no_port', False),
     ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", False)
 ])
@@ -691,7 +689,6 @@ def test_large_initial_import(params_from_base_test_setup, sg_conf_name):
     sg_client.verify_docs_in_changes(url=sg_url, db=sg_db, expected_docs=docs_to_verify_in_changes, auth=seth_auth)
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
 @pytest.mark.changes

--- a/testsuites/syncgateway/functional/tests/test_xattrs.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs.py
@@ -412,7 +412,7 @@ def test_on_demand_import_of_external_updates(params_from_base_test_setup, sg_co
     with pytest.raises(HTTPError) as he:
         sg_client.put_doc(url=sg_url, db=sg_db, doc_id=doc_id, rev=doc_rev_one, doc_body=doc_body, auth=seth_auth)
     log_info(he.value)
-    assert he.value.message.startswith('409')
+    assert str(he.value).startswith('409')
 
     # Following update_doc method will get the doc with on demand processing and update the doc based on rev got from get doc
     sg_updated_doc = sg_client.update_doc(url=sg_url, db=sg_db, doc_id=doc_id, auth=seth_auth)
@@ -1891,7 +1891,7 @@ def update_sg_docs(client, url, db, docs_to_update, prop_to_update, number_updat
 
 def is_conflict(httperror):
     if httperror.response.status_code == 409 \
-            and httperror.message.startswith('409 Client Error: Conflict for url:'):
+            and str(httperror).startswith('409 Client Error: Conflict for url:'):
         return True
     else:
         return False
@@ -2031,14 +2031,14 @@ def verify_sg_deletes(client, url, db, docs_to_verify_deleted, auth):
             client.get_doc(url=url, db=db, doc_id=doc_id, auth=auth)
 
         assert he is not None
-        log_info(he.value.message)
+        log_info(str(he.value))
 
-        assert he.value.message.startswith('404 Client Error: Not Found for url:') or \
-            he.value.message.startswith('403 Client Error: Forbidden for url:')
+        assert str(he.value).startswith('404 Client Error: Not Found for url:') or \
+            str(he.value).startswith('403 Client Error: Forbidden for url:')
 
         # Parse out the doc id
         # sg_0?conflicts=true&revs=true
-        parts = he.value.message.split('/')[-1]
+        parts = str(he.value).split('/')[-1]
         doc_id_from_parts = parts.split('?')[0]
 
         # Remove the doc id from the list

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/test_multiple_accels.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/test_multiple_accels.py
@@ -212,7 +212,6 @@ def test_dcp_reshard_single_sg_accel_goes_down_and_up(params_from_base_test_setu
 
 
 @pytest.mark.topospecific
-
 @pytest.mark.syncgateway
 @pytest.mark.sgaccel
 @pytest.mark.parametrize("sg_conf", [

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/test_multiple_accels.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/test_multiple_accels.py
@@ -85,7 +85,6 @@ def test_dcp_reshard_sync_gateway_goes_down(params_from_base_test_setup, sg_conf
 
 
 @pytest.mark.topospecific
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sgaccel
 @pytest.mark.basicauth
@@ -143,7 +142,6 @@ def test_dcp_reshard_sync_gateway_comes_up(params_from_base_test_setup, sg_conf)
 
 
 @pytest.mark.topospecific
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sgaccel
 @pytest.mark.basicauth
@@ -214,7 +212,7 @@ def test_dcp_reshard_single_sg_accel_goes_down_and_up(params_from_base_test_setu
 
 
 @pytest.mark.topospecific
-@pytest.mark.sanity
+
 @pytest.mark.syncgateway
 @pytest.mark.sgaccel
 @pytest.mark.parametrize("sg_conf", [
@@ -237,7 +235,6 @@ def test_pindex_distribution(params_from_base_test_setup, sg_conf):
 
 
 @pytest.mark.topospecific
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sgaccel
 @pytest.mark.basicauth
@@ -334,7 +331,6 @@ def test_take_down_bring_up_sg_accel_validate_cbgt(params_from_base_test_setup, 
 
 
 @pytest.mark.topospecific
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sgaccel
 @pytest.mark.session
@@ -476,7 +472,6 @@ def test_take_all_sgaccels_down(params_from_base_test_setup, sg_conf):
 
 
 @pytest.mark.topospecific
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sgaccel
 @pytest.mark.parametrize("sg_conf", [
@@ -515,7 +510,6 @@ def test_missing_num_shards(params_from_base_test_setup, sg_conf):
 # When the test was written, sync gateway should fail to start in this scenario. This behavior was removed in the
 # above commit and now sync gateway will start when in this state
 @pytest.mark.topospecific
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sgaccel
 @pytest.mark.basicauth

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/test_multiple_servers.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/test_multiple_servers.py
@@ -98,7 +98,6 @@ def test_rebalance_sanity(params_from_base_test_setup):
     cb_server.rebalance_in(cluster_servers, server_to_remove)
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.failover
@@ -222,7 +221,6 @@ def test_server_goes_down_sanity(params_from_base_test_setup):
     log_info("test_server_goes_down_sanity complete!")
 
 
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.failover

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_bucket_shadow.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_bucket_shadow.py
@@ -152,7 +152,6 @@ def test_bucket_shadow_low_revs_limit_repeated_deletes(params_from_base_test_set
 
 
 @pytest.mark.topospecific
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.bucketshadow
 @pytest.mark.channel

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_sg_replicate.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_sg_replicate.py
@@ -138,7 +138,6 @@ def test_sg_replicate_basic_test(params_from_base_test_setup):
 
 
 @pytest.mark.topospecific
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sgreplicate
 @pytest.mark.channel
@@ -195,7 +194,6 @@ def test_sg_replicate_basic_test_channels(params_from_base_test_setup):
 
 
 @pytest.mark.topospecific
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sgreplicate
 @pytest.mark.channel
@@ -309,7 +307,6 @@ def test_sg_replicate_continuous_replication(params_from_base_test_setup):
 
 
 @pytest.mark.topospecific
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sgreplicate
 def test_sg_replicate_non_existent_db(params_from_base_test_setup):
@@ -351,7 +348,6 @@ def test_sg_replicate_non_existent_db(params_from_base_test_setup):
 
 
 @pytest.mark.topospecific
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sgreplicate
 @pytest.mark.channel
@@ -417,7 +413,6 @@ def test_sg_replicate_push_async(params_from_base_test_setup, num_docs):
 
 
 @pytest.mark.topospecific
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sgreplicate
 @pytest.mark.channel
@@ -467,7 +462,6 @@ def test_stop_replication_via_replication_id(params_from_base_test_setup):
 
 
 @pytest.mark.topospecific
-@pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sgreplicate
 def test_replication_config(params_from_base_test_setup):


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- updated pytest and py on requirements.txt to get latest version and to get feature to tag the parameter as sanity 
- I also fixed some of the warnings which was showing at the end of the test to accomodate latest version of pytest and py
- cleaned up sanity tags. Too many sanity tests 
