### PR TITLE
Fix/getnodes for oscertify

### DIFF
--- a/keywords/SyncGateway.py
+++ b/keywords/SyncGateway.py
@@ -567,6 +567,7 @@ class SyncGateway(object):
         )
         sg_conf = os.path.abspath(sg_config.config_path)
         sg_cert_path = os.path.abspath(SYNC_GATEWAY_CERT)
+        cbs_cert_path = os.path.join(os.getcwd(), "certs")
         couchbase_server_primary_node = add_cbs_to_sg_config_server_field(cluster_config)
         bucket_names = get_buckets_from_sync_gateway_config(sg_conf)
 
@@ -587,6 +588,7 @@ class SyncGateway(object):
             "cacertpath": "",
             "x509_auth": False,
             "sg_cert_path": sg_cert_path,
+            "x509_certs_dir": cbs_cert_path,
             "server_port": self.server_port,
             "server_scheme": self.server_scheme,
             "autoimport": "",
@@ -704,6 +706,7 @@ class SyncGateway(object):
         server_port = 8091
         server_scheme = "http"
         sg_cert_path = os.path.abspath(SYNC_GATEWAY_CERT)
+        cbs_cert_path = os.path.join(os.getcwd(), "certs")
         bucket_names = get_buckets_from_sync_gateway_config(sg_conf)
         version, build = version_and_build(sync_gateway_version)
 
@@ -719,6 +722,7 @@ class SyncGateway(object):
             "keypath": "",
             "cacertpath": "",
             "x509_auth": False,
+            "x509_certs_dir": cbs_cert_path,
             "sg_cert_path": sg_cert_path,
             "sync_gateway_config_filepath": sg_conf,
             "server_port": server_port,
@@ -762,7 +766,7 @@ class SyncGateway(object):
 
             if is_x509_auth(cluster_config):
                 playbook_vars[
-                    "certpath"] = '"certpath": "{}/certs/chain.pem",'.format(sg_home_directory)
+                    "certpath"] = '"certpath": "{}/certs "{}/certs/chain.pem",'.format(sg_home_directory)
                 playbook_vars[
                     "keypath"] = '"keypath": "{}/certs/pkey.key",'.format(sg_home_directory)
                 playbook_vars[

--- a/libraries/provision/ansible/playbooks/deploy-sync-gateway-config.yml
+++ b/libraries/provision/ansible/playbooks/deploy-sync-gateway-config.yml
@@ -17,7 +17,9 @@
     sslcert:
     sslkey:
     logging:
+    cacertpath:
     x509_auth:
+    x509_certs_dir:
 
   tasks:
   - include: tasks/stop-sync-gateway.yml

--- a/libraries/provision/ansible/playbooks/install-sync-gateway-package-macos.yml
+++ b/libraries/provision/ansible/playbooks/install-sync-gateway-package-macos.yml
@@ -73,20 +73,20 @@
   tasks:
   - include: tasks/install-sg.yml
 
-# Copy certs to /Users/sync_gateway dir
-  - name: Copying certs.zip to /Users/sync_gateway directory
-    shell: cp /tmp/certs.zip /Users/sync_gateway
-    when: x509_auth
+# # Copy certs to /Users/sync_gateway dir
+#   - name: Copying certs.zip to /Users/sync_gateway directory
+#     shell: cp /tmp/certs.zip /Users/sync_gateway
+#     when: x509_auth
 
 # Deleting cert directory if exist
   - name: Deleting /Users/sync_gateway/certs
     shell: rm -rf /Users/sync_gateway/certs/*
     when: x509_auth
 
-# unzip certs.zip
-  - name: Unzipping certs.zip
-    shell: unzip /Users/sync_gateway/certs.zip -d /Users/sync_gateway/certs
-    when: x509_auth
+# # unzip certs.zip
+#   - name: Unzipping certs.zip
+#     shell: unzip /Users/sync_gateway/certs.zip -d /Users/sync_gateway/certs
+#     when: x509_auth
 
 # Deploy non writer sync_gateway configs
 - hosts: sync_gateways
@@ -104,6 +104,8 @@
     keypath:
     username:
     password:
+    x509_auth:
+    x509_certs_dir:
 
   tasks:
   - include: tasks/deploy-sync-gateway-config-macos.yml

--- a/libraries/provision/ansible/playbooks/install-sync-gateway-package-macos.yml
+++ b/libraries/provision/ansible/playbooks/install-sync-gateway-package-macos.yml
@@ -73,20 +73,12 @@
   tasks:
   - include: tasks/install-sg.yml
 
-# # Copy certs to /Users/sync_gateway dir
-#   - name: Copying certs.zip to /Users/sync_gateway directory
-#     shell: cp /tmp/certs.zip /Users/sync_gateway
-#     when: x509_auth
 
 # Deleting cert directory if exist
   - name: Deleting /Users/sync_gateway/certs
     shell: rm -rf /Users/sync_gateway/certs/*
     when: x509_auth
 
-# # unzip certs.zip
-#   - name: Unzipping certs.zip
-#     shell: unzip /Users/sync_gateway/certs.zip -d /Users/sync_gateway/certs
-#     when: x509_auth
 
 # Deploy non writer sync_gateway configs
 - hosts: sync_gateways

--- a/libraries/provision/ansible/playbooks/install-sync-gateway-package-windows.yml
+++ b/libraries/provision/ansible/playbooks/install-sync-gateway-package-windows.yml
@@ -60,6 +60,9 @@
     # hack until mobile-testkit/issues/406 allows any sync gateway to be referenced
     sync_gateway_node: "{{ hostvars[groups.sync_gateways[0]].ansible_host }}"
     is_index_writer: "false"
+    cacertpath:
+    x509_auth:
+    x509_certs_dir:
   tasks:
   - include: tasks/deploy-sync-gateway-config-windows.yml
  

--- a/libraries/provision/ansible/playbooks/install-sync-gateway-package.yml
+++ b/libraries/provision/ansible/playbooks/install-sync-gateway-package.yml
@@ -78,21 +78,11 @@
   tasks:
   - include: tasks/install-sg.yml
 
-# # Copy certs to /home/sync_gateway dir
-#   - name: Copying certs.zip to /home/sync_gateway directory
-#     shell: cp /tmp/certs.zip /home/sync_gateway
-#     when: x509_auth
-
 # Deleting cert directory if exist
   - name: Deleting /home/sync_gateway/certs
     become: yes
     shell: rm -rf /home/sync_gateway/certs/*
     when: x509_auth
-
-# # unzip certs.zip
-#   - name: Unzipping certs.zip
-#     shell: unzip /home/sync_gateway/certs.zip -d /home/sync_gateway/certs
-#     when: x509_auth
 
 # Deploy non writer sync_gateway configs
 - hosts: sync_gateways

--- a/libraries/provision/ansible/playbooks/install-sync-gateway-package.yml
+++ b/libraries/provision/ansible/playbooks/install-sync-gateway-package.yml
@@ -78,20 +78,21 @@
   tasks:
   - include: tasks/install-sg.yml
 
-# Copy certs to /home/sync_gateway dir
-  - name: Copying certs.zip to /home/sync_gateway directory
-    shell: cp /tmp/certs.zip /home/sync_gateway
-    when: x509_auth
+# # Copy certs to /home/sync_gateway dir
+#   - name: Copying certs.zip to /home/sync_gateway directory
+#     shell: cp /tmp/certs.zip /home/sync_gateway
+#     when: x509_auth
 
 # Deleting cert directory if exist
   - name: Deleting /home/sync_gateway/certs
+    become: yes
     shell: rm -rf /home/sync_gateway/certs/*
     when: x509_auth
 
-# unzip certs.zip
-  - name: Unzipping certs.zip
-    shell: unzip /home/sync_gateway/certs.zip -d /home/sync_gateway/certs
-    when: x509_auth
+# # unzip certs.zip
+#   - name: Unzipping certs.zip
+#     shell: unzip /home/sync_gateway/certs.zip -d /home/sync_gateway/certs
+#     when: x509_auth
 
 # Deploy non writer sync_gateway configs
 - hosts: sync_gateways
@@ -109,6 +110,8 @@
     keypath:
     username:
     password:
+    x509_auth:
+    x509_certs_dir:
 
   tasks:
   - include: tasks/deploy-sync-gateway-config.yml

--- a/libraries/provision/ansible/playbooks/install-sync-gateway-source.yml
+++ b/libraries/provision/ansible/playbooks/install-sync-gateway-source.yml
@@ -119,6 +119,9 @@
     couchbase_server_primary_node: "{{ hostvars[groups.couchbase_servers[0]].ansible_host }}"
     sync_gateway_node: "{{ hostvars[groups.sync_gateways[0]].ansible_host }}"
     is_index_writer: "false"
+    cacertpath:
+    x509_auth:
+    x509_certs_dir:
   tasks:
   - include: tasks/deploy-sync-gateway-config.yml
   when: ansible_distribution == "CentOS" or ansible_distribution == "Ubuntu"

--- a/libraries/provision/ansible/playbooks/reset-hosts.yml
+++ b/libraries/provision/ansible/playbooks/reset-hosts.yml
@@ -1,0 +1,19 @@
+# Reset the hosts to the state which test requires
+- hosts: couchbase_servers
+
+  tasks:
+  - name: OS | Reset the clocks
+    become: yes
+    command: timedatectl set-ntp false | timedatectl set-ntp true
+    ignore_errors: True
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Ubuntu" or ansible_distribution == "Debian" or ansible_os_family == "Darwin"
+
+
+- hosts: sync_gateways
+
+  tasks:
+  - name: OS | Reset the clocks
+    become: yes
+    command: timedatectl set-ntp false | timedatectl set-ntp true
+    ignore_errors: True
+    when: ansible_os_family == "Darwin"

--- a/libraries/provision/ansible/playbooks/reset-sync-gateway.yml
+++ b/libraries/provision/ansible/playbooks/reset-sync-gateway.yml
@@ -35,6 +35,9 @@
     sslcert:
     sslkey:
     logging:
+    cacertpath:
+    x509_auth:
+    x509_certs_dir:
 
   tasks:
   - include: tasks/deploy-sync-gateway-config.yml
@@ -64,6 +67,9 @@
     sslcert:
     sslkey:
     logging:
+    cacertpath:
+    x509_auth:
+    x509_certs_dir:
 
   tasks:
   - include: tasks/deploy-sync-gateway-config.yml

--- a/libraries/provision/ansible/playbooks/start-sync-gateway.yml
+++ b/libraries/provision/ansible/playbooks/start-sync-gateway.yml
@@ -18,6 +18,7 @@
     logging:
     x509_auth:
     x509_certs_dir:
+    cacertpath:
 
   tasks:
   - include: tasks/deploy-sync-gateway-config.yml

--- a/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config-macos.yml
+++ b/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config-macos.yml
@@ -9,31 +9,6 @@
     path: /Users/sync_gateway/certs/
   become: yes
 
-# - name: Deleting /Users/sync_gateway/certs.zip
-#   file:
-#     state: absent
-#     path: /Users/sync_gateway/certs.zip
-#   become: yes
-#   when: x509_auth
-
-# # Copy certs to /Users/sync_gateway dir
-# - name: Copying certs.zip to /Users/sync_gateway directory
-#   copy:
-#     owner: sync_gateway
-#     src: /tmp/certs.zip
-#     dest: /Users/sync_gateway/
-#     remote_src: yes
-#     force: yes
-#   when: x509_auth
-#   become: yes
-
-
-# unzip certs.zip
-# - name: Unzipping certs.zip
-#  shell: unzip /Users/sync_gateway/certs.zip -d /Users/sync_gateway/certs
-#  when: x509_auth
-#  become: yes
-
 - name: SYNC GATEWAY | Check deployed config
   become: yes
   shell: cat /Users/sync_gateway/sync_gateway.json

--- a/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config-macos.yml
+++ b/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config-macos.yml
@@ -8,37 +8,31 @@
     state: absent
     path: /Users/sync_gateway/certs/
   become: yes
-  when: x509_auth
 
-- name: Deleting /Users/sync_gateway/certs.zip
-  file:
-    state: absent
-    path: /Users/sync_gateway/certs.zip
-  become: yes
-  when: x509_auth
+# - name: Deleting /Users/sync_gateway/certs.zip
+#   file:
+#     state: absent
+#     path: /Users/sync_gateway/certs.zip
+#   become: yes
+#   when: x509_auth
 
-# Copy certs to /Users/sync_gateway dir
-- name: Copying certs.zip to /Users/sync_gateway directory
-  copy:
-    owner: sync_gateway
-    src: /tmp/certs.zip
-    dest: /Users/sync_gateway/
-    remote_src: yes
-    force: yes
-  when: x509_auth
-  become: yes
+# # Copy certs to /Users/sync_gateway dir
+# - name: Copying certs.zip to /Users/sync_gateway directory
+#   copy:
+#     owner: sync_gateway
+#     src: /tmp/certs.zip
+#     dest: /Users/sync_gateway/
+#     remote_src: yes
+#     force: yes
+#   when: x509_auth
+#   become: yes
 
 
 # unzip certs.zip
-- name: Unzipping certs.zip
-  shell: unzip /Users/sync_gateway/certs.zip -d /Users/sync_gateway/certs
-  when: x509_auth
-  become: yes
-
-- name: SYNC GATEWAY | Change the mode permissions
-  become: yes
-  shell: chmod 777 /Users/sync_gateway/certs/*.*
-  when: x509_auth
+# - name: Unzipping certs.zip
+#  shell: unzip /Users/sync_gateway/certs.zip -d /Users/sync_gateway/certs
+#  when: x509_auth
+#  become: yes
 
 - name: SYNC GATEWAY | Check deployed config
   become: yes
@@ -57,3 +51,28 @@
   become: yes
   template: src="{{ sg_cert_path }}/sg_privkey.pem" dest=/Users/sync_gateway/sg_privkey.pem owner=sync_gateway group=sync_gateway mode=0644 force=true
   when: sslkey is defined
+
+- name: SYNC GATEWAY | Create certs directory on sync gateway home directory on Macos
+  become: yes
+  shell : mkdir /Users/sync_gateway/certs
+  when: x509_auth
+
+- name: SYNC GATEWAY | Deploying cert path for x509 on Macos
+  become: yes
+  template: src="{{ x509_certs_dir }}/chain.pem" dest=/Users/sync_gateway/certs/chain.pem owner=sync_gateway group=sync_gateway mode=0644 force=true
+  when: certpath is defined and x509_auth
+
+- name: SYNC GATEWAY | Deploying keypath for x509 on Macos
+  become: yes
+  template: src="{{ x509_certs_dir }}/pkey.key" dest=/Users/sync_gateway/certs/pkey.key owner=sync_gateway group=sync_gateway mode=0644 force=true
+  when: keypath is defined and x509_auth
+
+- name: SYNC GATEWAY | Deploying cacertpath for x509 on Macos
+  become: yes
+  template: src="{{ x509_certs_dir }}/ca.pem" dest=/Users/sync_gateway/certs/ca.pem owner=sync_gateway group=sync_gateway mode=0644 force=true
+  when: cacertpath is defined and x509_auth
+
+- name: SYNC GATEWAY | Change the mode permissions
+  become: yes
+  shell: chmod 777 /Users/sync_gateway/certs/*.*
+  when: x509_auth

--- a/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config-windows.yml
+++ b/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config-windows.yml
@@ -40,26 +40,45 @@
     state: absent
   when: x509_auth
 
-- name: Deleting C:\PROGRA~1\Couchbase\Sync Gateway\certs.zip
+# - name: Deleting C:\PROGRA~1\Couchbase\Sync Gateway\certs.zip
+#   win_file:
+#     path: C:\PROGRA~1\Couchbase\Sync Gateway\certs.zip
+#     state: absent
+#   when: x509_auth
+
+# # Copy certs to C:\PROGRA~1\Couchbase\Sync Gateway dir
+# - name: Copying certs.zip to C:\PROGRA~1\Couchbase\Sync Gateway directory
+#   win_copy:
+#     src: '/tmp/certs.zip'
+#     dest: 'C:\PROGRA~1\Couchbase\Sync Gateway\certs.zip'
+#   when: x509_auth
+
+# # unzip certs.zip
+# - name: Unzip package and remove certs.zip
+#   win_unzip:
+#     src: C:\PROGRA~1\Couchbase\Sync Gateway\certs.zip
+#     dest: C:\PROGRA~1\Couchbase\Sync Gateway\certs
+#     rm: true
+#   when: x509_auth
+
+- name: SYNC GATEWAY | Create certs directory on sync gateway home directory
   win_file:
-    path: C:\PROGRA~1\Couchbase\Sync Gateway\certs.zip
-    state: absent
+    path: C:\PROGRA~1\Couchbase\Sync Gateway\certs
+    state: directory
   when: x509_auth
 
-# Copy certs to C:\PROGRA~1\Couchbase\Sync Gateway dir
-- name: Copying certs.zip to C:\PROGRA~1\Couchbase\Sync Gateway directory
-  win_copy:
-    src: '/tmp/certs.zip'
-    dest: 'C:\PROGRA~1\Couchbase\Sync Gateway\certs.zip'
-  when: x509_auth
+- name: SYNC GATEWAY | Deploying cert path for x509
+  win_copy: src='{{ x509_certs_dir }}/chain.pem' dest='C:\PROGRA~1\Couchbase\Sync Gateway\certs\chain.pem' force=true
+  when: certpath is defined and x509_auth
 
-# unzip certs.zip
-- name: Unzip package and remove certs.zip
-  win_unzip:
-    src: C:\PROGRA~1\Couchbase\Sync Gateway\certs.zip
-    dest: C:\PROGRA~1\Couchbase\Sync Gateway\certs
-    rm: true
-  when: x509_auth
+- name: SYNC GATEWAY | Deploying keypath for x509
+  win_copy: src='{{ x509_certs_dir }}/pkey.key' dest='C:\PROGRA~1\Couchbase\Sync Gateway\certs\pkey.key' force=true
+  when: keypath is defined and x509_auth
+
+- name: SYNC GATEWAY | Deploying cacertpath for x509
+  win_copy: src='{{ x509_certs_dir }}/ca.pem' dest='C:\PROGRA~1\Couchbase\Sync Gateway\certs\ca.pem' force=true
+  when: cacertpath is defined and x509_auth
+
 
 - name: give full permissions to certs directory
   win_shell: icacls "C:\PROGRA~1\Couchbase\Sync Gateway\certs" /grant Everyone:F

--- a/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config-windows.yml
+++ b/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config-windows.yml
@@ -40,27 +40,6 @@
     state: absent
   when: x509_auth
 
-# - name: Deleting C:\PROGRA~1\Couchbase\Sync Gateway\certs.zip
-#   win_file:
-#     path: C:\PROGRA~1\Couchbase\Sync Gateway\certs.zip
-#     state: absent
-#   when: x509_auth
-
-# # Copy certs to C:\PROGRA~1\Couchbase\Sync Gateway dir
-# - name: Copying certs.zip to C:\PROGRA~1\Couchbase\Sync Gateway directory
-#   win_copy:
-#     src: '/tmp/certs.zip'
-#     dest: 'C:\PROGRA~1\Couchbase\Sync Gateway\certs.zip'
-#   when: x509_auth
-
-# # unzip certs.zip
-# - name: Unzip package and remove certs.zip
-#   win_unzip:
-#     src: C:\PROGRA~1\Couchbase\Sync Gateway\certs.zip
-#     dest: C:\PROGRA~1\Couchbase\Sync Gateway\certs
-#     rm: true
-#   when: x509_auth
-
 - name: SYNC GATEWAY | Create certs directory on sync gateway home directory
   win_file:
     path: C:\PROGRA~1\Couchbase\Sync Gateway\certs

--- a/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config.yml
+++ b/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config.yml
@@ -10,31 +10,6 @@
   become: yes
   when: x509_auth
 
-# - name: Deleting /home/sync_gateway/certs.zip
-#   file:
-#     state: absent
-#     path: /home/sync_gateway/certs.zip
-#   become: yes
-#   when: x509_auth
-
-# # Copy certs to /home/sync_gateway dir
-# - name: Copying certs.zip to /home/sync_gateway directory
-#   copy:
-#     owner: sync_gateway
-#     src: /tmp/certs.zip
-#     dest: /home/sync_gateway/
-#     remote_src: yes
-#     force: yes
-#   when: x509_auth
-#   become: yes
-
-
-# # unzip certs.zip
-# - name: Unzipping certs.zip
-#   shell: unzip /home/sync_gateway/certs.zip -d /home/sync_gateway/certs
-#   when: x509_auth
-#   become: yes
-
 - name: SYNC GATEWAY | Create certs directory on sync gateway home directory
   become: yes
   shell : mkdir /home/sync_gateway/certs

--- a/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config.yml
+++ b/libraries/provision/ansible/playbooks/tasks/deploy-sync-gateway-config.yml
@@ -10,35 +10,55 @@
   become: yes
   when: x509_auth
 
-- name: Deleting /home/sync_gateway/certs.zip
-  file:
-    state: absent
-    path: /home/sync_gateway/certs.zip
+# - name: Deleting /home/sync_gateway/certs.zip
+#   file:
+#     state: absent
+#     path: /home/sync_gateway/certs.zip
+#   become: yes
+#   when: x509_auth
+
+# # Copy certs to /home/sync_gateway dir
+# - name: Copying certs.zip to /home/sync_gateway directory
+#   copy:
+#     owner: sync_gateway
+#     src: /tmp/certs.zip
+#     dest: /home/sync_gateway/
+#     remote_src: yes
+#     force: yes
+#   when: x509_auth
+#   become: yes
+
+
+# # unzip certs.zip
+# - name: Unzipping certs.zip
+#   shell: unzip /home/sync_gateway/certs.zip -d /home/sync_gateway/certs
+#   when: x509_auth
+#   become: yes
+
+- name: SYNC GATEWAY | Create certs directory on sync gateway home directory
   become: yes
+  shell : mkdir /home/sync_gateway/certs
   when: x509_auth
 
-# Copy certs to /home/sync_gateway dir
-- name: Copying certs.zip to /home/sync_gateway directory
-  copy:
-    owner: sync_gateway
-    src: /tmp/certs.zip
-    dest: /home/sync_gateway/
-    remote_src: yes
-    force: yes
-  when: x509_auth
+- name: SYNC GATEWAY | Deploying cert path for x509
   become: yes
+  template: src="{{ x509_certs_dir }}/chain.pem" dest=/home/sync_gateway/certs/chain.pem owner=sync_gateway group=sync_gateway mode=0644 force=true
+  when: certpath is defined and x509_auth
 
-
-# unzip certs.zip
-- name: Unzipping certs.zip
-  shell: unzip /home/sync_gateway/certs.zip -d /home/sync_gateway/certs
-  when: x509_auth
+- name: SYNC GATEWAY | Deploying keypath for x509
   become: yes
+  template: src="{{ x509_certs_dir }}/pkey.key" dest=/home/sync_gateway/certs/pkey.key owner=sync_gateway group=sync_gateway mode=0644 force=true
+  when: keypath is defined and x509_auth
+
+- name: SYNC GATEWAY | Deploying cacertpath for x509
+  become: yes
+  template: src="{{ x509_certs_dir }}/ca.pem" dest=/home/sync_gateway/certs/ca.pem owner=sync_gateway group=sync_gateway mode=0644 force=true
+  when: cacertpath is defined and x509_auth
 
 - name: SYNC GATEWAY | Change the mode permissions on Centos
   become: yes
   shell: chmod 777 /home/sync_gateway/certs/*.*
-  when: x509_auth
+  when: x509_auth 
 
 - name: SYNC GATEWAY | Check deployed config
   become: yes

--- a/libraries/provision/ansible/playbooks/tasks/stop-sync-gateway.yml
+++ b/libraries/provision/ansible/playbooks/tasks/stop-sync-gateway.yml
@@ -2,7 +2,7 @@
 
 - name: SYNC GATEWAY | Stop sync_gateway service
   service: name=sync_gateway state=stopped
-  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version >= "7") or (ansible_distribution == "Amazon") or (ansible_distribution == "Ubuntu") or (ansible_distribution == "RedHat")
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version >= "7") or (ansible_distribution == "Amazon") or (ansible_distribution == "Ubuntu") or (ansible_distribution == "RedHat") or (ansible_distribution == "Debian")
 
 - name: SYNC GATEWAY | Stop sync_gateway for CentOS 6
   shell: /sbin/initctl stop sync_gateway

--- a/libraries/provision/ansible/playbooks/upgrade-sg-sgaccel-package.yml
+++ b/libraries/provision/ansible/playbooks/upgrade-sg-sgaccel-package.yml
@@ -48,6 +48,9 @@
     is_index_writer: "false"
     sslcert:
     sslkey:
+    x509_auth:
+    x509_certs_dir:
+    cacertpath:
 
   tasks:
   - include: tasks/deploy-sync-gateway-config.yml

--- a/libraries/provision/clean_cluster.py
+++ b/libraries/provision/clean_cluster.py
@@ -19,6 +19,11 @@ def clean_cluster(cluster_config):
     if status != 0:
         raise ProvisioningError("Failed to flush firewall")
 
+    # Reset to ntp time . Required for x509 tests to clock sync for couchbase server and sync gateway
+    status = ansible_runner.run_ansible_playbook("reset-hosts.yml")
+    if status != 0:
+        raise ProvisioningError("Failed to reset hosts")
+
 
 def clear_firewall_rules(cluster_config):
     log_info("Flusing firewall before teardown: {}".format(cluster_config))

--- a/utilities/cluster_config_utils.py
+++ b/utilities/cluster_config_utils.py
@@ -103,20 +103,20 @@ def generate_x509_certs(cluster_config, bucket_name, sg_platform):
     stdout, stderr = proc.communicate()
     print(stdout, stderr)
 
-    # zipping the certificates
+    # # zipping the certificates
     os.chdir(curr_dir)
-    make_archive("certs", "zip", certs_dir)
+    # make_archive("certs", "zip", certs_dir)
 
-    for node in cluster["sync_gateways"]:
-        if sg_platform.lower() != "macos" and sg_platform.lower() != "windows":
-            cmd = ["scp", "certs.zip", "{}@{}:/tmp".format(username, node["ip"])]
-        else:
-            cmd = ["cp", "certs.zip", "/tmp"]
-        print(" ".join(cmd))
-        proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
-        stdout, stderr = proc.communicate()
-        if stdout or stderr:
-            print(stdout, stderr)
+    # for node in cluster["sync_gateways"]:
+    #     if sg_platform.lower() != "macos" and sg_platform.lower() != "windows":
+    #         cmd = ["scp", "certs.zip", "{}@{}:/tmp".format(username, node["ip"])]
+    #     else:
+    #         cmd = ["cp", "certs.zip", "/tmp"]
+    #     print(" ".join(cmd))
+    #     proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
+    #     stdout, stderr = proc.communicate()
+    #     if stdout or stderr:
+    #         print(stdout, stderr)
 
 
 def load_cluster_config_json(cluster_config):

--- a/utilities/cluster_config_utils.py
+++ b/utilities/cluster_config_utils.py
@@ -4,7 +4,7 @@ import os
 import re
 
 from keywords.exceptions import ProvisioningError
-from shutil import copyfile, rmtree, make_archive
+from shutil import copyfile, rmtree
 from subprocess import Popen, PIPE
 from distutils.dir_util import copy_tree
 
@@ -82,7 +82,7 @@ def generate_x509_certs(cluster_config, bucket_name, sg_platform):
             if match:
                 username = match.groups()[0].strip()
                 break
-
+    print(username)
     curr_dir = os.getcwd()
     certs_dir = os.path.join(curr_dir, "certs")
     if os.path.exists(certs_dir):
@@ -103,20 +103,7 @@ def generate_x509_certs(cluster_config, bucket_name, sg_platform):
     stdout, stderr = proc.communicate()
     print(stdout, stderr)
 
-    # # zipping the certificates
     os.chdir(curr_dir)
-    # make_archive("certs", "zip", certs_dir)
-
-    # for node in cluster["sync_gateways"]:
-    #     if sg_platform.lower() != "macos" and sg_platform.lower() != "windows":
-    #         cmd = ["scp", "certs.zip", "{}@{}:/tmp".format(username, node["ip"])]
-    #     else:
-    #         cmd = ["cp", "certs.zip", "/tmp"]
-    #     print(" ".join(cmd))
-    #     proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
-    #     stdout, stderr = proc.communicate()
-    #     if stdout or stderr:
-    #         print(stdout, stderr)
 
 
 def load_cluster_config_json(cluster_config):

--- a/utilities/mobile_server_pool.py
+++ b/utilities/mobile_server_pool.py
@@ -170,7 +170,7 @@ def cleanup_for_blocked_nodes(job_name=None):
         job_name = length_array[0]
         build_id = length_array[1]
         log_info("Releasing node {} for job {}".format(doc_id, job_id))
-        if job_name is not None or not is_jenkins_job_running(job_name, build_id) :
+        if job_name is not None or not is_jenkins_job_running(job_name, build_id):
             doc["prevUser"] = doc["username"]
             doc["username"] = ""
             doc["state"] = "available"
@@ -265,7 +265,7 @@ if __name__ == "__main__":
     (opts, args) = parser.parse_args(arg_parameters)
     if opts.cleanup_nodes and opts.reserve_nodes and opts.release_nodes and opts.get_available_nodes:
         raise Exception("Use either one the flag from --cleanup_nodes or --release-nodes or --reserve-nodes or --get-available-nodes")
-    
+
     elif opts.get_available_nodes:
         get_nodes_available_from_mobile_pool(opts.nodes_os_type, opts.nodes_os_version)
 
@@ -292,7 +292,7 @@ if __name__ == "__main__":
                 pool_json_str += '"ip_to_node_type": {'
                 for node in node_list:
                     pool_json_str += '"{}": "couchbase_servers", '.format(node)
-            
+
                 for sgw_node in sgw_node_list:
                     pool_json_str += '"{}": "sync_gateways", '.format(sgw_node)
                 if opts.load_balancer_nodes:

--- a/utilities/mobile_server_pool.py
+++ b/utilities/mobile_server_pool.py
@@ -61,10 +61,9 @@ def get_nodes_from_pool_server(num_of_nodes, nodes_os_type, node_os_version, job
                 "and state='available'".format(doc_id)
             query = N1QLQuery(query_str)
             sdk_client.n1ql_query(query)
-        if is_node_reserved:
+        if is_node_reserved and vm_alive:
             pool_list.append(str(doc_id))
-        else:
-            continue
+
         if len(pool_list) == int(num_of_nodes):
             return pool_list
 

--- a/utilities/mobile_server_pool.py
+++ b/utilities/mobile_server_pool.py
@@ -195,6 +195,14 @@ if __name__ == "__main__":
     parser.add_option("--pool-list",
                       action="store", dest="pool_list",
                       help="Pass the list of ips to be release back to QE-mobile-pool.")
+
+    parser.add_option("--sgw-nodes",
+                      action="store", dest="sgw_nodes", default=None,
+                      help="Pass the list of sgw ips to label on pool.json.")
+
+    parser.add_option("--loadbalancer-nodes",
+                      action="store", dest="load_balancer_nodes", default=None,
+                      help="Pass the list of load balancer ips to  label on pool.json")
     arg_parameters = sys.argv[1:]
 
     (opts, args) = parser.parse_args(arg_parameters)
@@ -210,8 +218,31 @@ if __name__ == "__main__":
             pool_json_str = '{ "ips": ['
             for node in node_list:
                 pool_json_str += '"{}", '.format(node)
+            if opts.sgw_nodes:
+                sgw_node_list = opts.sgw_nodes.strip().split(',')
+                for node in sgw_node_list:
+                    pool_json_str += '"{}", '.format(node)
+            if opts.load_balancer_nodes:
+                lp_node_list = opts.load_balancer_nodes.strip().split(',')
+                for node in lp_node_list:
+                    pool_json_str += '"{}", '.format(node)
             pool_json_str = pool_json_str.rstrip(', ')
-            pool_json_str += "] }"
+            pool_json_str += "],"
+            if opts.sgw_nodes:
+                pool_json_str += '"ip_to_node_type": {'
+                for node in node_list:
+                    pool_json_str += '"{}": "couchbase_servers", '.format(node)
+            
+                for sgw_node in sgw_node_list:
+                    print("sgw nodes is : ", sgw_node)
+                    pool_json_str += '"{}": "sync_gateways", '.format(sgw_node)
+                if opts.load_balancer_nodes:
+                    for lp_node in lp_node_list:
+                        pool_json_str += '"{}": "load_balancers", '.format(lp_node)
+                pool_json_str = pool_json_str.rstrip(', ')
+                pool_json_str += "},"
+            pool_json_str = pool_json_str.rstrip(', ')
+            pool_json_str += "}"
             fh.write(pool_json_str)
     elif opts.release_nodes:
         try:

--- a/utilities/mobile_server_pool.py
+++ b/utilities/mobile_server_pool.py
@@ -101,12 +101,10 @@ def cleanup_for_blocked_nodes(job_name=None):
     Go through QE-mobile-pool bucket and release unused block nodes
     :return: void
     """
-    # query_str = "select meta().id from `{}`".format(BUCKET_NAME)
     if job_name is not None:
         query_str = "select meta().id from `{}` where state=\"booked\" and username=\"{}\"".format(BUCKET_NAME, job_name)
     else:
         query_str = "select meta().id from `{}` where state=\"booked\"".format(BUCKET_NAME)
-    print("query string is ----", query_str)
     query = N1QLQuery(query_str)
     release_node_list = []
     for row in sdk_client.n1ql_query(query):
@@ -125,7 +123,7 @@ def cleanup_for_blocked_nodes(job_name=None):
         job_name = length_array[0]
         build_id = length_array[1]
         log_info("Releasing node {} for job {}".format(doc_id, job_id))
-        if not is_jenkins_job_running(job_name, build_id):
+        if job_name is not None or not is_jenkins_job_running(job_name, build_id) :
             doc["prevUser"] = doc["username"]
             doc["username"] = ""
             doc["state"] = "available"


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- added support to share vms for os certification with server team
- avoided the dependency of unzip package and added support to sync the clocks of server and sync gateway
- added project 100 feature on mobile pool script to check the sshability of the nodes 


Due to frame work changes:  ran differrent set of sqw jobs:
Test failures are comparable with the branch without these changes and they are expected. 

SGW functional tests : http://uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-functional-tests-xattrs-userViews-ServerSsl/79/testReport/
upgrade job :  http://uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-upgrade/30/testReport/
upgrade test server job :  http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-upgrade-centos-testserver/488/testReport/
Windows sgw tests : http://uberjenkins.sc.couchbase.com:8080/job/win10-sync-gateway-functional-tests-base-cc/512/testReport/
Macos SGW tests : http://uberjenkins.sc.couchbase.com:8080/view/os-certifications/job/Macos-sync-gateway-functional-tests-base/67/testReport/
shared centos 8 VM for SGW : http://uberjenkins.sc.couchbase.com:8080/view/os-certifications/job/cen8-sync-gateway-functional-tests/45/testReport/
shared ubuntu 18 vm for SGW : http://uberjenkins.sc.couchbase.com:8080/view/os-certifications/job/ubuntu18-sync-gateway-functional-tests/10/testReport/