### PR TITLE
add service install scripts for java desktop

### DIFF
--- a/CBLClient/Apps/CBLTestServer-Java-Desktop/build_java_desktop_testserver_app.sh
+++ b/CBLClient/Apps/CBLTestServer-Java-Desktop/build_java_desktop_testserver_app.sh
@@ -39,6 +39,10 @@ export PATH=$PATH:$JAVA_HOME
 echo ./gradlew clean -Dversion=${MAVEN_UPLOAD_VERSION} assemble
 ./gradlew clean -Dversion=${MAVEN_UPLOAD_VERSION} assemble
 
-TESTSERVER_JAR="./build/libs/CBLTestServer-Java-Desktop-${MAVEN_UPLOAD_VERSION}-${EDITION}.jar"
-cp -f ${TESTSERVER_JAR} ${ARTIFACTS_DIR}/CBLTestServer-Java-Desktop-${MAVEN_UPLOAD_VERSION}-${EDITION}.jar
+cp "./build/libs/CBLTestServer-Java-Desktop-${MAVEN_UPLOAD_VERSION}-${EDITION}.jar" "CBLTestServer-Java-Desktop-${MAVEN_UPLOAD_VERSION}-${EDITION}.jar"
+
+zip "CBLTestServer-Java-Desktop-${MAVEN_UPLOAD_VERSION}-${EDITION}.zip" "./CBLTestServer-Java-Desktop-${MAVEN_UPLOAD_VERSION}-${EDITION}.jar" daemon_manager.sh win_service_manager.bat
+
+TESTSERVER_ZIP="CBLTestServer-Java-Desktop-${MAVEN_UPLOAD_VERSION}-${EDITION}.zip"
+cp -f ${TESTSERVER_ZIP} ${ARTIFACTS_DIR}/CBLTestServer-Java-Desktop-${MAVEN_UPLOAD_VERSION}-${EDITION}.zip
 

--- a/CBLClient/Apps/CBLTestServer-Java-Desktop/daemon_manager.sh
+++ b/CBLClient/Apps/CBLTestServer-Java-Desktop/daemon_manager.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+SERVICE_STATUS=$1
+BINARY_LOCATION=$2
+OUTPUT_LOCATION=$3
+JAVA_HOME_LOCATION=$4
+JSVC_LOCATION=$5
+
+
+# Setup variables
+EXEC=${JSVC_LOCATION}
+JAVA_HOME=${JAVA_HOME_LOCATION}
+CLASS_PATH=${BINARY_LOCATION}
+CLASS=com.couchbase.mobiletestkit.javatestserver.TestServerMain
+USER=root
+PID=${OUTPUT_LOCATION}/testserver-java.pid
+LOG_OUT=${OUTPUT_LOCATION}/testserver-java.out
+LOG_ERR=${OUTPUT_LOCATION}/testserver-java.err
+
+do_exec()
+{
+    $EXEC -home "$JAVA_HOME" -cp $CLASS_PATH -user $USER -outfile $LOG_OUT -errfile $LOG_ERR -pidfile $PID $1 $CLASS
+}
+
+case "${SERVICE_STATUS}" in
+    start)
+        do_exec
+            ;;
+    stop)
+        do_exec "-stop"
+            ;;
+    restart)
+        if [ -f "$PID" ]; then
+            do_exec "-stop"
+            do_exec
+        else
+            echo "service not running, will do nothing"
+            exit 1
+        fi
+            ;;
+    *)
+            echo "usage: daemon {start|stop|restart}" >&2
+            exit 3
+            ;;
+esac

--- a/CBLClient/Apps/CBLTestServer-Java-Desktop/win_service_manager.bat
+++ b/CBLClient/Apps/CBLTestServer-Java-Desktop/win_service_manager.bat
@@ -1,0 +1,66 @@
+echo off
+REM this script is to install TestServer jar file as a Windows Service
+
+IF [%1]==[] (
+  set service_name=TestServerJava
+) ELSE (
+ set service_name=%1
+)
+echo service_name=%service_name%
+
+IF [%2]==[] (
+  set status=install
+) ELSE (
+  set status=%2
+)
+echo status=%status%
+
+REM install Windows Service requires the following parameters
+IF "%status%"=="install" (
+  IF [%3]==[] (
+    set location=C:\\Users\\Administrator\\Desktop\\TestServer\\TestServer-java-2.7.0-94
+  ) ELSE (
+    set location=%3
+  )
+  echo location=%location%
+
+  IF [%4]==[] (
+    set jar_name=CBLTestServer-Java-Desktop-2.7.0-94-enterprise.jar
+  ) ELSE (
+    set jar_name=%4
+  )
+  echo jar_name=%jar_name%
+
+  IF [%5]==[] (
+    set service_user=Administrator
+  ) ELSE (
+    set service_user=%5
+  )
+  echo service_user=%service_user%
+
+  IF [%6]==[] (
+    set service_pwd=Membase123
+  ) ELSE (
+    set service_pwd=%6
+  )
+  echo service_pwd=%service_pwd%
+)
+
+IF "%status%"=="install" (
+  REM install Windows Service, service can be found on Windows Service console listed by name
+  REM service is installed but not started automatically. 
+  echo %service_name%.exe //IS//%service_name% --Install=%location%\\%service_name%.exe --Description=%service_name% --Jvm=auto --Classpath=%location%\\%jar_name% --StartMode=jvm --StartClass=com.couchbase.mobiletestkit.javatestserver.TestServerMain --StartMethod=windowsService --StartParams=start --StopMode=jvm --StopClass=com.couchbase.mobiletestkit.javatestserver.TestServerMain --StopMethod=windowsService --StopParams=stop --LogPath=%location%\\logs --StdOutput=auto --StdError=auto --ServiceUser=.\%service_user% --ServicePassword=%service_pwd%
+  %service_name%.exe //IS//%service_name% --Install=%location%\\%service_name%.exe --Description=%service_name% --Jvm=auto --Classpath=%location%\\%jar_name% --StartMode=jvm --StartClass=com.couchbase.mobiletestkit.javatestserver.TestServerMain --StartMethod=windowsService --StartParams=start --StopMode=jvm --StopClass=com.couchbase.mobiletestkit.javatestserver.TestServerMain --StopMethod=windowsService --StopParams=stop --LogPath=%location%\\logs --StdOutput=auto --StdError=auto --ServiceUser=.\%service_user% --ServicePassword=%service_pwd%
+)
+IF "%status%"=="start" (
+  REM start Windows Service
+  %service_name%.exe //ES//%service_name%
+)
+IF "%status%"=="stop" (
+  REM stop Windows Service
+  %service_name%.exe //SS//%service_name%
+)
+IF "%status%"=="remove" (
+  REM remove Windows Service, if the service is running, it will stop & remove the service
+  %service_name%.exe //DS//%service_name%
+)


### PR DESCRIPTION
#### Add script to install java desktop app as daemon or windows service

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- added shell script for daemon service
- added batch script for windows service
- updated build script to wrap the 2 scripts files in TestServer build zip

