### PR TITLE
set the loglevel to None for dotnet

### DIFF
--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.NetCore/Program.cs
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.NetCore/Program.cs
@@ -52,7 +52,7 @@ namespace Couchbase.Lite.Testing.NetCore
             Couchbase.Lite.Support.NetDesktop.Activate();
             Extend();
 
-            Database.Log.Console.Level = Logging.LogLevel.Debug;
+            Database.Log.Console.Level = Logging.LogLevel.None;
             Database.Log.Console.Domains = Logging.LogDomain.All;
             
             TestServer.FilePathResolver = (path, unzip) => path;

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.iOS/AppDelegate.cs
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.iOS/AppDelegate.cs
@@ -30,7 +30,7 @@ namespace Couchbase.Lite.Testing.iOS
             Window.MakeKeyAndVisible();
 
             Couchbase.Lite.Support.iOS.Activate();
-            Database.Log.Console.Level = Logging.LogLevel.Verbose;
+            Database.Log.Console.Level = Logging.LogLevel.None;
 
             TestServer.FilePathResolver = ResolvePath;
             var listener = new TestServer();


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- log file for system test is generating a huge file which is unnecessary as we can cbl logs. This will help in having small file for console


