### PR TITLE
Fix/macos zip build

### DIFF
--- a/libraries/provision/ansible/playbooks/tasks/install-sg.yml
+++ b/libraries/provision/ansible/playbooks/tasks/install-sg.yml
@@ -12,7 +12,7 @@
 - name: SYNC GATEWAY | Install sync_gateway zip
   become: yes
   shell: |
-    unzip /tmp/{{ couchbase_sync_gateway_package }} --directory /opt
+    unzip /tmp/{{ couchbase_sync_gateway_package }} -d /opt
   when: ansible_distribution == "MacOSX"
 
 - include: stop-sync-gateway.yml

--- a/libraries/provision/ansible/playbooks/tasks/install-sg.yml
+++ b/libraries/provision/ansible/playbooks/tasks/install-sg.yml
@@ -9,10 +9,10 @@
   shell: dpkg -i /tmp/{{ couchbase_sync_gateway_package }}
   when: ansible_distribution == "Ubuntu" or ansible_distribution == "Debian"
 
-- name: SYNC GATEWAY | Install sync_gateway tar.gz
+- name: SYNC GATEWAY | Install sync_gateway zip
   become: yes
   shell: |
-    tar -zxvf /tmp/{{ couchbase_sync_gateway_package }} --directory /opt
+    unzip /tmp/{{ couchbase_sync_gateway_package }} --directory /opt
   when: ansible_distribution == "MacOSX"
 
 - include: stop-sync-gateway.yml

--- a/libraries/provision/install_sync_gateway.py
+++ b/libraries/provision/install_sync_gateway.py
@@ -73,7 +73,7 @@ class SyncGatewayConfig:
         elif "ubuntu" in sg_platform:
             sg_platform_extension = "deb"
         elif "macos" in sg_platform:
-            sg_platform_extension = "tar.gz"
+            sg_platform_extension = "zip"
 
         # Setting SG Accel platform extension
         if "windows" in sa_platform:
@@ -83,7 +83,7 @@ class SyncGatewayConfig:
         elif "ubuntu" in sa_platform:
             sa_platform_extension = "deb"
         elif "macos" in sa_platform:
-            sg_platform_extension = "tar.gz"
+            sg_platform_extension = "zip"
 
         if self._version_number == "1.1.0" or self._build_number == "1.1.1":
             log_info("Version unsupported in provisioning.")


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Build team replaced Macos build from tar.gz to zip file
- replaced in the framework to download, install and start with zip file

Ran jenkins job and it went though. I aborted the job as I wanted upgraded jobs to run. This job was able to install and start Macos and tests are running fine.
http://uberjenkins.sc.couchbase.com:8080/view/04%20sync-gateway/job/Macos-sync-gateway-functional-tests-base/59/