### PR TITLE
Fix/java get log in zip

### DIFF
--- a/CBLClient/Apps/CBLTestServer-Java-WS/src/main/java/com/couchbase/javaws/TestServerContext.java
+++ b/CBLClient/Apps/CBLTestServer-Java-WS/src/main/java/com/couchbase/javaws/TestServerContext.java
@@ -53,7 +53,7 @@ public class TestServerContext implements Context {
         in Tomcat structure, this points to %CATALINE_HOME%/temp/TestServerTemp/
         and a subdirectory with the value of filetype will be created under
          */
-        File externalFilesDir = new File(getFilesDir().getAbsoluteFile().getName(), filetype);
+        File externalFilesDir = new File(getFilesDir().getAbsoluteFile(), filetype);
         if(!externalFilesDir.exists()){
             try {
                 externalFilesDir.mkdir();

--- a/CBLClient/Apps/CBLTestServer-Java-WS/src/main/java/com/couchbase/javaws/TestServerWS.java
+++ b/CBLClient/Apps/CBLTestServer-Java-WS/src/main/java/com/couchbase/javaws/TestServerWS.java
@@ -96,19 +96,38 @@ public class TestServerWS extends HttpServlet {
         try{
             Object body = RequestHandlerDispatcher.handle(handlerType, method, args);
 
-            if (body != null) {
-                response.setStatus(HttpServletResponse.SC_OK);
-                response.setHeader("Content-Type", "text/plain");
-                response.getOutputStream().write(body.toString().getBytes());
-                response.getOutputStream().flush();
-                response.getOutputStream().close();
-            }
-            else {
+            if (body == null) {
                 response.setStatus(HttpServletResponse.SC_OK);
                 response.setHeader("Content-Type", "text/plain");
                 response.getWriter().write("I-1");
                 response.getWriter().flush();
                 response.getWriter().close();
+
+                return;
+            }
+
+            if (body instanceof String) {
+                response.setStatus(HttpServletResponse.SC_OK);
+                response.setHeader("Content-Type", "text/plain");
+                response.getOutputStream().write(body.toString().getBytes());
+                response.getOutputStream().flush();
+                response.getOutputStream().close();
+
+                return;
+            }
+            else if (body instanceof RawData) {
+                RawData dataObj = (RawData) body;
+
+                response.setStatus(HttpServletResponse.SC_OK);
+                response.setHeader("Content-Type", dataObj.contentType);
+                response.getOutputStream().write(dataObj.data);
+                response.getOutputStream().flush();
+                response.getOutputStream().close();
+
+                return;
+            }
+            else {
+                throw new IllegalArgumentException("unrecognized body type: " + body.getClass());
             }
         }catch (Exception e){
             Log.e(TAG, e.getMessage());

--- a/CBLClient/Apps/CBLTestServer-Java-WS/src/main/java/com/couchbase/javaws/TestServerWS.java
+++ b/CBLClient/Apps/CBLTestServer-Java-WS/src/main/java/com/couchbase/javaws/TestServerWS.java
@@ -11,7 +11,6 @@ import com.google.gson.GsonBuilder;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.util.EnumSet;
 import java.util.Map;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -130,10 +129,10 @@ public class TestServerWS extends HttpServlet {
                 throw new IllegalArgumentException("unrecognized body type: " + body.getClass());
             }
         }catch (Exception e){
-            Log.e(TAG, e.getMessage());
+            Log.w(TAG, "Request failed", e);
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             response.setHeader("Content-Type", "text/plain");
-            response.getWriter().println(e.getMessage());
+            response.getWriter().println(e.toString());
         }
     }
 

--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/LoggingRequestHandler.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/LoggingRequestHandler.java
@@ -25,7 +25,7 @@ public class LoggingRequestHandler {
 
         if (directory.isEmpty()) {
             long ts = System.currentTimeMillis() / 1000;
-            directory = RequestHandlerDispatcher.context.getFilesDir().getAbsolutePath() + "/logs_" + ts;
+            directory = RequestHandlerDispatcher.context.getFilesDir().getAbsolutePath() + File.separator + "logs_" + ts;
             Log.i(TAG, "File logging configured at: " + directory);
         }
         LogFileConfiguration config = new LogFileConfiguration(directory);
@@ -109,7 +109,7 @@ public class LoggingRequestHandler {
         String directory = args.get("directory");
         if (directory.isEmpty()) {
             long ts = System.currentTimeMillis() / 1000;
-            directory = RequestHandlerDispatcher.context.getFilesDir().getAbsolutePath() + "/logs_" + ts;
+            directory = RequestHandlerDispatcher.context.getFilesDir().getAbsolutePath() + File.separator + "logs_" + ts;
 
             Log.i(TAG, "File logging configured at: " + directory);
         }

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_database.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_database.py
@@ -117,6 +117,10 @@ def test_invalidEncryption(params_from_base_test_setup, password):
     if liteserv_platform == "ios":
         cbl_db1 = db.create(cbl_db_name, db_config_without_password)
         assert "file is not a database" in cbl_db1
+    elif liteserv_platform in ["javaws-macosx", "javaws-msft", "javaws-ubuntu", "javaws-centos"]:
+        with pytest.raises(Exception) as he:
+            db.create(cbl_db_name, db_config_without_password)
+        assert str(he.value).startswith('400 Client Error:  for url:')
     else:
         with pytest.raises(Exception) as he:
             db.create(cbl_db_name, db_config_without_password)
@@ -128,6 +132,11 @@ def test_invalidEncryption(params_from_base_test_setup, password):
         invalid_key_db_config = db_configure.setEncryptionKey(db_config, password=password)
         cbl_db2 = db.create(cbl_db_name, invalid_key_db_config)
         assert "file is not a database" in cbl_db2
+    elif liteserv_platform in ["javaws-macosx", "javaws-msft", "javaws-ubuntu", "javaws-centos"]:
+        with pytest.raises(Exception) as he:
+            invalid_key_db_config = db_configure.setEncryptionKey(db_config, password=password)
+            db.create(cbl_db_name, invalid_key_db_config)
+        assert str(he.value).startswith('400 Client Error:  for url:')
     else:
         with pytest.raises(Exception) as he:
             invalid_key_db_config = db_configure.setEncryptionKey(db_config, password=password)

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_database.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_database.py
@@ -185,6 +185,11 @@ def test_updateDBEncryptionKey(params_from_base_test_setup):
     if liteserv_platform == "ios":
         cbl_db1 = db.create(cbl_db_name, db_config)
         assert "file is not a database" in cbl_db1
+    elif liteserv_platform in ["javaws-macosx", "javaws-msft", "javaws-ubuntu", "javaws-centos"]:
+        with pytest.raises(Exception) as he:
+            db.create(cbl_db_name, db_config)
+
+        assert str(he.value).startswith('400 Client Error:  for url:')
     else:
         with pytest.raises(Exception) as he:
             db.create(cbl_db_name, db_config)
@@ -283,6 +288,10 @@ def test_removeDBEncryptionKey(params_from_base_test_setup):
     if liteserv_platform == "ios":
         cbl_db2 = db.create(cbl_db_name, db_config)
         assert "file is not a database" in cbl_db2
+    elif liteserv_platform in ["javaws-macosx", "javaws-msft", "javaws-ubuntu", "javaws-centos"]:
+        with pytest.raises(Exception) as he:
+            db.create(cbl_db_name, db_config)
+        assert str(he.value).startswith('400 Client Error:  for url:')
     else:
         with pytest.raises(Exception) as he:
             db.create(cbl_db_name, db_config)


### PR DESCRIPTION
#### Fixes #. fix response payload data type and corresponding test assertion string

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- corrected RawData type in testserver http response
- fixed testserver http exception format
- correct the assertion string to deal with java ws specific response.

