### PR TITLE
Feature/java testserver daemon jar

### DIFF
--- a/CBLClient/Apps/CBLTestServer-Android/build.gradle
+++ b/CBLClient/Apps/CBLTestServer-Android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/CBLClient/Apps/CBLTestServer-Java-Desktop/build.gradle
+++ b/CBLClient/Apps/CBLTestServer-Java-Desktop/build.gradle
@@ -37,9 +37,6 @@ repositories {
     maven {
         url "https://oss.sonatype.org/content/repositories/snapshots"
     }
-    maven {
-        url "https://mvnrepository.com/artifact/commons-daemon/commons-daemon"
-    }
 }
 
 java {
@@ -56,8 +53,8 @@ java {
 }
 
 dependencies {
-    compile 'commons-daemon:commons-daemon:1.2.2'
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    implementation 'commons-daemon:commons-daemon:1.2.2'
+    implementation group: 'junit', name: 'junit', version: '4.12'
 
     implementation "com.couchbase.lite:couchbase-lite-java-ee:${COUCHBASE_LITE_JAVA_VERSION}"
     implementation 'com.google.code.gson:gson:2.8.5'

--- a/CBLClient/Apps/CBLTestServer-Java-Desktop/build.gradle
+++ b/CBLClient/Apps/CBLTestServer-Java-Desktop/build.gradle
@@ -54,7 +54,7 @@ java {
 
 dependencies {
     implementation 'commons-daemon:commons-daemon:1.2.2'
-    implementation group: 'junit', name: 'junit', version: '4.12'
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
 
     implementation "com.couchbase.lite:couchbase-lite-java-ee:${COUCHBASE_LITE_JAVA_VERSION}"
     implementation 'com.google.code.gson:gson:2.8.5'

--- a/CBLClient/Apps/CBLTestServer-Java-Desktop/build.gradle
+++ b/CBLClient/Apps/CBLTestServer-Java-Desktop/build.gradle
@@ -37,6 +37,9 @@ repositories {
     maven {
         url "https://oss.sonatype.org/content/repositories/snapshots"
     }
+    maven {
+        url "https://mvnrepository.com/artifact/commons-daemon/commons-daemon"
+    }
 }
 
 java {
@@ -53,6 +56,7 @@ java {
 }
 
 dependencies {
+    compile 'commons-daemon:commons-daemon:1.2.2'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 
     implementation "com.couchbase.lite:couchbase-lite-java-ee:${COUCHBASE_LITE_JAVA_VERSION}"

--- a/CBLClient/Apps/CBLTestServer-Java-Desktop/src/main/java/com/couchbase/mobiletestkit/javatestserver/TestServerMain.java
+++ b/CBLClient/Apps/CBLTestServer-Java-Desktop/src/main/java/com/couchbase/mobiletestkit/javatestserver/TestServerMain.java
@@ -1,5 +1,9 @@
 package com.couchbase.mobiletestkit.javatestserver;
 
+import org.apache.commons.daemon.Daemon;
+import org.apache.commons.daemon.DaemonContext;
+import org.apache.commons.daemon.DaemonInitException;
+
 import com.couchbase.mobiletestkit.javacommon.Context;
 import com.couchbase.mobiletestkit.javalistener.Server;
 import com.couchbase.mobiletestkit.javacommon.util.Log;
@@ -9,27 +13,45 @@ import org.nanohttpd.util.ServerRunner;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 
-public class TestServerMain {
+
+public class TestServerMain implements Daemon {
     private static final int PORT = 8080;
     private static final String TMP_DIR = System.getProperty("java.io.tmpdir");
     private static Context context;
 
     public static void main(String[] args) throws IOException {
+        String ip = context.getLocalIpAddress();  //here the context hands out an ip address of 0.0.0.0
+        Server.memory.setIpAddress(ip);
+        Log.i("JavaDesktop", "Launching a HTTP server at " + ip + ", port = " + PORT);
+
+        NanoHTTPD server = new Server(context, PORT);
+        ServerRunner.executeInstance(server);
+    }
+
+    @Override
+    public void init(DaemonContext dc) throws DaemonInitException, Exception {
         Log.init(new TestServerLogger());
         CouchbaseLite.init();
 
         File tempDir = new File(TMP_DIR, "TestServerTemp");
         context = new TestServerContext(tempDir);
         Server.setContext(context);
+    }
 
-        String ip = context.getLocalIpAddress();  //here the context hands out an ip address of 0.0.0.0
-        Server.memory.setIpAddress(ip);
-        Log.i("JavaDesktop", "Starting the server at " + ip + ", port = " + PORT);
+    @Override
+    public void start() throws Exception {
+        Log.i("JavaDesktop", "Starting TestServer application as a daemon service.");
+        main(null);
+    }
 
-        NanoHTTPD server = new Server(context, PORT);
+    @Override
+    public void stop() throws Exception {
+        Log.i("JavaDesktop", "Stopping TestServer daemon service.");
+    }
 
-        ServerRunner.executeInstance(server);
+    @Override
+    public void destroy() {
+        Log.i("JavaDesktop", "TestServer daemon service is destroyed.");
     }
 }

--- a/CBLClient/Apps/CBLTestServer-Java-Desktop/src/main/java/com/couchbase/mobiletestkit/javatestserver/TestServerMain.java
+++ b/CBLClient/Apps/CBLTestServer-Java-Desktop/src/main/java/com/couchbase/mobiletestkit/javatestserver/TestServerMain.java
@@ -46,11 +46,7 @@ public class TestServerMain implements Daemon {
      * @param args Arguments from prunsrv command line
      **/
     public static void windowsService(String args[]) {
-        String cmd = "start";
-        if (args.length > 0) {
-            cmd = args[0];
-        }
-
+        final String cmd = (args.length <= 0) ? "start" : args[0];
         if ("start".equals(cmd)) {
             if(testserverLauncherInstance == null){
                 testserverLauncherInstance = new TestServerMain();
@@ -72,8 +68,6 @@ public class TestServerMain implements Daemon {
     public void startServer(boolean asService) {
         NanoHTTPD server = null;
         try {
-
-
             File tempDir = new File(TMP_DIR, "TestServerTemp");
             context = new TestServerContext(tempDir);
             Server.setContext(context);
@@ -104,16 +98,25 @@ public class TestServerMain implements Daemon {
 
     private void waitForEnter() {
         System.out.println("Server started, Hit Enter to stop.\n");
+
         try {
             System.in.read();
-        } catch (Throwable th) { }
+        } catch (IOException ioe) {
+            System.err.println("waiting for entry key, but failed to get:\n" + ioe.toString());
+        }
     }
 
     private synchronized void waitForStopService() {
+        if(stopped){
+            stopped = false;
+            return;
+        }
         try {
+            // service will be running until stop() method gets called
+            // which will notify this wait function and set server to stop
             wait();
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            System.err.println("service got interrupted while waiting for notify call.");
         }
         stopped = false;
     }

--- a/CBLClient/Apps/CBLTestServer-Java-Desktop/src/main/java/com/couchbase/mobiletestkit/javatestserver/TestServerMain.java
+++ b/CBLClient/Apps/CBLTestServer-Java-Desktop/src/main/java/com/couchbase/mobiletestkit/javatestserver/TestServerMain.java
@@ -9,7 +9,6 @@ import com.couchbase.mobiletestkit.javalistener.Server;
 import com.couchbase.mobiletestkit.javacommon.util.Log;
 import com.couchbase.lite.CouchbaseLite;
 import org.nanohttpd.protocols.http.NanoHTTPD;
-import org.nanohttpd.util.ServerRunner;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,26 +17,76 @@ import java.io.IOException;
 public class TestServerMain implements Daemon {
     private static final int PORT = 8080;
     private static final String TMP_DIR = System.getProperty("java.io.tmpdir");
+    private static final String TAG = "TestServer-Java";
     private static Context context;
     private static boolean stopped = false;
+    private static TestServerMain testserverLauncherInstance = null;
 
+    /**
+     * Main method runs as non-service mode for debugging use
+     * @param args
+     * @throws IOException
+     */
     public static void main(String[] args) throws IOException {
-        //ServerRunner.executeInstance(server);
-        new TestServerMain().startServer(false);
+        if(testserverLauncherInstance == null){
+            testserverLauncherInstance = new TestServerMain();
+        }
+
+        testserverLauncherInstance.initCouchbaseLite();
+        Log.i(TAG, "Main");
+        testserverLauncherInstance.startServer(stopped);
+    }
+
+    /**
+     * Static methods called by prunsrv to start/stop
+     * the Windows service.  Pass the argument "start"
+     * to start the service, and pass "stop" to
+     * stop the service.
+     *
+     * @param args Arguments from prunsrv command line
+     **/
+    public static void windowsService(String args[]) {
+        String cmd = "start";
+        if (args.length > 0) {
+            cmd = args[0];
+        }
+
+        if ("start".equals(cmd)) {
+            if(testserverLauncherInstance == null){
+                testserverLauncherInstance = new TestServerMain();
+            }
+
+            testserverLauncherInstance.initCouchbaseLite();
+            testserverLauncherInstance.startServer(true);
+        }
+        else {
+            try{
+                testserverLauncherInstance.stop();
+            }
+            catch (Exception e){
+                e.printStackTrace();
+            }
+        }
     }
 
     public void startServer(boolean asService) {
         NanoHTTPD server = null;
         try {
+
+
+            File tempDir = new File(TMP_DIR, "TestServerTemp");
+            context = new TestServerContext(tempDir);
+            Server.setContext(context);
+
             String ip = context.getLocalIpAddress();  //here the context hands out an ip address of 0.0.0.0
             Server.memory.setIpAddress(ip);
 
             server = new Server(context, PORT);
             server.start(5000, false);
 
-            Log.i("JavaDesktop", "Launching a HTTP server at " + ip + ", port = " + PORT);
+            Log.i(TAG, "A HTTP server launched at " + ip + ", port = " + PORT);
         } catch (IOException var3) {
-            System.err.println("Couldn't start server:\n" + var3);
+            Log.e(TAG, "Couldn't start server:\n" + var3);
             System.exit(-1);
         }
 
@@ -49,7 +98,7 @@ public class TestServerMain implements Daemon {
 
         if (server != null) {
             server.stop();
-            System.out.println("Server stopped.\n");
+            Log.i(TAG, "The HTTP Server stopped.\n");
         }
     }
 
@@ -74,30 +123,33 @@ public class TestServerMain implements Daemon {
         notifyAll();
     }
 
-    @Override
-    public void init(DaemonContext dc) throws DaemonInitException, Exception {
+    private void initCouchbaseLite(){
         Log.init(new TestServerLogger());
         CouchbaseLite.init();
+        Log.i(TAG, "CouchbaseLite is initialized.");
+    }
 
-        File tempDir = new File(TMP_DIR, "TestServerTemp");
-        context = new TestServerContext(tempDir);
-        Server.setContext(context);
+    @Override
+    public void init(DaemonContext dc) throws DaemonInitException, Exception {
+        // Log object is not initialized yet, call System.out here
+        System.out.println("system.out TestServer service init is called.");
+        initCouchbaseLite();
     }
 
     @Override
     public void start() throws Exception {
-        Log.i("JavaDesktop", "Starting TestServer application as a daemon service.");
+        Log.i(TAG, "Starting TestServer application as a service.");
         startServer(true);
     }
 
     @Override
     public void stop() throws Exception {
-        Log.i("JavaDesktop", "Stopping TestServer daemon service.");
+        Log.i(TAG, "Stopping TestServer service.");
         notifyStopped();
     }
 
     @Override
     public void destroy() {
-        Log.i("JavaDesktop", "TestServer daemon service is destroyed.");
+        Log.i(TAG, "TestServer service is destroyed.");
     }
 }

--- a/CBLClient/Apps/CBLTestServer-Java-Desktop/src/main/java/com/couchbase/mobiletestkit/javatestserver/TestServerMain.java
+++ b/CBLClient/Apps/CBLTestServer-Java-Desktop/src/main/java/com/couchbase/mobiletestkit/javatestserver/TestServerMain.java
@@ -28,13 +28,13 @@ public class TestServerMain implements Daemon {
      * @throws IOException
      */
     public static void main(String[] args) throws IOException {
-        if(testserverLauncherInstance == null){
+        if (testserverLauncherInstance == null) {
             testserverLauncherInstance = new TestServerMain();
         }
 
         testserverLauncherInstance.initCouchbaseLite();
         Log.i(TAG, "Main");
-        testserverLauncherInstance.startServer(stopped);
+        testserverLauncherInstance.startServer(false);
     }
 
     /**
@@ -48,7 +48,7 @@ public class TestServerMain implements Daemon {
     public static void windowsService(String args[]) {
         final String cmd = (args.length <= 0) ? "start" : args[0];
         if ("start".equals(cmd)) {
-            if(testserverLauncherInstance == null){
+            if (testserverLauncherInstance == null) {
                 testserverLauncherInstance = new TestServerMain();
             }
 
@@ -56,7 +56,7 @@ public class TestServerMain implements Daemon {
             testserverLauncherInstance.startServer(true);
         }
         else {
-            try{
+            try {
                 testserverLauncherInstance.stop();
             }
             catch (Exception e){
@@ -107,7 +107,7 @@ public class TestServerMain implements Daemon {
     }
 
     private synchronized void waitForStopService() {
-        if(stopped){
+        if (stopped) {
             stopped = false;
             return;
         }

--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/DatabaseConfigurationRequestHandler.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/DatabaseConfigurationRequestHandler.java
@@ -2,6 +2,7 @@ package com.couchbase.mobiletestkit.javacommon.RequestHandler;
 
 
 import com.couchbase.mobiletestkit.javacommon.Args;
+import com.couchbase.mobiletestkit.javacommon.RequestHandlerDispatcher;
 import com.couchbase.mobiletestkit.javacommon.util.Log;
 import com.couchbase.lite.DatabaseConfiguration;
 import com.couchbase.lite.EncryptionKey;
@@ -10,12 +11,17 @@ public class DatabaseConfigurationRequestHandler {
     private static final String TAG = "DATABASE_CONFIG";
     public DatabaseConfiguration configure(Args args) {
         String directory = args.get("directory");
-        Log.i(TAG, "database_create name=" + directory);
+        Log.i(TAG, "DatabaseConfiguration_configure directory=" + directory);
         EncryptionKey encryptionKey;
         //ConflictResolver conflictResolver = args.get("conflictResolver");
         String password = args.get("password");
         DatabaseConfiguration config = new DatabaseConfiguration();
         if (directory != null) {
+            config.setDirectory(directory);
+        }
+        else{
+            directory = RequestHandlerDispatcher.context.getFilesDir().getAbsolutePath();
+            Log.i(TAG, "No directory is set, now point to " + directory);
             config.setDirectory(directory);
         }
         /*if (conflictResolver != null) {

--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/DatabaseConfigurationRequestHandler.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/DatabaseConfigurationRequestHandler.java
@@ -11,22 +11,16 @@ public class DatabaseConfigurationRequestHandler {
     private static final String TAG = "DATABASE_CONFIG";
     public DatabaseConfiguration configure(Args args) {
         String directory = args.get("directory");
-        Log.i(TAG, "DatabaseConfiguration_configure directory=" + directory);
-        EncryptionKey encryptionKey;
-        //ConflictResolver conflictResolver = args.get("conflictResolver");
-        String password = args.get("password");
-        DatabaseConfiguration config = new DatabaseConfiguration();
-        if (directory != null) {
-            config.setDirectory(directory);
-        }
-        else{
+        if(directory == null){
             directory = RequestHandlerDispatcher.context.getFilesDir().getAbsolutePath();
             Log.i(TAG, "No directory is set, now point to " + directory);
-            config.setDirectory(directory);
         }
-        /*if (conflictResolver != null) {
-            config.setConflictResolver(conflictResolver);
-        }*/
+        Log.i(TAG, "DatabaseConfiguration_configure directory=" + directory);
+        DatabaseConfiguration config = new DatabaseConfiguration();
+        config.setDirectory(directory);
+
+        EncryptionKey encryptionKey;
+        String password = args.get("password");
         if (password != null) {
             encryptionKey = new EncryptionKey(password);
             config.setEncryptionKey(encryptionKey);

--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/DatabaseConfigurationRequestHandler.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/DatabaseConfigurationRequestHandler.java
@@ -11,7 +11,7 @@ public class DatabaseConfigurationRequestHandler {
     private static final String TAG = "DATABASE_CONFIG";
     public DatabaseConfiguration configure(Args args) {
         String directory = args.get("directory");
-        if(directory == null){
+        if (directory == null) {
             directory = RequestHandlerDispatcher.context.getFilesDir().getAbsolutePath();
             Log.i(TAG, "No directory is set, now point to " + directory);
         }

--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/DatabaseRequestHandler.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/DatabaseRequestHandler.java
@@ -45,6 +45,11 @@ public class DatabaseRequestHandler {
         if (config == null) {
             config = new DatabaseConfiguration();
         }
+        String dbDir = config.getDirectory();
+        if(dbDir == null || dbDir.equals("/")){
+            config.setDirectory(RequestHandlerDispatcher.context.getFilesDir().getAbsolutePath());
+        }
+        Log.i(TAG, "database_create directory=" + config.getDirectory());
         return new Database(name, config);
     }
 

--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/DatabaseRequestHandler.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/DatabaseRequestHandler.java
@@ -46,7 +46,14 @@ public class DatabaseRequestHandler {
             config = new DatabaseConfiguration();
         }
         String dbDir = config.getDirectory();
-        if(dbDir == null || dbDir.equals("/")){
+        /*
+        dbDir is obtained from cblite database configuration
+        1. dbDir shouldn't be null unless a bad situation happen.
+        2. while TestServer app running as a daemon service,
+           cblite core sets dbDir "/", which will cause due permission issues.
+           set dbDir to wherever the application context points to
+        */
+        if (dbDir == null || dbDir.equals("/")) {
             config.setDirectory(RequestHandlerDispatcher.context.getFilesDir().getAbsolutePath());
         }
         Log.i(TAG, "database_create directory=" + config.getDirectory());


### PR DESCRIPTION
#### Fixes # CM-356 & CM-357 making java desktop app as daemon and windows service

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- this change reference Apache Commons Daemon APIs
- java desktop TestServer app is available as daemon (Linux/MacOSX), windows service, and standalone app (for debugging or run with java -jar command)

