### PR TITLE
Fix/separate ios background app

### DIFF
--- a/keywords/TestServeriOS.py
+++ b/keywords/TestServeriOS.py
@@ -174,8 +174,11 @@ class TestServeriOS(TestServerBase):
 
         log_info("Installing: {}".format(self.app_path))
         # Launch the simulator and install the app
+        # output = subprocess.check_output([
+        #     "ios-sim", "--devicetypeid", self.device, "install", self.app_path, "--exit"
+        # ])
         output = subprocess.check_output([
-            "ios-sim", "--devicetypeid", self.device, "install", self.app_path, "--exit"
+             "ios-sim", "install", self.app_path, "--devicetypeid", self.device, "--exit"
         ])
 
         log_info(output)
@@ -274,8 +277,11 @@ class TestServeriOS(TestServerBase):
         # Without --exit, ios-sim blocks
         # With --exit, --log has no effect
         # subprocess.Popen didn't launch the app
+        # output = subprocess.check_output([
+        #    "ios-sim", "--devicetypeid", self.device, "launch", self.app_path, "--exit"
+        # ])
         output = subprocess.check_output([
-            "ios-sim", "--devicetypeid", self.device, "launch", self.app_path, "--exit"
+            "ios-sim", "launch", self.app_path, "--devicetypeid", self.device,  "--exit"
         ])
 
         self._wait_until_reachable(port=self.port)

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
@@ -1117,7 +1117,7 @@ def CBL_offline_test(params_from_base_test_setup, sg_conf_name, num_of_docs):
 @pytest.mark.listener
 @pytest.mark.syncgateway
 @pytest.mark.replication
-@pytest.mark.session
+@pytest.mark.backgroundapp
 @pytest.mark.parametrize("num_docs, need_attachments, replication_after_backgroundApp", [
     (1000, True, False),
     (1000, False, False),
@@ -1213,6 +1213,7 @@ def test_initial_pull_replication_background_apprun(params_from_base_test_setup,
 
 @pytest.mark.listener
 @pytest.mark.replication
+@pytest.mark.backgroundapp
 @pytest.mark.parametrize("num_docs, need_attachments, replication_after_backgroundApp", [
     (100, True, False),
     (10000, False, False),


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- isolated backgroud app tests
- fixed iOS-sim command which is failing with simulator

