### PR TITLE
added logic for unshare on cbl

### DIFF
--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
@@ -3360,6 +3360,10 @@ def test_doc_removal_from_channel(params_from_base_test_setup):
     assert cbl_ids[0] in sg_doc_ids, "doc A does not exist for the user"
     assert cbl_ids[1] not in sg_doc_ids, "doc B exist for the user"
 
+    # Verify user can only access doc A, but not doc B on CBL side too
+    cbl_doc_ids = db.getDocIds(cbl_db)
+    assert cbl_ids[1] not in cbl_doc_ids, "user on cbl still able to access the doc even after unshare"
+
 
 @pytest.mark.listener
 @pytest.mark.replication


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- added small logic to verify that unshared docs are not accessible to CBL


