### PR TITLE
add mad hatter version to release version list

### DIFF
--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -835,6 +835,7 @@ class CouchbaseServer:
         Return the base_url of the package download URL (everything except the filename)
         """
         released_versions = {
+            "6.5.0": "4960",
             "5.5.0": "2958",
             "5.1.0": "5552",
             "5.0.1": "5003",


### PR DESCRIPTION
#### Fixes #. add 6.5.0 couchbase server release version

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- add 6.5.0-4960 as couchbase server release version

