### PR TITLE
Fix/mac remote support and nginx cleanup

### DIFF
--- a/libraries/provision/ansible/playbooks/install-nginx.yml
+++ b/libraries/provision/ansible/playbooks/install-nginx.yml
@@ -8,7 +8,7 @@
 
   tasks:
   - name: SYNC-GATEWAY | kill sync-gateway process
-    shell: lsof -n -i:4984 | grep LISTEN | awk '{ print $2 }' | uniq | xargs kill -9
+    shell: netstat -ano -p | grep "4984" | awk '{print $7}' | cut -f 1 -d "/" | xargs kill -9
 
   - name: epel-release | install epel-release for nginx
     yum: pkg=epel-release state=latest

--- a/libraries/provision/ansible/playbooks/install-nginx.yml
+++ b/libraries/provision/ansible/playbooks/install-nginx.yml
@@ -7,6 +7,9 @@
     upstream_sync_gatways_admin:
 
   tasks:
+  - name: SYNC-GATEWAY | kill sync-gateway process
+    shell: lsof -n -i:4984 | grep LISTEN | awk '{ print $2 }' | uniq | xargs kill -9
+
   - name: epel-release | install epel-release for nginx
     yum: pkg=epel-release state=latest
 

--- a/libraries/utilities/generate_clusters_from_pool.py
+++ b/libraries/utilities/generate_clusters_from_pool.py
@@ -366,8 +366,9 @@ def write_config(config, pool_file, use_docker, sg_windows, sg_accel_windows, sg
 
         if sg_platform.lower() == "macos":
             f.write("\n\n[sync_gateways:vars]\n")
-            f.write("ansible_connection=local\n")
-            f.write("ansible_become_pass=macOSFakePassword\n")
+            f.write("ansible_user=MacOSFakeUser\n")
+            f.write("ansible_password=MacOSFakePassword\n")
+            f.write("ansible_sudo_pass=MacOSFakePassword\n")
 
         if sg_windows:
             f.write("\n\n[sync_gateways:vars]\n")

--- a/libraries/utilities/generate_clusters_from_pool.py
+++ b/libraries/utilities/generate_clusters_from_pool.py
@@ -385,7 +385,7 @@ def write_config(config, pool_file, use_docker, sg_windows, sg_accel_windows, sg
             f.write("ansible_port=5986\n")
             f.write("ansible_connection=winrm\n")
             f.write("ansible_winrm_server_cert_validation=ignore\n")
-        
+
         # Add support for python3 in ansible
         if cbs_platform == "centos8":
             f.write("\n\n[couchbase_servers:vars]\n")


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- clean up SGW if it is running to avoid nginx set up failure
- Mac to run on remote node with username and password, this change will help to run topology tests

http://uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-upgrade/80/. - for SGW clean up for load balancer

http://uberjenkins.sc.couchbase.com:8080/view/os-certifications/job/Macos-sync-gateway-os-catalina-sanity-testing-withremotemac/11/. -> mac test with remote credentials 
