### PR TITLE
change download location to be align with dev/build changes

### DIFF
--- a/keywords/TestServerAndroid.py
+++ b/keywords/TestServerAndroid.py
@@ -18,12 +18,11 @@ class TestServerAndroid(TestServerBase):
         self.platform = platform
 
         if self.platform == "android":
+            self.download_source = "couchbase-lite-android"
             if community_enabled:
                 apk_name_prefix = "CBLTestServer-Android-{}-community".format(self.version_build)
-                self.download_source = "couchbase-lite-android"
             else:
                 apk_name_prefix = "CBLTestServer-Android-{}-enterprise".format(self.version_build)
-                self.download_source = "couchbase-lite-android-ee"
             if debug_mode:
                 self.apk_name = "{}-debug.apk".format(apk_name_prefix)
             else:


### PR DESCRIPTION
#### Fixes #. a quick fix for android testserver app output location update

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- now android ce and ee builds are merged into one united directory. 

