### PR TITLE
replace clean up sync gateway with flush firewalls

### DIFF
--- a/libraries/provision/clean_cluster.py
+++ b/libraries/provision/clean_cluster.py
@@ -20,6 +20,15 @@ def clean_cluster(cluster_config):
         raise ProvisioningError("Failed to flush firewall")
 
 
+def clear_firewall_rules(cluster_config):
+    log_info("Flusing firewall before teardown: {}".format(cluster_config))
+
+    ansible_runner = AnsibleRunner(config=cluster_config)
+    status = ansible_runner.run_ansible_playbook("flush-firewall.yml")
+    if status != 0:
+        raise ProvisioningError("Failed to flush firewall")
+
+
 if __name__ == "__main__":
     usage = "usage: python clean_cluster.py"
 

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -12,7 +12,7 @@ from libraries.NetworkUtils import NetworkUtils
 from libraries.testkit import cluster
 from utilities.cluster_config_utils import persist_cluster_config_environment_prop, is_x509_auth
 from utilities.cluster_config_utils import get_load_balancer_ip
-from libraries.provision.clean_cluster import clean_cluster
+from libraries.provision.clean_cluster import clear_firewall_rules
 
 UNSUPPORTED_1_5_0_CC = {
     "test_db_offline_tap_loss_sanity[bucket_online_offline/bucket_online_offline_default_dcp-100]": {
@@ -367,7 +367,7 @@ def params_from_base_suite_setup(request):
     log_info("Tearing down 'params_from_base_suite_setup' ...")
 
     # clean up firewall rules if any ports blocked for server ssl testing
-    clean_cluster(cluster_config)
+    clear_firewall_rules(cluster_config)
     # Stop all sync_gateway and sg_accels as test finished
     c = cluster.Cluster(cluster_config)
     c.stop_sg_and_accel()


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- with x509 merge, it stops sync gateway, remove sgw and flush firewall, with that it is unnecessarily deleting sync gateway, it effects when we run locally with skip-provisioing. Fixed that to clean up only firewall rules and this will not clean up sgw. 


