### PR TITLE
fix the encoding issue for query jobs on windows

### DIFF
--- a/CBLClient/Apps/JavaRequestListener/src/main/java/com/couchbase/mobiletestkit/javalistener/Server.java
+++ b/CBLClient/Apps/JavaRequestListener/src/main/java/com/couchbase/mobiletestkit/javalistener/Server.java
@@ -133,7 +133,7 @@ public class Server extends NanoHTTPD {
 			}                
             else {
 				if (body instanceof String) {
-                    return Response.newFixedLengthResponse(Status.OK, "text/plain", ((String) body).getBytes());
+                    return Response.newFixedLengthResponse(Status.OK, "text/plain", ((String) body).getBytes("UTF-8"));
                 }
 				else if (body instanceof RawData) {
                     RawData dataObj = (RawData) body;


### PR DESCRIPTION
#### Fixes #. fix an encoding issue on windows platform

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Windows JVM does not set UTF-8 as default, we need to set encoders in order to receive results cross platform

