### PR TITLE
Fix/cm 278 use executor on java

### DIFF
--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/DatabaseRequestHandler.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/DatabaseRequestHandler.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import com.couchbase.mobiletestkit.javacommon.Args;
 import com.couchbase.mobiletestkit.javacommon.Context;
 import com.couchbase.mobiletestkit.javacommon.RequestHandlerDispatcher;
+import com.couchbase.mobiletestkit.javacommon.util.ConcurrentExecutor;
 import com.couchbase.mobiletestkit.javacommon.util.Log;
 import com.couchbase.mobiletestkit.javacommon.util.ZipUtils;
 import com.couchbase.lite.Blob;
@@ -300,11 +301,11 @@ public class DatabaseRequestHandler {
         if (args.contain("docId")) {
             String docId = args.get("docId");
             MyDocumentChangeListener changeListener = new MyDocumentChangeListener();
-            token = database.addDocumentChangeListener(docId, changeListener);
+            token = database.addDocumentChangeListener(docId, ConcurrentExecutor.EXECUTOR, changeListener);
         }
         else {
             MyDatabaseChangeListener changeListener = new MyDatabaseChangeListener();
-            token = database.addChangeListener(changeListener);
+            token = database.addChangeListener(ConcurrentExecutor.EXECUTOR, changeListener);
         }
         return token;
     }

--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/ReplicatorRequestHandler.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/ReplicatorRequestHandler.java
@@ -13,6 +13,7 @@ import com.couchbase.lite.Replicator;
 import com.couchbase.lite.ReplicatorChange;
 import com.couchbase.lite.ReplicatorChangeListener;
 import com.couchbase.lite.ReplicatorConfiguration;
+import com.couchbase.mobiletestkit.javacommon.util.ConcurrentExecutor;
 
 
 public class ReplicatorRequestHandler {
@@ -43,20 +44,20 @@ public class ReplicatorRequestHandler {
     public ReplicatorChangeListener addChangeListener(Args args) {
         Replicator replicator = args.get("replicator");
         MyReplicatorListener changeListener = new MyReplicatorListener();
-        replicator.addChangeListener(changeListener);
+        replicator.addChangeListener(ConcurrentExecutor.EXECUTOR, changeListener);
         return changeListener;
     }
 
     public void removeChangeListener(Args args) {
         Replicator replicator = args.get("replicator");
         MyReplicatorListener changeListener = args.get("changeListener");
-        replicator.addChangeListener(changeListener);
+        replicator.addChangeListener(ConcurrentExecutor.EXECUTOR, changeListener);
     }
 
     public MyDocumentReplicatorListener addReplicatorEventChangeListener(Args args) {
         Replicator replicator = args.get("replicator");
         MyDocumentReplicatorListener changeListener = new MyDocumentReplicatorListener();
-        ListenerToken token = replicator.addDocumentReplicationListener(changeListener);
+        ListenerToken token = replicator.addDocumentReplicationListener(ConcurrentExecutor.EXECUTOR, changeListener);
         changeListener.setToken(token);
         return changeListener;
     }

--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/util/ConcurrentExecutor.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/util/ConcurrentExecutor.java
@@ -1,0 +1,9 @@
+package com.couchbase.mobiletestkit.javacommon.util;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+
+public class ConcurrentExecutor {
+    public static final Executor EXECUTOR = Executors.newSingleThreadExecutor();
+}


### PR DESCRIPTION
#### Fixes #. use executor to improve testapp performance on android/java

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- LiteCore android/java provide executor signature on database & replicator object AddChangeListener and related functions. Implement executor in testserver app to improve performance.

