### PR TITLE
modified the rBAC role for sync gateway on 6.6

### DIFF
--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -231,7 +231,7 @@ class CouchbaseServer:
             roles = "mobile_sync_gateway[{}]".format(bucketname)
         else:
             roles = "ro_admin,bucket_full_access[{}]".format(bucketname)
-        
+
         if is_x509_auth(cluster_config):
             roles = "admin"
         password = 'password'

--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -2,7 +2,7 @@ import time
 import json
 import requests
 import re
-from requests.exceptions import ConnectionError, HTTPError
+from requests.exceptions import ConnectionError, HTTPError, ChunkedEncodingError
 from requests import Session
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from libraries.provision.ansible_runner import AnsibleRunner
@@ -293,6 +293,8 @@ class CouchbaseServer:
             except ConnectionError as e:
                 log_info(str(e))
                 log_info("RBAC user does not exist, Catching connection errors here")
+            except ChunkedEncodingError as che:
+                log_info(str(che))
             count += 1
 
     def _get_mem_total_lowest(self, server_info):

--- a/keywords/exceptions.py
+++ b/keywords/exceptions.py
@@ -68,3 +68,7 @@ class FeatureSupportedError(Error):
 
 class ConnectionError(Error):
     pass
+
+
+class ChunkedEncodingError(Error):
+    pass

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_bucket_shadow.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_bucket_shadow.py
@@ -25,8 +25,7 @@ ShadowCluster = namedtuple(
         'admin',
         'alice_shadower',
         'bob_non_shadower',
-    ],
-    verbose=False)
+    ])
 
 
 def init_shadow_cluster(cluster, config_path_shadower, config_path_non_shadower):


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- New rbac role added in 6.6.. started using new rbac role for sync gateway 
- Removed read only admin and application access as new role 'sync gateway'

http://uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-functional-tests-xattrs-noConflicts-serverSsl/50/testReport/