### PR TITLE
Fix/sgw tagging

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -52,3 +52,5 @@ markers =
     logredaction:  test that covers log redaction on Sync gateway
     noconflicts:   test that covers no conflicts scenarios
     views:          test that covers view i.e non GSI scenarios
+    oscertify:     test that covers for os certification
+    basicsgw:      test that covers all basic functionality on SGW

--- a/testsuites/syncgateway/functional/tests/test_attachments.py
+++ b/testsuites/syncgateway/functional/tests/test_attachments.py
@@ -18,7 +18,8 @@ from utilities.cluster_config_utils import is_ipv6
 @pytest.mark.syncgateway
 @pytest.mark.attachments
 @pytest.mark.basicauth
-@pytest.mark.channel
+@pytest.mark.basicsgw
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", [
     "sync_gateway_default"
 ])
@@ -100,7 +101,8 @@ def test_attachment_revpos_when_ancestor_unavailable(params_from_base_test_setup
 @pytest.mark.syncgateway
 @pytest.mark.attachments
 @pytest.mark.session
-@pytest.mark.channel
+@pytest.mark.basicsgw
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", [
     "sync_gateway_default"
 ])
@@ -183,7 +185,8 @@ def test_attachment_revpos_when_ancestor_unavailable_active_revision_doesnt_shar
 @pytest.mark.syncgateway
 @pytest.mark.attachments
 @pytest.mark.session
-@pytest.mark.channel
+@pytest.mark.basicsgw
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", [
     "sync_gateway_default"
 ])

--- a/testsuites/syncgateway/functional/tests/test_bulk_get_compression.py
+++ b/testsuites/syncgateway/functional/tests/test_bulk_get_compression.py
@@ -152,8 +152,8 @@ def verify_response_size(user_agent, accept_encoding, x_accept_part_encoding, re
 
 
 @pytest.mark.syncgateway
-@pytest.mark.channel
 @pytest.mark.basicauth
+@pytest.mark.basicsgw
 @pytest.mark.parametrize("sg_conf_name, num_docs, accept_encoding, x_accept_part_encoding, user_agent, x509_cert_auth", [
     ("sync_gateway_gzip", 300, None, None, None, True),
     ("sync_gateway_gzip", 300, None, None, "CouchbaseLite/1.1", False),
@@ -163,10 +163,10 @@ def verify_response_size(user_agent, accept_encoding, x_accept_part_encoding, re
     ("sync_gateway_gzip", 300, None, "gzip", "CouchbaseLite/1.1", False),
     ("sync_gateway_gzip", 300, "gzip", "gzip", None, True),
     ("sync_gateway_gzip", 300, "gzip", "gzip", "CouchbaseLite/1.1", False),
-    ("sync_gateway_gzip", 300, None, None, "CouchbaseLite/1.2", False),
+    pytest.param("sync_gateway_gzip", 300, None, None, "CouchbaseLite/1.2", False, marks=[pytest.mark.oscertify, pytest.mark.sanity]),
     ("sync_gateway_gzip", 300, "gzip", None, "CouchbaseLite/1.2", True),
     ("sync_gateway_gzip", 300, None, "gzip", "CouchbaseLite/1.2", True),
-    pytest.param("sync_gateway_gzip", 300, "gzip", "gzip", "CouchbaseLite/1.2", False, marks=pytest.mark.sanity)
+    ("sync_gateway_gzip", 300, "gzip", "gzip", "CouchbaseLite/1.2", False)
 ])
 def test_bulk_get_compression(params_from_base_test_setup, sg_conf_name, num_docs, accept_encoding,
                               x_accept_part_encoding, user_agent, x509_cert_auth):

--- a/testsuites/syncgateway/functional/tests/test_cache_management.py
+++ b/testsuites/syncgateway/functional/tests/test_cache_management.py
@@ -14,6 +14,8 @@ from keywords.MobileRestClient import MobileRestClient
 @pytest.mark.syncgateway
 @pytest.mark.sanity
 @pytest.mark.cachemanagement
+@pytest.mark.basicsgw
+@pytest.mark.oscertify
 def test_importDocs_withSharedBucketAccessFalse(params_from_base_test_setup):
     """
     @summary :
@@ -83,6 +85,8 @@ def test_importDocs_withSharedBucketAccessFalse(params_from_base_test_setup):
 @pytest.mark.syncgateway
 @pytest.mark.community
 @pytest.mark.cachemanagement
+@pytest.mark.basicsgw
+@pytest.mark.oscertify
 def test_importDocs_defaultBehavior_withSharedBucketAccessTrue(params_from_base_test_setup):
     """
     @summary :
@@ -148,6 +152,8 @@ def test_importDocs_defaultBehavior_withSharedBucketAccessTrue(params_from_base_
 
 @pytest.mark.syncgateway
 @pytest.mark.cachemanagement
+@pytest.mark.basicsgw
+@pytest.mark.oscertify
 def test_importPartitions_withSharedBucketAccessTrue(params_from_base_test_setup):
     """
     @summary :

--- a/testsuites/syncgateway/functional/tests/test_changes.py
+++ b/testsuites/syncgateway/functional/tests/test_changes.py
@@ -12,6 +12,7 @@ from utilities.cluster_config_utils import persist_cluster_config_environment_pr
 @pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.changes
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
     ("sync_gateway_default", False),
 ])

--- a/testsuites/syncgateway/functional/tests/test_changes_backfill.py
+++ b/testsuites/syncgateway/functional/tests/test_changes_backfill.py
@@ -18,11 +18,10 @@ from keywords import exceptions
 @pytest.mark.session
 @pytest.mark.access
 @pytest.mark.role
-@pytest.mark.channel
 @pytest.mark.backfill
 @pytest.mark.parametrize("sg_conf_name, grant_type, x509_cert_auth", [
     ("custom_sync/access", "CHANNEL-REST", True),
-    pytest.param("custom_sync/access", "CHANNEL-SYNC", False, marks=pytest.mark.sanity),
+    pytest.param("custom_sync/access", "CHANNEL-SYNC", False, marks=[pytest.mark.sanity, pytest.mark.oscertify]),
     ("custom_sync/access", "ROLE-REST", False),
     ("custom_sync/access", "ROLE-SYNC", True),
     ("custom_sync/access", "CHANNEL-TO-ROLE-REST", True),
@@ -219,8 +218,8 @@ def test_backfill_channels_oneshot_changes(params_from_base_test_setup, sg_conf_
 @pytest.mark.session
 @pytest.mark.access
 @pytest.mark.role
-@pytest.mark.channel
 @pytest.mark.backfill
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, grant_type", [
     ("custom_sync/access", "CHANNEL-REST"),
     ("custom_sync/access", "CHANNEL-SYNC"),

--- a/testsuites/syncgateway/functional/tests/test_channels.py
+++ b/testsuites/syncgateway/functional/tests/test_channels.py
@@ -15,9 +15,9 @@ from keywords import document
 
 
 @pytest.mark.syncgateway
-@pytest.mark.changes
 @pytest.mark.session
 @pytest.mark.channel
+@pytest.mark.oscertify
 @pytest.mark.parametrize('sg_conf_name', [
     'sync_gateway_default'
 ])
@@ -108,9 +108,9 @@ def test_channels_view_after_restart(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.sanity
 @pytest.mark.syncgateway
-@pytest.mark.changes
 @pytest.mark.basicauth
 @pytest.mark.channel
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
     ("sync_gateway_default", False),
 ])

--- a/testsuites/syncgateway/functional/tests/test_conflicts.py
+++ b/testsuites/syncgateway/functional/tests/test_conflicts.py
@@ -19,13 +19,11 @@ from keywords import document
 
 @pytest.mark.syncgateway
 @pytest.mark.conflicts
-@pytest.mark.changes
 @pytest.mark.basicauth
-@pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name", [
     "sync_gateway_default_functional_tests",
     "sync_gateway_allow_conflicts",
-    "sync_gateway_default_functional_tests_no_port",
+    pytest.param("sync_gateway_default_functional_tests_no_port", marks=pytest.mark.oscertify),
     "sync_gateway_default_functional_tests_couchbase_protocol_withport_11210"
 ])
 def test_non_winning_revisions(params_from_base_test_setup, sg_conf_name):
@@ -180,11 +178,9 @@ def test_non_winning_revisions(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.conflicts
-@pytest.mark.changes
 @pytest.mark.basicauth
-@pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
-    pytest.param("sync_gateway_default_functional_tests", True, marks=pytest.mark.sanity),
+    pytest.param("sync_gateway_default_functional_tests", True, marks=[pytest.mark.sanity, pytest.mark.oscertify]),
     ("sync_gateway_default_functional_tests", False)
 ])
 def test_winning_conflict_branch_revisions(params_from_base_test_setup, sg_conf_name, x509_cert_auth):
@@ -309,7 +305,7 @@ def test_winning_conflict_branch_revisions(params_from_base_test_setup, sg_conf_
 @pytest.mark.conflicts
 @pytest.mark.parametrize("sg_conf_name, revs_limit", [
     ('sync_gateway_revs_conflict_configurable', 1),
-    ('sync_gateway_revs_conflict_configurable', 19),
+    pytest.param('sync_gateway_revs_conflict_configurable', 19, marks=pytest.mark.oscertify),
     ('sync_gateway_revs_conflict_configurable', 'a'),
     ('sync_gateway_revs_conflict_configurable', -1)
     # TODO : commenting as revs_limit 0 behavior is going to change, existing behavior start sg successfully , but it will change to sg fails
@@ -353,6 +349,7 @@ def test_invalid_revs_limit_with_allow_conflicts(params_from_base_test_setup, sg
 
 @pytest.mark.syncgateway
 @pytest.mark.conflicts
+@pytest.mark.oscertify
 def test_concurrent_attachment_updatesonDoc(params_from_base_test_setup):
     """ @summary
     1. Create a doc

--- a/testsuites/syncgateway/functional/tests/test_continuous.py
+++ b/testsuites/syncgateway/functional/tests/test_continuous.py
@@ -16,10 +16,9 @@ from utilities.cluster_config_utils import get_sg_version, persist_cluster_confi
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.basicauth
-@pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name, num_users, num_docs, num_revisions", [
     ("sync_gateway_default_functional_tests_no_port", 1, 5000, 1),
-    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 1, 5000, 1),
+    pytest.param("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 1, 5000, 1, marks=pytest.mark.oscertify),
     ("sync_gateway_default_functional_tests", 1, 5000, 1),
     ("sync_gateway_default_functional_tests", 50, 5000, 1),
     ("sync_gateway_default_functional_tests", 50, 10, 10),
@@ -91,10 +90,9 @@ def test_continuous_changes_parametrized(params_from_base_test_setup, sg_conf_na
 @pytest.mark.syncgateway
 @pytest.mark.changes
 @pytest.mark.basicauth
-@pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name, num_docs, num_revisions, x509_cert_auth", [
     ("sync_gateway_default_functional_tests", 10, 10, True),
-    pytest.param("sync_gateway_default_functional_tests_no_port", 10, 10, False, marks=pytest.mark.sanity),
+    pytest.param("sync_gateway_default_functional_tests_no_port", 10, 10, False, marks=[pytest.mark.sanity, pytest.mark.oscertify]),
     ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 10, 10, False)
 ])
 def test_continuous_changes_sanity(params_from_base_test_setup, sg_conf_name, num_docs, num_revisions, x509_cert_auth):

--- a/testsuites/syncgateway/functional/tests/test_crud.py
+++ b/testsuites/syncgateway/functional/tests/test_crud.py
@@ -16,14 +16,13 @@ from utilities.cluster_config_utils import get_sg_version, persist_cluster_confi
 
 
 @pytest.mark.syncgateway
-@pytest.mark.xattrs
-@pytest.mark.changes
 @pytest.mark.session
+@pytest.mark.basicsgw
 @pytest.mark.parametrize('sg_conf_name, deletion_type, x509_cert_auth', [
-    ('sync_gateway_default_functional_tests', 'tombstone', False),
+    pytest.param('sync_gateway_default_functional_tests', 'tombstone', False, marks=pytest.mark.oscertify),
     ('sync_gateway_default_functional_tests', 'purge', True),
     ('sync_gateway_default_functional_tests_no_port', 'tombstone', True),
-    pytest.param('sync_gateway_default_functional_tests_no_port', 'purge', False, marks=pytest.mark.sanity),
+    pytest.param('sync_gateway_default_functional_tests_no_port', 'purge', False, marks=[pytest.mark.sanity, pytest.mark.oscertify]),
     ('sync_gateway_default_functional_tests_couchbase_protocol_withport_11210', 'purge', False)
 ])
 def test_document_resurrection(params_from_base_test_setup, sg_conf_name, deletion_type, x509_cert_auth):
@@ -308,7 +307,8 @@ def test_document_resurrection(params_from_base_test_setup, sg_conf_name, deleti
 
 
 @pytest.mark.syncgateway
-@pytest.mark.xattrs
+@pytest.mark.basicsgw
+@pytest.mark.oscertify
 @pytest.mark.parametrize('sg_conf_name', [
     'sync_gateway_default_functional_tests'
 ])

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline.py
@@ -26,9 +26,8 @@ NUM_ENDPOINTS = 13
 @pytest.mark.onlineoffline
 @pytest.mark.basicauth
 @pytest.mark.role
-@pytest.mark.channel
 @pytest.mark.bulkops
-@pytest.mark.changes
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, num_docs, x509_cert_auth", [
     ("bucket_online_offline/bucket_online_offline_default", 100, False)
 ])
@@ -70,9 +69,8 @@ def test_online_default_rest(params_from_base_test_setup, sg_conf_name, num_docs
 @pytest.mark.onlineoffline
 @pytest.mark.basicauth
 @pytest.mark.role
-@pytest.mark.channel
 @pytest.mark.bulkops
-@pytest.mark.changes
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, num_docs", [
     ("bucket_online_offline/bucket_online_offline_offline_false", 100)
 ])
@@ -111,9 +109,8 @@ def test_offline_false_config_rest(params_from_base_test_setup, sg_conf_name, nu
 @pytest.mark.onlineoffline
 @pytest.mark.basicauth
 @pytest.mark.role
-@pytest.mark.channel
 @pytest.mark.bulkops
-@pytest.mark.changes
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, num_docs", [
     ("bucket_online_offline/bucket_online_offline_default", 100)
 ])
@@ -158,6 +155,7 @@ def test_online_to_offline_check_503(params_from_base_test_setup, sg_conf_name, 
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
 @pytest.mark.basicauth
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, num_docs", [
     ("bucket_online_offline/bucket_online_offline_default", 5000)
 ])
@@ -234,7 +232,7 @@ def test_online_to_offline_changes_feed_controlled_close_continuous(params_from_
 # Scenario 6 - longpoll
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
-@pytest.mark.changes
+@pytest.mark.oscertify
 @pytest.mark.basicauth
 @pytest.mark.parametrize("sg_conf_name, num_docs, num_users", [
     ("bucket_online_offline/bucket_online_offline_default", 5000, 40)
@@ -299,7 +297,7 @@ def test_online_to_offline_continous_changes_feed_controlled_close_sanity_mulitp
 # Scenario 6 - longpoll
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
-@pytest.mark.changes
+@pytest.mark.oscertify
 @pytest.mark.basicauth
 @pytest.mark.parametrize("sg_conf_name, num_docs", [
     ("bucket_online_offline/bucket_online_offline_default", 5000)
@@ -361,7 +359,7 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll_sanity(params_
 # Scenario 6 - longpoll
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
-@pytest.mark.changes
+@pytest.mark.oscertify
 @pytest.mark.basicauth
 @pytest.mark.parametrize("sg_conf_name, num_docs, num_users", [
     ("bucket_online_offline/bucket_online_offline_default", 5000, 40)
@@ -432,7 +430,7 @@ def test_online_to_offline_longpoll_changes_feed_controlled_close_sanity_mulitpl
 # NOTE: Was disabled for di
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
-@pytest.mark.changes
+@pytest.mark.oscertify
 @pytest.mark.basicauth
 @pytest.mark.parametrize("sg_conf_name, num_docs", [
     ("bucket_online_offline/bucket_online_offline_default", 5000)
@@ -542,9 +540,8 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll(params_from_ba
 @pytest.mark.onlineoffline
 @pytest.mark.basicauth
 @pytest.mark.role
-@pytest.mark.channel
 @pytest.mark.bulkops
-@pytest.mark.changes
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, num_docs", [
     ("bucket_online_offline/bucket_online_offline_offline_true", 100)
 ])
@@ -590,9 +587,8 @@ def test_offline_true_config_bring_online(params_from_base_test_setup, sg_conf_n
 @pytest.mark.onlineoffline
 @pytest.mark.basicauth
 @pytest.mark.role
-@pytest.mark.channel
 @pytest.mark.bulkops
-@pytest.mark.changes
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, num_docs", [
     ("bucket_online_offline/bucket_online_offline_default_dcp", 100),
     ("bucket_online_offline/bucket_online_offline_default", 100)
@@ -635,9 +631,8 @@ def test_db_offline_tap_loss_sanity(params_from_base_test_setup, sg_conf_name, n
 @pytest.mark.onlineoffline
 @pytest.mark.basicauth
 @pytest.mark.role
-@pytest.mark.channel
 @pytest.mark.bulkops
-@pytest.mark.changes
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, num_docs", [
     ("bucket_online_offline/bucket_online_offline_default", 100)
 ])
@@ -689,9 +684,8 @@ def test_db_delayed_online(params_from_base_test_setup, sg_conf_name, num_docs):
 @pytest.mark.onlineoffline
 @pytest.mark.basicauth
 @pytest.mark.role
-@pytest.mark.channel
 @pytest.mark.bulkops
-@pytest.mark.changes
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, num_docs", [
     ("bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets", 100)
 ])

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline_resync.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline_resync.py
@@ -19,11 +19,9 @@ from utilities.cluster_config_utils import persist_cluster_config_environment_pr
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
 @pytest.mark.basicauth
-@pytest.mark.channel
-@pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name, num_users, num_docs, num_revisions, x509_cert_auth", [
     pytest.param("bucket_online_offline/db_online_offline_access_all", 5, 100, 10, True, marks=pytest.mark.sanity),
-    ("bucket_online_offline/db_online_offline_access_all", 5, 100, 10, False)
+    pytest.param("bucket_online_offline/db_online_offline_access_all", 5, 100, 10, False, marks=pytest.mark.oscertify)
 ])
 def test_bucket_online_offline_resync_sanity(params_from_base_test_setup, sg_conf_name, num_users, num_docs,
                                              num_revisions, x509_cert_auth):
@@ -161,6 +159,7 @@ def test_bucket_online_offline_resync_sanity(params_from_base_test_setup, sg_con
 # attempt to bring DB _online, expected result _online will succeed, return status 200.
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, num_users, num_docs, num_revisions", [
     ("bucket_online_offline/db_online_offline_access_all", 5, 100, 10),
 ])
@@ -347,6 +346,7 @@ def test_bucket_online_offline_resync_with_online(params_from_base_test_setup, s
 # expected result 'state' property with value 'Resyncing' is returned.
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, num_users, num_docs, num_revisions", [
     ("bucket_online_offline/db_online_offline_access_all", 5, 100, 10),
 ])

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline_webhooks.py
@@ -17,9 +17,8 @@ from utilities.cluster_config_utils import persist_cluster_config_environment_pr
 
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
-@pytest.mark.webhooks
 @pytest.mark.parametrize("sg_conf_name, num_users, num_channels, num_docs, num_revisions, x509_cert_auth", [
-    pytest.param("webhooks/webhook_offline", 5, 1, 1, 2, False, marks=pytest.mark.sanity),
+    pytest.param("webhooks/webhook_offline", 5, 1, 1, 2, False, marks=[pytest.mark.sanity, pytest.mark.oscertify]),
     ("webhooks/webhook_offline", 5, 1, 1, 2, True)
 ])
 def test_db_online_offline_webhooks_offline(params_from_base_test_setup, sg_conf_name, num_users, num_channels,
@@ -118,7 +117,7 @@ def test_db_online_offline_webhooks_offline(params_from_base_test_setup, sg_conf
 # implements scenarios: 21
 @pytest.mark.syncgateway
 @pytest.mark.onlineoffline
-@pytest.mark.webhooks
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, num_users, num_channels, num_docs, num_revisions", [
     ("webhooks/webhook_offline", 5, 1, 1, 2),
 ])

--- a/testsuites/syncgateway/functional/tests/test_log_redaction.py
+++ b/testsuites/syncgateway/functional/tests/test_log_redaction.py
@@ -22,6 +22,8 @@ from libraries.provision.ansible_runner import AnsibleRunner
 
 @pytest.mark.syncgateway
 @pytest.mark.logredaction
+@pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, redaction_level, x509_cert_auth", [
     pytest.param("log_redaction", "partial", False, marks=pytest.mark.sanity),
     ("log_redaction", "none", True)
@@ -84,6 +86,8 @@ def test_log_redaction_config(params_from_base_test_setup, remove_tmp_sg_redacti
 
 @pytest.mark.syncgateway
 @pytest.mark.logredaction
+@pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, redaction_level, redaction_salt, x509_cert_auth", [
     ("log_redaction", "partial", False, True),
     pytest.param("log_redaction", "none", False, False, marks=pytest.mark.sanity),
@@ -146,11 +150,12 @@ def test_sgCollect1(params_from_base_test_setup, remove_tmp_sg_redaction_logs, s
 
 @pytest.mark.syncgateway
 @pytest.mark.logredaction
+@pytest.mark.logging
 @pytest.mark.parametrize("sg_conf_name, redaction_level, redaction_salt, output_dir, x509_cert_auth", [
     ("log_redaction", "partial", False, False, True),
-    ("log_redaction", None, False, False, False),
+    pytest.param("log_redaction", None, False, False, False, marks=pytest.mark.oscertify),
     ("log_redaction", "partial", True, False, False),
-    ("log_redaction", "partial", True, True, True)
+    pytest.param("log_redaction", "partial", True, True, True, marks=pytest.mark.oscertify)
 ])
 def test_sgCollect_restApi(params_from_base_test_setup, remove_tmp_sg_redaction_logs, sg_conf_name, redaction_level,
                            redaction_salt, output_dir, x509_cert_auth):
@@ -267,6 +272,8 @@ def test_sgCollect_restApi(params_from_base_test_setup, remove_tmp_sg_redaction_
 
 @pytest.mark.syncgateway
 @pytest.mark.logredaction
+@pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
     ("log_redaction", False)
 ])

--- a/testsuites/syncgateway/functional/tests/test_log_rotation.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation.py
@@ -67,6 +67,7 @@ def load_sync_gateway_config(sync_gateway_config, mode, server_url, xattrs_enabl
 @pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
     ("log_rotation", True)
 ])
@@ -150,6 +151,7 @@ def test_log_rotation_default_values(params_from_base_test_setup, sg_conf_name, 
 
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation"])
 def test_log_logKeys_string(params_from_base_test_setup, sg_conf_name):
     """Negative test to verify that we are not able start SG when
@@ -207,6 +209,7 @@ def test_log_logKeys_string(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation"])
 def test_log_nondefault_logKeys_set(params_from_base_test_setup, sg_conf_name):
     """Test to verify non default logKeys with any invalid area.
@@ -259,6 +262,7 @@ def test_log_nondefault_logKeys_set(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation"])
 def test_log_maxage_10_timestamp_ignored(params_from_base_test_setup, sg_conf_name):
     """Test to verify SG continues to wrile logs in the same file even when
@@ -331,6 +335,7 @@ def test_log_maxage_10_timestamp_ignored(params_from_base_test_setup, sg_conf_na
 # https://github.com/couchbase/sync_gateway/issues/2221
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation"])
 def test_log_rotation_invalid_path(params_from_base_test_setup, sg_conf_name):
     """Test to check that SG is not started with invalid logFilePath.
@@ -389,6 +394,7 @@ def test_log_rotation_invalid_path(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.skip(reason="This causes paramiko to timeout intermittently. Need to revisit.")
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation"])
 def test_log_200mb(params_from_base_test_setup, sg_conf_name):
@@ -453,6 +459,7 @@ def test_log_200mb(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation"])
 def test_log_number_backups(params_from_base_test_setup, sg_conf_name):
     """Test to check general behaviour for number of backups.
@@ -515,6 +522,7 @@ def test_log_number_backups(params_from_base_test_setup, sg_conf_name):
 # https://github.com/couchbase/sync_gateway/issues/2222
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation"])
 def test_log_rotation_negative(params_from_base_test_setup, sg_conf_name):
     """Test log rotation with negative values for:
@@ -581,6 +589,7 @@ def test_log_rotation_negative(params_from_base_test_setup, sg_conf_name):
 # https://github.com/couchbase/sync_gateway/issues/2225
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation"])
 def test_log_maxbackups_0(params_from_base_test_setup, sg_conf_name):
     """Test with maxbackups=0 that means do not limit the number of backups
@@ -644,6 +653,7 @@ def test_log_maxbackups_0(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation"])
 def test_log_logLevel_invalid(params_from_base_test_setup, sg_conf_name):
     """Run SG with non existing logLevel value

--- a/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
@@ -15,6 +15,7 @@ from utilities.cluster_config_utils import load_cluster_config_json, persist_clu
 @pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
     ("log_rotation_new", False)
 ])
@@ -123,6 +124,7 @@ def test_log_rotation_default_values(params_from_base_test_setup, sg_conf_name, 
 
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation_new"])
 def test_invalid_logKeys_string(params_from_base_test_setup, sg_conf_name):
     """
@@ -180,6 +182,7 @@ def test_invalid_logKeys_string(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation_new"])
 def test_log_nondefault_logKeys_set(params_from_base_test_setup, sg_conf_name):
     """
@@ -232,6 +235,7 @@ def test_log_nondefault_logKeys_set(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation_new"])
 def test_log_maxage_timestamp_ignored(params_from_base_test_setup, sg_conf_name):
     """
@@ -332,6 +336,7 @@ def test_log_maxage_timestamp_ignored(params_from_base_test_setup, sg_conf_name)
 # https://github.com/couchbase/sync_gateway/issues/2221
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation_new"])
 def test_log_rotation_invalid_path(params_from_base_test_setup, sg_conf_name):
     """
@@ -390,6 +395,7 @@ def test_log_rotation_invalid_path(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation_new"])
 def test_log_200mb(params_from_base_test_setup, sg_conf_name):
     """
@@ -478,6 +484,7 @@ def test_log_200mb(params_from_base_test_setup, sg_conf_name):
 # https://github.com/couchbase/sync_gateway/issues/2222
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation_new"])
 def test_log_rotation_negative(params_from_base_test_setup, sg_conf_name):
     """
@@ -549,6 +556,7 @@ def test_log_rotation_negative(params_from_base_test_setup, sg_conf_name):
 # https://github.com/couchbase/sync_gateway/issues/2225
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation_new"])
 def test_log_maxbackups_0(params_from_base_test_setup, sg_conf_name):
     """
@@ -633,6 +641,7 @@ def test_log_maxbackups_0(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation_new"])
 def test_log_logLevel_invalid(params_from_base_test_setup, sg_conf_name):
     """
@@ -690,6 +699,7 @@ def test_log_logLevel_invalid(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.logging
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", ["log_rotation_new"])
 def test_rotated_logs_size_limit(params_from_base_test_setup, sg_conf_name):
     """

--- a/testsuites/syncgateway/functional/tests/test_longpoll.py
+++ b/testsuites/syncgateway/functional/tests/test_longpoll.py
@@ -20,11 +20,10 @@ from keywords import userinfo
 
 
 @pytest.mark.syncgateway
-@pytest.mark.changes
 @pytest.mark.basicauth
-@pytest.mark.channel
+@pytest.mark.basicsgw
 @pytest.mark.parametrize("sg_conf_name, num_docs, num_revisions", [
-    ("sync_gateway_default_functional_tests", 5000, 1),
+    pytest.param("sync_gateway_default_functional_tests", 5000, 1, marks=pytest.mark.oscertify),
     ("sync_gateway_default_functional_tests", 50, 100),
     ("sync_gateway_default_functional_tests_no_port", 5000, 1),
     ("sync_gateway_default_functional_tests_no_port", 50, 100),
@@ -92,11 +91,10 @@ def test_longpoll_changes_parametrized(params_from_base_test_setup, sg_conf_name
 
 
 @pytest.mark.syncgateway
-@pytest.mark.changes
 @pytest.mark.basicauth
-@pytest.mark.channel
+@pytest.mark.basicsgw
 @pytest.mark.parametrize("sg_conf_name, num_docs, num_revisions, x509_cert_auth", [
-    pytest.param("sync_gateway_default_functional_tests", 10, 10, True, marks=pytest.mark.sanity),
+    pytest.param("sync_gateway_default_functional_tests", 10, 10, True, marks=[pytest.mark.sanity, pytest.mark.oscertify]),
     ("sync_gateway_default_functional_tests_no_port", 10, 10, False),
     ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 10, 10, False)
 ])
@@ -168,13 +166,12 @@ def test_longpoll_changes_sanity(params_from_base_test_setup, sg_conf_name, num_
 
 
 @pytest.mark.syncgateway
-@pytest.mark.changes
+@pytest.mark.basicsgw
 @pytest.mark.basicauth
-@pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name", [
-    "sync_gateway_default_functional_tests",
-    "sync_gateway_default_functional_tests_no_port",
-    "sync_gateway_default_functional_tests_couchbase_protocol_withport_11210"
+    pytest.param("sync_gateway_default_functional_tests", marks=pytest.mark.oscertify),
+    ("sync_gateway_default_functional_tests_no_port"),
+    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210")
 ])
 def test_longpoll_awaken_doc_add_update(params_from_base_test_setup, sg_conf_name):
 
@@ -419,14 +416,13 @@ def test_longpoll_awaken_doc_add_update(params_from_base_test_setup, sg_conf_nam
 
 
 @pytest.mark.syncgateway
-@pytest.mark.changes
 @pytest.mark.basicauth
 @pytest.mark.access
-@pytest.mark.channel
+@pytest.mark.basicsgw
 @pytest.mark.parametrize("sg_conf_name", [
-    "sync_gateway_default_functional_tests",
-    "sync_gateway_default_functional_tests_no_port",
-    "sync_gateway_default_functional_tests_couchbase_protocol_withport_11210"
+    ("sync_gateway_default_functional_tests"),
+    pytest.param("sync_gateway_default_functional_tests_no_port", marks=pytest.mark.oscertify),
+    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210")
 ])
 def test_longpoll_awaken_channels(params_from_base_test_setup, sg_conf_name):
 
@@ -661,15 +657,13 @@ def test_longpoll_awaken_channels(params_from_base_test_setup, sg_conf_name):
 
 
 @pytest.mark.syncgateway
-@pytest.mark.changes
 @pytest.mark.basicauth
 @pytest.mark.access
 @pytest.mark.role
-@pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name", [
-    "sync_gateway_default_functional_tests",
-    "sync_gateway_default_functional_tests_no_port",
-    "sync_gateway_default_functional_tests_couchbase_protocol_withport_11210"
+    ("sync_gateway_default_functional_tests"),
+    ("sync_gateway_default_functional_tests_no_port"),
+    pytest.param("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", marks=pytest.mark.oscertify)
 ])
 def test_longpoll_awaken_roles(params_from_base_test_setup, sg_conf_name):
 
@@ -851,10 +845,10 @@ def test_longpoll_awaken_roles(params_from_base_test_setup, sg_conf_name):
 
 
 @pytest.mark.syncgateway
-@pytest.mark.changes
 @pytest.mark.basicauth
 @pytest.mark.access
-@pytest.mark.channel
+@pytest.mark.basicsgw
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", [
     "custom_sync/wake_changes_access",
 ])
@@ -969,11 +963,11 @@ def test_longpoll_awaken_via_sync_access(params_from_base_test_setup, sg_conf_na
 
 
 @pytest.mark.syncgateway
-@pytest.mark.changes
 @pytest.mark.basicauth
 @pytest.mark.role
 @pytest.mark.access
-@pytest.mark.channel
+@pytest.mark.oscertify
+@pytest.mark.basicsgw
 @pytest.mark.parametrize("sg_conf_name", [
     "custom_sync/wake_changes_roles",
 ])

--- a/testsuites/syncgateway/functional/tests/test_mobile_opt_in.py
+++ b/testsuites/syncgateway/functional/tests/test_mobile_opt_in.py
@@ -18,6 +18,7 @@ from libraries.testkit.cluster import Cluster
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
 @pytest.mark.session
+@pytest.mark.oscertify
 @pytest.mark.parametrize('sg_conf_name', [
     'xattrs/mobile_opt_in'
 ])

--- a/testsuites/syncgateway/functional/tests/test_multiple_dbs.py
+++ b/testsuites/syncgateway/functional/tests/test_multiple_dbs.py
@@ -13,9 +13,9 @@ from utilities.cluster_config_utils import is_x509_auth, persist_cluster_config_
 
 @pytest.mark.syncgateway
 @pytest.mark.basicauth
-@pytest.mark.channel
 @pytest.mark.bulkops
-@pytest.mark.changes
+@pytest.mark.oscertify
+@pytest.mark.basicsgw
 @pytest.mark.parametrize("sg_conf_name, num_users, num_docs_per_user", [
     ("multiple_dbs_unique_data_unique_index", 10, 500),
 ])
@@ -72,11 +72,10 @@ def test_multiple_db_unique_data_bucket_unique_index_bucket(params_from_base_tes
 # Kind of an edge case in that most users would not point multiple dbs at the same server bucket
 @pytest.mark.syncgateway
 @pytest.mark.basicauth
-@pytest.mark.channel
 @pytest.mark.bulkops
-@pytest.mark.changes
+@pytest.mark.basicsgw
 @pytest.mark.parametrize("sg_conf_name, num_users, num_docs_per_user, x509_cert_auth", [
-    pytest.param("multiple_dbs_shared_data_shared_index", 10, 500, False, marks=pytest.mark.sanity),
+    pytest.param("multiple_dbs_shared_data_shared_index", 10, 500, False, marks=[pytest.mark.sanity, pytest.mark.oscertify]),
     ("multiple_dbs_shared_data_shared_index", 10, 500, True)
 ])
 def test_multiple_db_single_data_bucket_single_index_bucket(params_from_base_test_setup, sg_conf_name, num_users,

--- a/testsuites/syncgateway/functional/tests/test_multiple_users_multiple_channels_multiple_revisions.py
+++ b/testsuites/syncgateway/functional/tests/test_multiple_users_multiple_channels_multiple_revisions.py
@@ -20,11 +20,10 @@ from utilities.cluster_config_utils import get_sg_version, persist_cluster_confi
 @pytest.mark.syncgateway
 @pytest.mark.basicauth
 @pytest.mark.channel
-@pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name, num_users, num_channels, num_docs, num_revisions, x509_cert_auth", [
     ("sync_gateway_default_functional_tests", 10, 3, 10, 10, False),
     ("sync_gateway_default_functional_tests_no_port", 10, 3, 10, 10, True),
-    pytest.param("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 10, 3, 10, 10, False, marks=pytest.mark.sanity)
+    pytest.param("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 10, 3, 10, 10, False, marks=[pytest.mark.sanity, pytest.mark.oscertify])
 ])
 def test_mulitple_users_mulitiple_channels_mulitple_revisions(params_from_base_test_setup, sg_conf_name, num_users,
                                                               num_channels, num_docs, num_revisions, x509_cert_auth):

--- a/testsuites/syncgateway/functional/tests/test_no_conflicts.py
+++ b/testsuites/syncgateway/functional/tests/test_no_conflicts.py
@@ -17,6 +17,7 @@ from keywords.constants import SDK_TIMEOUT
 @pytest.mark.syncgateway
 @pytest.mark.conflicts
 @pytest.mark.noconflicts
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, num_of_docs", [
     ('sync_gateway_revs_conflict_configurable', 10)
 ])
@@ -82,7 +83,7 @@ def test_no_conflicts_enabled(params_from_base_test_setup, sg_conf_name, num_of_
 @pytest.mark.noconflicts
 @pytest.mark.parametrize("sg_conf_name, num_of_docs, revs_limit", [
     ('sync_gateway_revs_conflict_configurable', 10, 1),
-    ('sync_gateway_revs_conflict_configurable', 10, 10)
+    pytest.param('sync_gateway_revs_conflict_configurable', 10, 10, marks=pytest.mark.oscertify)
 ])
 def test_no_conflicts_with_revs_limit(params_from_base_test_setup, sg_conf_name, num_of_docs, revs_limit):
     """ @summary Enable no conflicts and  with non default revs_limit and verify revs_limit is maintained
@@ -169,6 +170,7 @@ def test_no_conflicts_with_revs_limit(params_from_base_test_setup, sg_conf_name,
 @pytest.mark.syncgateway
 @pytest.mark.conflicts
 @pytest.mark.noconflicts
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, num_of_docs, revs_limit", [
     ('sync_gateway_revs_conflict_configurable', 1, 5)
 ])
@@ -257,7 +259,7 @@ def test_no_conflicts_update_revs_limit(params_from_base_test_setup, sg_conf_nam
 @pytest.mark.conflicts
 @pytest.mark.noconflicts
 @pytest.mark.parametrize("sg_conf_name, num_of_docs, revs_limit, additional_updates", [
-    ('sync_gateway_revs_conflict_configurable', 10, 25, 5),
+    pytest.param('sync_gateway_revs_conflict_configurable', 10, 25, 5, marks=pytest.mark.oscertify),
     ('sync_gateway_revs_conflict_configurable', 10, 1000, 1000)
 ])
 def test_conflicts_sg_accel_added(params_from_base_test_setup, sg_conf_name, num_of_docs, revs_limit, additional_updates):
@@ -344,7 +346,7 @@ def test_conflicts_sg_accel_added(params_from_base_test_setup, sg_conf_name, num
 @pytest.mark.noconflicts
 @pytest.mark.parametrize("sg_conf_name, num_of_docs, revs_limit", [
     ('sync_gateway_revs_conflict_configurable', 1, None),
-    ('sync_gateway_revs_conflict_configurable', 1, 10),
+    pytest.param('sync_gateway_revs_conflict_configurable', 1, 10, marks=pytest.mark.oscertify),
     ('sync_gateway_revs_conflict_configurable', 1, 1)
 ])
 def test_migrate_conflicts_to_noConflicts(params_from_base_test_setup, sg_conf_name, num_of_docs, revs_limit):
@@ -446,7 +448,7 @@ def test_migrate_conflicts_to_noConflicts(params_from_base_test_setup, sg_conf_n
 @pytest.mark.parametrize("sg_conf_name, num_of_docs, revs_limit", [
     ('sync_gateway_revs_conflict_configurable', 100, 10),
     ('sync_gateway_revs_conflict_configurable', 100, 10),
-    ('sync_gateway_revs_conflict_configurable', 1000, 100),
+    pytest.param('sync_gateway_revs_conflict_configurable', 1000, 100, marks=pytest.mark.oscertify),
     ('sync_gateway_revs_conflict_configurable', 10, 1000),
 ])
 def test_concurrent_updates_no_conflicts(params_from_base_test_setup, sg_conf_name, num_of_docs, revs_limit):
@@ -564,6 +566,7 @@ def sdk_bulk_update(sdk_client, sdk_docs, num_of_updates):
 @pytest.mark.syncgateway
 @pytest.mark.conflicts
 @pytest.mark.noconflicts
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, num_of_docs", [
     ('sync_gateway_revs_conflict_configurable', 10)
 ])
@@ -649,7 +652,7 @@ def test_migrate_conflicts_delete_last_rev(params_from_base_test_setup, sg_conf_
 @pytest.mark.parametrize("sg_conf_name, num_of_docs", [
     ('sync_gateway_revs_conflict_configurable', 5),
     ('sync_gateway_revs_conflict_configurable', 100),
-    ('sync_gateway_revs_conflict_configurable', 900)
+    pytest.param('sync_gateway_revs_conflict_configurable', 900, marks=pytest.mark.oscertify)
 ])
 def test_revs_cache_size(params_from_base_test_setup, sg_conf_name, num_of_docs):
     """ @summary Test for no-conflicts with rev_cache size

--- a/testsuites/syncgateway/functional/tests/test_openid_connect.py
+++ b/testsuites/syncgateway/functional/tests/test_openid_connect.py
@@ -114,9 +114,10 @@ def discover_authenticate_endpoint(sg_url, sg_db, provider, ipv6):
 
 @pytest.mark.syncgateway
 @pytest.mark.oidc
+@pytest.mark.basicsgw
 @pytest.mark.parametrize("sg_conf_name, is_admin_port, expect_signed_id_token", [
     ("sync_gateway_openid_connect", False, True),
-    pytest.param("sync_gateway_openid_connect", True, True, marks=pytest.mark.sanity),
+    pytest.param("sync_gateway_openid_connect", True, True, marks=[pytest.mark.sanity, pytest.mark.oscertify]),
     ("sync_gateway_openid_connect_unsigned", False, False)
 ])
 def test_openidconnect_basic_test(params_from_base_test_setup, sg_conf_name, is_admin_port, expect_signed_id_token):
@@ -233,6 +234,8 @@ def test_openidconnect_basic_test(params_from_base_test_setup, sg_conf_name, is_
 
 @pytest.mark.syncgateway
 @pytest.mark.oidc
+@pytest.mark.oscertify
+@pytest.mark.basicsgw
 @pytest.mark.parametrize("sg_conf_name", [
     "sync_gateway_openid_connect"
 ])
@@ -281,6 +284,8 @@ def test_openidconnect_notauthenticated(params_from_base_test_setup, sg_conf_nam
 
 @pytest.mark.syncgateway
 @pytest.mark.oidc
+@pytest.mark.oscertify
+@pytest.mark.basicsgw
 @pytest.mark.parametrize("sg_conf_name", [
     "sync_gateway_openid_connect"
 ])
@@ -319,6 +324,8 @@ def test_openidconnect_oidc_challenge_invalid_provider_name(params_from_base_tes
 
 @pytest.mark.syncgateway
 @pytest.mark.oidc
+@pytest.mark.oscertify
+@pytest.mark.basicsgw
 @pytest.mark.parametrize("sg_conf_name", [
     "sync_gateway_openid_connect"
 ])
@@ -361,6 +368,8 @@ def test_openidconnect_no_session(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.oidc
+@pytest.mark.oscertify
+@pytest.mark.basicsgw
 @pytest.mark.parametrize("sg_conf_name", [
     "sync_gateway_openid_connect"
 ])
@@ -430,6 +439,8 @@ def test_openidconnect_expired_token(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.oidc
+@pytest.mark.oscertify
+@pytest.mark.basicsgw
 @pytest.mark.parametrize("sg_conf_name", [
     "sync_gateway_openid_connect"
 ])
@@ -483,6 +494,8 @@ def test_openidconnect_negative_token_expiry(params_from_base_test_setup, sg_con
 
 @pytest.mark.syncgateway
 @pytest.mark.oidc
+@pytest.mark.oscertify
+@pytest.mark.basicsgw
 @pytest.mark.parametrize("sg_conf_name", [
     "sync_gateway_openid_connect"
 ])
@@ -563,6 +576,8 @@ def test_openidconnect_garbage_token(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.oidc
+@pytest.mark.oscertify
+@pytest.mark.basicsgw
 @pytest.mark.parametrize("sg_conf_name", [
     "sync_gateway_openid_connect"
 ])
@@ -602,6 +617,8 @@ def test_openidconnect_invalid_scope(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.oidc
+@pytest.mark.oscertify
+@pytest.mark.basicsgw
 @pytest.mark.parametrize("sg_conf_name", [
     "sync_gateway_openid_connect"
 ])
@@ -662,6 +679,8 @@ def test_openidconnect_small_scope(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.oidc
+@pytest.mark.oscertify
+@pytest.mark.basicsgw
 @pytest.mark.parametrize("sg_conf_name", [
     "sync_gateway_openid_connect"
 ])
@@ -724,6 +743,8 @@ def test_openidconnect_large_scope(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.oidc
+@pytest.mark.oscertify
+@pytest.mark.basicsgw
 @pytest.mark.parametrize("sg_conf_name", [
     "sync_gateway_openid_connect"
 ])

--- a/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
+++ b/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
@@ -18,10 +18,9 @@ from utilities.cluster_config_utils import persist_cluster_config_environment_pr
 @pytest.mark.basicauth
 @pytest.mark.channel
 @pytest.mark.bulkops
-@pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name, num_docs, user_channels, filter, limit, x509_cert_auth", [
     ("sync_gateway_channel_cache", 5000, "*", True, 50, False),
-    pytest.param("sync_gateway_channel_cache", 1000, "*", True, 50, True, marks=pytest.mark.sanity),
+    pytest.param("sync_gateway_channel_cache", 1000, "*", True, 50, True, marks=[pytest.mark.sanity, pytest.mark.oscertify]),
     ("sync_gateway_channel_cache", 1000, "ABC", False, 50, True),
     ("sync_gateway_channel_cache", 1000, "ABC", True, 50, False),
 ])

--- a/testsuites/syncgateway/functional/tests/test_resync.py
+++ b/testsuites/syncgateway/functional/tests/test_resync.py
@@ -15,7 +15,8 @@ from utilities.cluster_config_utils import persist_cluster_config_environment_pr
 
 @pytest.mark.sanity
 @pytest.mark.syncgateway
-@pytest.mark.changes
+@pytest.mark.basicsgw
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
     ("custom_sync/grant_access_one", False)
 ])

--- a/testsuites/syncgateway/functional/tests/test_roles.py
+++ b/testsuites/syncgateway/functional/tests/test_roles.py
@@ -14,10 +14,9 @@ from utilities.cluster_config_utils import get_sg_version, persist_cluster_confi
 @pytest.mark.basicauth
 @pytest.mark.channel
 @pytest.mark.bulkops
-@pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
     ("sync_gateway_default_functional_tests", True),
-    pytest.param("sync_gateway_default_functional_tests_no_port", False, marks=pytest.mark.sanity),
+    pytest.param("sync_gateway_default_functional_tests_no_port", False, marks=[pytest.mark.sanity, pytest.mark.oscertify]),
     ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", False)
 ])
 def test_roles_sanity(params_from_base_test_setup, sg_conf_name, x509_cert_auth):

--- a/testsuites/syncgateway/functional/tests/test_rollback.py
+++ b/testsuites/syncgateway/functional/tests/test_rollback.py
@@ -17,11 +17,11 @@ from utilities.cluster_config_utils import persist_cluster_config_environment_pr
 
 @pytest.mark.sanity
 @pytest.mark.syncgateway
-@pytest.mark.changes
 @pytest.mark.session
-@pytest.mark.channel
 @pytest.mark.rollback
 @pytest.mark.bulkops
+@pytest.mark.basicsgw
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
     ("sync_gateway_default", False)
 ])

--- a/testsuites/syncgateway/functional/tests/test_seq.py
+++ b/testsuites/syncgateway/functional/tests/test_seq.py
@@ -13,13 +13,12 @@ from utilities.cluster_config_utils import get_sg_version, persist_cluster_confi
 
 @pytest.mark.syncgateway
 @pytest.mark.basicauth
-@pytest.mark.channel
 @pytest.mark.bulkops
 @pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name, num_users, num_docs, num_revisions, x509_cert_auth", [
     ("sync_gateway_default_functional_tests", 10, 500, 1, False),
     ("sync_gateway_default_functional_tests_no_port", 10, 500, 1, True),
-    pytest.param("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 10, 500, 1, False, marks=pytest.mark.sanity)
+    pytest.param("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 10, 500, 1, False, marks=[pytest.mark.sanity, pytest.mark.oscertify])
 ])
 def test_seq(params_from_base_test_setup, sg_conf_name, num_users, num_docs, num_revisions, x509_cert_auth):
     cluster_conf = params_from_base_test_setup["cluster_config"]

--- a/testsuites/syncgateway/functional/tests/test_single_user_single_channel_doc_updates.py
+++ b/testsuites/syncgateway/functional/tests/test_single_user_single_channel_doc_updates.py
@@ -21,9 +21,8 @@ log = logging.getLogger(libraries.testkit.settings.LOGGER)
 @pytest.mark.syncgateway
 @pytest.mark.basicauth
 @pytest.mark.channel
-@pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name, num_docs, num_revisions, x509_cert_auth", [
-    pytest.param("sync_gateway_default_functional_tests", 100, 100, False, marks=pytest.mark.sanity),
+    pytest.param("sync_gateway_default_functional_tests", 100, 100, False, marks=[pytest.mark.sanity, pytest.mark.oscertify]),
     ("sync_gateway_default_functional_tests_no_port", 100, 100, True),
     ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", 100, 100, False)
 ])

--- a/testsuites/syncgateway/functional/tests/test_sync-function-reject.py
+++ b/testsuites/syncgateway/functional/tests/test_sync-function-reject.py
@@ -16,7 +16,8 @@ from keywords import attachment
 @pytest.mark.syncgateway
 @pytest.mark.attachments
 @pytest.mark.session
-@pytest.mark.channel
+@pytest.mark.sync
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", [
     "reject_all"
 ])

--- a/testsuites/syncgateway/functional/tests/test_sync.py
+++ b/testsuites/syncgateway/functional/tests/test_sync.py
@@ -24,12 +24,11 @@ from utilities.cluster_config_utils import persist_cluster_config_environment_pr
 
 
 @pytest.mark.syncgateway
-@pytest.mark.sync
 @pytest.mark.basicauth
-@pytest.mark.channel
 @pytest.mark.access
 @pytest.mark.bulkops
-@pytest.mark.changes
+@pytest.mark.sync
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, num_docs", [
     ("custom_sync/grant_access_one", 10),
 ])
@@ -106,8 +105,7 @@ def test_issue_1524(params_from_base_test_setup, sg_conf_name, num_docs):
 @pytest.mark.sync
 @pytest.mark.access
 @pytest.mark.basicauth
-@pytest.mark.channel
-@pytest.mark.changes
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
     ("custom_sync/sync_gateway_custom_sync_access_sanity", True)
 ])
@@ -159,10 +157,9 @@ def test_sync_access_sanity(params_from_base_test_setup, sg_conf_name, x509_cert
 
 @pytest.mark.syncgateway
 @pytest.mark.sync
-@pytest.mark.channel
 @pytest.mark.basicauth
 @pytest.mark.bulkops
-@pytest.mark.changes
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", [
     "custom_sync/sync_gateway_custom_sync_channel_sanity"
 ])
@@ -228,11 +225,10 @@ def test_sync_channel_sanity(params_from_base_test_setup, sg_conf_name):
 @pytest.mark.syncgateway
 @pytest.mark.sync
 @pytest.mark.role
-@pytest.mark.channel
 @pytest.mark.access
 @pytest.mark.basicauth
 @pytest.mark.bulkops
-@pytest.mark.changes
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", [
     "custom_sync/sync_gateway_custom_sync_role_sanity"
 ])
@@ -304,11 +300,10 @@ def test_sync_role_sanity(params_from_base_test_setup, sg_conf_name):
 @pytest.mark.sanity
 @pytest.mark.syncgateway
 @pytest.mark.sync
-@pytest.mark.channel
 @pytest.mark.access
 @pytest.mark.basicauth
 @pytest.mark.bulkops
-@pytest.mark.changes
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", [
     "custom_sync/sync_gateway_custom_sync_one"
 ])
@@ -357,10 +352,9 @@ def test_sync_sanity(params_from_base_test_setup, sg_conf_name):
 @pytest.mark.syncgateway
 @pytest.mark.sync
 @pytest.mark.basicauth
-@pytest.mark.channel
 @pytest.mark.access
 @pytest.mark.bulkops
-@pytest.mark.changes
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", [
     "custom_sync/sync_gateway_custom_sync_one"
 ])
@@ -410,9 +404,8 @@ def test_sync_sanity_backfill(params_from_base_test_setup, sg_conf_name):
 @pytest.mark.sync
 @pytest.mark.role
 @pytest.mark.basicauth
-@pytest.mark.channel
 @pytest.mark.bulkops
-@pytest.mark.changes
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name", [
     "custom_sync/sync_gateway_custom_sync_require_roles"
 ])
@@ -513,6 +506,8 @@ def test_sync_require_roles(params_from_base_test_setup, sg_conf_name):
 
 
 @pytest.mark.syncgateway
+@pytest.mark.oscertify
+@pytest.mark.sync
 @pytest.mark.parametrize('sg_conf_name', [
     'sync_gateway_default_functional_tests'
 ])
@@ -555,6 +550,8 @@ def test_sync_20mb(params_from_base_test_setup, sg_conf_name):
 
 
 @pytest.mark.syncgateway
+@pytest.mark.oscertify
+@pytest.mark.sync
 @pytest.mark.parametrize('sg_conf_name', [
     'custom_sync/sync_gateway_custom_sync_olddoc_delete_check'
 ])

--- a/testsuites/syncgateway/functional/tests/test_ttl.py
+++ b/testsuites/syncgateway/functional/tests/test_ttl.py
@@ -53,9 +53,8 @@ Test suite for Sync Gateway's expiry feature.
 @pytest.mark.syncgateway
 @pytest.mark.ttl
 @pytest.mark.session
-@pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name", [
-    pytest.param("sync_gateway_default_functional_tests", marks=pytest.mark.sanity),
+    pytest.param("sync_gateway_default_functional_tests", marks=[pytest.mark.sanity, pytest.mark.oscertify]),
     ("sync_gateway_default_functional_tests_no_port"),
     ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210")
 ])
@@ -165,11 +164,10 @@ def test_numeric_expiry_as_ttl(params_from_base_test_setup, sg_conf_name):
 @pytest.mark.syncgateway
 @pytest.mark.ttl
 @pytest.mark.session
-@pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name", [
-    "sync_gateway_default_functional_tests",
-    "sync_gateway_default_functional_tests_no_port",
-    "sync_gateway_default_functional_tests_couchbase_protocol_withport_11210"
+    ("sync_gateway_default_functional_tests"),
+    ("sync_gateway_default_functional_tests_no_port"),
+    pytest.param("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", marks=pytest.mark.oscertify)
 ])
 def test_string_expiry_as_ttl(params_from_base_test_setup, sg_conf_name):
     """
@@ -275,11 +273,10 @@ def test_string_expiry_as_ttl(params_from_base_test_setup, sg_conf_name):
 @pytest.mark.syncgateway
 @pytest.mark.ttl
 @pytest.mark.session
-@pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name", [
-    "sync_gateway_default_functional_tests",
-    "sync_gateway_default_functional_tests_no_port",
-    "sync_gateway_default_functional_tests_couchbase_protocol_withport_11210"
+    pytest.param("sync_gateway_default_functional_tests", marks=pytest.mark.oscertify),
+    ("sync_gateway_default_functional_tests_no_port"),
+    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210")
 ])
 def test_numeric_expiry_as_unix_date(params_from_base_test_setup, sg_conf_name):
     """
@@ -389,11 +386,10 @@ def test_numeric_expiry_as_unix_date(params_from_base_test_setup, sg_conf_name):
 @pytest.mark.syncgateway
 @pytest.mark.ttl
 @pytest.mark.session
-@pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name", [
-    "sync_gateway_default_functional_tests",
-    "sync_gateway_default_functional_tests_no_port",
-    "sync_gateway_default_functional_tests_couchbase_protocol_withport_11210"
+    ("sync_gateway_default_functional_tests"),
+    ("sync_gateway_default_functional_tests_no_port"),
+    pytest.param("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", marks=pytest.mark.oscertify)
 ])
 def test_string_expiry_as_unix_date(params_from_base_test_setup, sg_conf_name):
     """
@@ -507,11 +503,10 @@ def test_string_expiry_as_unix_date(params_from_base_test_setup, sg_conf_name):
 @pytest.mark.syncgateway
 @pytest.mark.ttl
 @pytest.mark.session
-@pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name", [
-    "sync_gateway_default_functional_tests",
-    "sync_gateway_default_functional_tests_no_port",
-    "sync_gateway_default_functional_tests_couchbase_protocol_withport_11210"
+    ("sync_gateway_default_functional_tests"),
+    pytest.param("sync_gateway_default_functional_tests_no_port", marks=pytest.mark.oscertify),
+    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210")
 ])
 def test_string_expiry_as_iso_8601_date(params_from_base_test_setup, sg_conf_name):
     """
@@ -621,11 +616,10 @@ def test_string_expiry_as_iso_8601_date(params_from_base_test_setup, sg_conf_nam
 @pytest.mark.syncgateway
 @pytest.mark.ttl
 @pytest.mark.session
-@pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name", [
-    "sync_gateway_default_functional_tests",
-    "sync_gateway_default_functional_tests_no_port",
-    "sync_gateway_default_functional_tests_couchbase_protocol_withport_11210"
+    pytest.param("sync_gateway_default_functional_tests", marks=pytest.mark.oscertify)
+    ("sync_gateway_default_functional_tests_no_port"),
+    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210")
 ])
 def test_removing_expiry(params_from_base_test_setup, sg_conf_name):
     """
@@ -703,11 +697,10 @@ def test_removing_expiry(params_from_base_test_setup, sg_conf_name):
 @pytest.mark.syncgateway
 @pytest.mark.ttl
 @pytest.mark.session
-@pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name", [
-    "sync_gateway_default_functional_tests",
-    "sync_gateway_default_functional_tests_no_port",
-    "sync_gateway_default_functional_tests_couchbase_protocol_withport_11210"
+    ("sync_gateway_default_functional_tests"),
+    ("sync_gateway_default_functional_tests_no_port"),
+    pytest.param("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", marks=pytest.mark.oscertify)
 ])
 def test_rolling_ttl_expires(params_from_base_test_setup, sg_conf_name):
     """
@@ -815,11 +808,10 @@ def test_rolling_ttl_expires(params_from_base_test_setup, sg_conf_name):
 @pytest.mark.syncgateway
 @pytest.mark.ttl
 @pytest.mark.session
-@pytest.mark.channel
 @pytest.mark.parametrize("sg_conf_name", [
-    "sync_gateway_default_functional_tests",
-    "sync_gateway_default_functional_tests_no_port",
-    "sync_gateway_default_functional_tests_couchbase_protocol_withport_11210"
+    pytest.param("sync_gateway_default_functional_tests", marks=pytest.mark.oscertify),
+    ("sync_gateway_default_functional_tests_no_port"),
+    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210")
 ])
 def test_rolling_ttl_remove_expirary(params_from_base_test_setup, sg_conf_name):
     """
@@ -927,12 +919,11 @@ def test_rolling_ttl_remove_expirary(params_from_base_test_setup, sg_conf_name):
 @pytest.mark.syncgateway
 @pytest.mark.ttl
 @pytest.mark.session
-@pytest.mark.channel
 @pytest.mark.bulkops
 @pytest.mark.parametrize("sg_conf_name", [
-    "sync_gateway_default_functional_tests",
-    "sync_gateway_default_functional_tests_no_port",
-    "sync_gateway_default_functional_tests_couchbase_protocol_withport_11210"
+    pytest.param("sync_gateway_default_functional_tests", marks=pytest.mark.oscertify),
+    ("sync_gateway_default_functional_tests_no_port"),
+    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210")
 ])
 def test_setting_expiry_in_bulk_docs(params_from_base_test_setup, sg_conf_name):
     """

--- a/testsuites/syncgateway/functional/tests/test_ttl.py
+++ b/testsuites/syncgateway/functional/tests/test_ttl.py
@@ -617,7 +617,7 @@ def test_string_expiry_as_iso_8601_date(params_from_base_test_setup, sg_conf_nam
 @pytest.mark.ttl
 @pytest.mark.session
 @pytest.mark.parametrize("sg_conf_name", [
-    pytest.param("sync_gateway_default_functional_tests", marks=pytest.mark.oscertify)
+    pytest.param("sync_gateway_default_functional_tests", marks=pytest.mark.oscertify),
     ("sync_gateway_default_functional_tests_no_port"),
     ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210")
 ])

--- a/testsuites/syncgateway/functional/tests/test_user_views.py
+++ b/testsuites/syncgateway/functional/tests/test_user_views.py
@@ -18,9 +18,9 @@ from utilities.cluster_config_utils import persist_cluster_config_environment_pr
 @pytest.mark.views
 @pytest.mark.role
 @pytest.mark.channel
-@pytest.mark.changes
 @pytest.mark.session
 @pytest.mark.attachments
+@pytest.mark.oscertify
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
     ("user_views/user_views", False),
 ])

--- a/testsuites/syncgateway/functional/tests/test_users_channels.py
+++ b/testsuites/syncgateway/functional/tests/test_users_channels.py
@@ -17,10 +17,9 @@ from keywords.utils import log_r
 @pytest.mark.syncgateway
 @pytest.mark.basicauth
 @pytest.mark.channel
-@pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name, x509_cert_auth", [
     ("sync_gateway_default_functional_tests", True),
-    pytest.param("sync_gateway_default_functional_tests_no_port", False, marks=pytest.mark.sanity),
+    pytest.param("sync_gateway_default_functional_tests_no_port", False, marks=[pytest.mark.sanity, pytest.mark.oscertify]),
     ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", False)
 ])
 def test_multiple_users_multiple_channels(params_from_base_test_setup, sg_conf_name, x509_cert_auth):
@@ -96,11 +95,10 @@ def test_multiple_users_multiple_channels(params_from_base_test_setup, sg_conf_n
 @pytest.mark.basicauth
 @pytest.mark.channel
 @pytest.mark.bulkops
-@pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name", [
-    "sync_gateway_default_functional_tests",
-    "sync_gateway_default_functional_tests_no_port",
-    "sync_gateway_default_functional_tests_couchbase_protocol_withport_11210"
+    ("sync_gateway_default_functional_tests"),
+    ("sync_gateway_default_functional_tests_no_port"),
+    pytest.param("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", marks=pytest.mark.oscertify)
 ])
 def test_muliple_users_single_channel(params_from_base_test_setup, sg_conf_name):
 
@@ -164,11 +162,10 @@ def test_muliple_users_single_channel(params_from_base_test_setup, sg_conf_name)
 @pytest.mark.basicauth
 @pytest.mark.channel
 @pytest.mark.bulkops
-@pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name", [
-    "sync_gateway_default_functional_tests",
-    "sync_gateway_default_functional_tests_no_port",
-    "sync_gateway_default_functional_tests_couchbase_protocol_withport_11210"
+    ("sync_gateway_default_functional_tests"),
+    pytest.param("sync_gateway_default_functional_tests_no_port", marks=pytest.mark.oscertify),
+    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210")
 ])
 def test_single_user_multiple_channels(params_from_base_test_setup, sg_conf_name):
 
@@ -224,11 +221,10 @@ def test_single_user_multiple_channels(params_from_base_test_setup, sg_conf_name
 @pytest.mark.syncgateway
 @pytest.mark.basicauth
 @pytest.mark.channel
-@pytest.mark.changes
 @pytest.mark.parametrize("sg_conf_name", [
-    "sync_gateway_default_functional_tests",
-    "sync_gateway_default_functional_tests_no_port",
-    "sync_gateway_default_functional_tests_couchbase_protocol_withport_11210"
+    pytest.param("sync_gateway_default_functional_tests", marks=pytest.mark.oscertify),
+    ("sync_gateway_default_functional_tests_no_port"),
+    ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210")
 ])
 def test_single_user_single_channel(params_from_base_test_setup, sg_conf_name):
 
@@ -285,6 +281,8 @@ def test_single_user_single_channel(params_from_base_test_setup, sg_conf_name):
 
 
 @pytest.mark.syncgateway
+@pytest.mark.channel
+@pytest.mark.oscertify
 def test_create_invalid_email(params_from_base_test_setup):
     """
     @summary

--- a/testsuites/syncgateway/functional/tests/test_views.py
+++ b/testsuites/syncgateway/functional/tests/test_views.py
@@ -16,8 +16,9 @@ from utilities.cluster_config_utils import get_sg_version, persist_cluster_confi
 @pytest.mark.syncgateway
 @pytest.mark.views
 @pytest.mark.session
+@pytest.mark.basicsgw
 @pytest.mark.parametrize('sg_conf_name, validate_changes_before_restart, x509_cert_auth', [
-    pytest.param('sync_gateway_default_functional_tests', False, False, marks=pytest.mark.sanity),
+    pytest.param('sync_gateway_default_functional_tests', False, False, marks=[pytest.mark.sanity, pytest.mark.oscertify]),
     ('sync_gateway_default_functional_tests', True, True),
     ('sync_gateway_default_functional_tests_no_port', False, True),
     ('sync_gateway_default_functional_tests_no_port', True, False)

--- a/testsuites/syncgateway/functional/tests/test_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_webhooks.py
@@ -18,12 +18,11 @@ from utilities.cluster_config_utils import persist_cluster_config_environment_pr
 
 
 @pytest.mark.syncgateway
-@pytest.mark.onlineoffline
 @pytest.mark.webhooks
 @pytest.mark.basicauth
-@pytest.mark.channel
+@pytest.mark.basicsgw
 @pytest.mark.parametrize("sg_conf_name, num_users, num_channels, num_docs, num_revisions, x509_cert_auth", [
-    pytest.param("webhooks/webhook_offline", 5, 1, 1, 2, True, marks=pytest.mark.sanity),
+    pytest.param("webhooks/webhook_offline", 5, 1, 1, 2, True, marks=[pytest.mark.sanity, pytest.mark.oscertify]),
     ("webhooks/webhook_offline", 5, 1, 1, 2, False)
 ])
 def test_webhooks(params_from_base_test_setup, sg_conf_name, num_users, num_channels, num_docs,
@@ -98,9 +97,10 @@ def test_webhooks(params_from_base_test_setup, sg_conf_name, num_users, num_chan
 
 
 @pytest.mark.syncgateway
-@pytest.mark.xattrs
 @pytest.mark.session
 @pytest.mark.webhooks
+@pytest.mark.basicsgw
+@pytest.mark.oscertify
 @pytest.mark.parametrize('sg_conf_name, filtered', [
     ('webhooks/webhook', False),
     ('webhooks/webhook_filter', True)

--- a/testsuites/syncgateway/functional/tests/test_xattrs.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs.py
@@ -1,5 +1,3 @@
-
-
 import random
 import time
 import json
@@ -36,6 +34,7 @@ SDK_OP_SLEEP = 0.05
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
 @pytest.mark.session
+@pytest.mark.oscertify
 @pytest.mark.parametrize('sg_conf_name', [
     'xattrs/old_doc'
 ])
@@ -176,11 +175,10 @@ def test_olddoc_nil(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
-@pytest.mark.changes
 @pytest.mark.session
 @pytest.mark.parametrize('sg_conf_name, number_users, number_docs_per_user, number_of_updates_per_user', [
     ('xattrs/no_import', 1, 1, 10),
-    ('xattrs/no_import', 100, 10, 10),
+    pytest.param('xattrs/no_import', 100, 10, 10, marks=pytest.mark.oscertify),
     ('xattrs/no_import', 10, 1000, 10)
     # ('xattrs/no_import', 100, 1000, 2)
 ])
@@ -316,6 +314,7 @@ def test_on_demand_doc_processing(params_from_base_test_setup, sg_conf_name, num
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
 @pytest.mark.session
+@pytest.mark.oscertify
 @pytest.mark.parametrize('sg_conf_name, x509_cert_auth', [
     ('xattrs/no_import', False)
 ])
@@ -425,7 +424,7 @@ def test_on_demand_import_of_external_updates(params_from_base_test_setup, sg_co
 @pytest.mark.xattrs
 @pytest.mark.session
 @pytest.mark.parametrize('sg_conf_name, x509_cert_auth', [
-    pytest.param('sync_gateway_default_functional_tests', True, marks=pytest.mark.sanity),
+    pytest.param('sync_gateway_default_functional_tests', True, marks=[pytest.mark.sanity, pytest.mark.oscertify]),
     ('sync_gateway_default_functional_tests_no_port', False),
     ("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", False)
 ])
@@ -583,9 +582,9 @@ def test_offline_processing_of_external_updates(params_from_base_test_setup, sg_
 @pytest.mark.xattrs
 @pytest.mark.session
 @pytest.mark.parametrize('sg_conf_name', [
-    'sync_gateway_default_functional_tests',
-    'sync_gateway_default_functional_tests_no_port',
-    "sync_gateway_default_functional_tests_couchbase_protocol_withport_11210"
+    ('sync_gateway_default_functional_tests'),
+    ('sync_gateway_default_functional_tests_no_port'),
+    pytest.param("sync_gateway_default_functional_tests_couchbase_protocol_withport_11210", marks=pytest.mark.oscertify)
 ])
 def test_large_initial_import(params_from_base_test_setup, sg_conf_name):
     """ Regression test for https://github.com/couchbase/sync_gateway/issues/2537
@@ -692,12 +691,11 @@ def test_large_initial_import(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
-@pytest.mark.changes
 @pytest.mark.session
 @pytest.mark.parametrize('sg_conf_name, use_multiple_channels, x509_cert_auth', [
     ('sync_gateway_default_functional_tests', False, True),
     ('sync_gateway_default_functional_tests', True, False),
-    ('sync_gateway_default_functional_tests_no_port', False, True),
+    pytest.param('sync_gateway_default_functional_tests_no_port', False, True, marks=pytest.mark.oscertify),
     ('sync_gateway_default_functional_tests_no_port', True, False)
 ])
 def test_purge(params_from_base_test_setup, sg_conf_name, use_multiple_channels, x509_cert_auth):
@@ -917,12 +915,11 @@ def test_purge(params_from_base_test_setup, sg_conf_name, use_multiple_channels,
 
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
-@pytest.mark.changes
 @pytest.mark.session
 @pytest.mark.parametrize('sg_conf_name', [
-    'sync_gateway_default_functional_tests',
-    'sync_gateway_default_functional_tests_no_port',
-    'sync_gateway_default_functional_tests_couchbase_protocol_withport_11210'
+    pytest.param('sync_gateway_default_functional_tests', marks=pytest.mark.oscertify),
+    ('sync_gateway_default_functional_tests_no_port'),
+    ('sync_gateway_default_functional_tests_couchbase_protocol_withport_11210')
 ])
 def test_sdk_does_not_see_sync_meta(params_from_base_test_setup, sg_conf_name):
     """
@@ -1040,12 +1037,11 @@ def test_sdk_does_not_see_sync_meta(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
-@pytest.mark.changes
 @pytest.mark.session
 @pytest.mark.parametrize('sg_conf_name', [
-    'sync_gateway_default_functional_tests',
-    'sync_gateway_default_functional_tests_no_port',
-    'sync_gateway_default_functional_tests_couchbase_protocol_withport_11210'
+    ('sync_gateway_default_functional_tests'),
+    pytest.param('sync_gateway_default_functional_tests_no_port', marks=pytest.mark.oscertify),
+    ('sync_gateway_default_functional_tests_couchbase_protocol_withport_11210')
 ])
 def test_sg_sdk_interop_unique_docs(params_from_base_test_setup, sg_conf_name):
     """
@@ -1268,7 +1264,6 @@ def test_sg_sdk_interop_unique_docs(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
-@pytest.mark.changes
 @pytest.mark.session
 @pytest.mark.parametrize(
     'sg_conf_name, number_docs_per_client, number_updates_per_doc_per_client',
@@ -1276,7 +1271,7 @@ def test_sg_sdk_interop_unique_docs(params_from_base_test_setup, sg_conf_name):
         ('sync_gateway_default_functional_tests', 10, 10),
         ('sync_gateway_default_functional_tests', 100, 10),
         ('sync_gateway_default_functional_tests_no_port', 100, 10),
-        ('sync_gateway_default_functional_tests', 10, 100),
+        pytest.param('sync_gateway_default_functional_tests', 10, 100, marks=pytest.mark.oscertify),
         ('sync_gateway_default_functional_tests_no_port', 10, 100),
         ('sync_gateway_default_functional_tests', 1, 1000)
     ]
@@ -1530,7 +1525,6 @@ def test_sg_sdk_interop_shared_docs(params_from_base_test_setup,
 
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
-@pytest.mark.changes
 @pytest.mark.session
 @pytest.mark.parametrize(
     'sg_conf_name, number_docs_per_client, number_updates_per_doc_per_client',
@@ -1538,7 +1532,7 @@ def test_sg_sdk_interop_shared_docs(params_from_base_test_setup,
         ('sync_gateway_default_functional_tests', 10, 10),
         ('sync_gateway_default_functional_tests', 100, 10),
         ('sync_gateway_default_functional_tests_no_port', 100, 10),
-        ('sync_gateway_default_functional_tests_couchbase_protocol_withport_11210', 100, 10),
+        pytest.param('sync_gateway_default_functional_tests_couchbase_protocol_withport_11210', 100, 10, marks=pytest.mark.oscertify),
         ('sync_gateway_default_functional_tests', 10, 100),
         ('sync_gateway_default_functional_tests_no_port', 10, 100),
         ('sync_gateway_default_functional_tests', 1, 1000)
@@ -2188,14 +2182,13 @@ def verify_doc_ids_in_sdk_get_multi(response, expected_number_docs, expected_ids
 
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
-@pytest.mark.changes
 @pytest.mark.session
 @pytest.mark.parametrize(
     'sg_conf_name, number_docs_per_client, number_updates_per_doc_per_client',
     [
         ('sync_gateway_default_functional_tests', 10, 10),
         ('sync_gateway_default_functional_tests', 100, 10),
-        ('sync_gateway_default_functional_tests_no_port', 100, 10),
+        pytest.param('sync_gateway_default_functional_tests_no_port', 100, 10, marks=pytest.mark.oscertify),
         ('sync_gateway_default_functional_tests_couchbase_protocol_withport_11210', 100, 10),
         ('sync_gateway_default_functional_tests_couchbase_protocol_withport_11210', 100, 10),
         ('sync_gateway_default_functional_tests', 10, 100),
@@ -2421,6 +2414,7 @@ def test_sg_sdk_interop_shared_updates_from_sg(params_from_base_test_setup,
 
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
+@pytest.mark.oscertify
 @pytest.mark.parametrize('sg_conf_name', [
     'sync_gateway_default_functional_tests'
 ])
@@ -2555,8 +2549,8 @@ def test_purge_and_view_compaction(params_from_base_test_setup, sg_conf_name):
 
 @pytest.mark.syncgateway
 @pytest.mark.xattrs
-@pytest.mark.changes
 @pytest.mark.session
+@pytest.mark.oscertify
 @pytest.mark.parametrize(
     'sg_conf_name, number_docs_per_client, number_updates_per_doc_per_client',
     [


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Added oscertify tags and provided tags to run tests as components
- cleaned up overlapping tags and tagged oscertify only one of the parameter for each test

