### PR TITLE
Adding support to rerun only failed tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,3 +60,4 @@ websocket-client==0.40.0
 wrapt==1.10.8
 xmltodict==0.10.2
 numpy==1.17.4
+pytest-rerunfailures==8.0


### PR DESCRIPTION
#### Fixes #.

- [ ] Ran `flake8`
- [ ] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:
Reruns only failed tests
-  http://uberjenkins.sc.couchbase.com:8080/job/CBLITE_Net-windows-TestSever-Funtional-tests/1277/
-http://uberjenkins.sc.couchbase.com:8080/job/CBLITE_Net-windows-TestSever-Funtional-tests/1277/artifact/results/report.html

#### Runs only failed tests  [ pytest --reruns 5 --reruns-delay 1 ]
#### Provision to rerun as many number of times we want
#### If needed we can specify at Individual test level also add reruns @pytest.mark.flaky(reruns=5, reruns_delay=2)

