### PR TITLE
Feature/p2p device type per client support

### DIFF
--- a/keywords/utils.py
+++ b/keywords/utils.py
@@ -443,9 +443,14 @@ def get_embedded_asset_file_path(cblite_platform, db, cbl_db, file_name):
         return "Files/{}".format(file_name)
 
 
-def set_device_enabled(run_on_device):
-    device_list = run_on_device.split(',')
+def set_device_enabled(run_on_device, list_size):
     device_enabled_list = []
+    if run_on_device is None:
+        for i in range(list_size):
+            device_enabled_list.append(False)
+        return device_enabled_list
+
+    device_list = run_on_device.split(',')
     for device in device_list:
         if device == "device":
             device_enabled_list.append(True)

--- a/keywords/utils.py
+++ b/keywords/utils.py
@@ -441,3 +441,15 @@ def get_embedded_asset_file_path(cblite_platform, db, cbl_db, file_name):
         return "{}\\Files\\{}".format(app_dir, file_name)
     else:
         return "Files/{}".format(file_name)
+
+
+def set_device_enabled(run_on_device):
+    device_list = run_on_device.split(',')
+    device_enabled_list = []
+    for device in device_list:
+        if device == "device":
+            device_enabled_list.append(True)
+        else:
+            device_enabled_list.append(False)
+
+    return device_enabled_list

--- a/testsuites/CBLTester/p2p_tests/conftest.py
+++ b/testsuites/CBLTester/p2p_tests/conftest.py
@@ -95,7 +95,7 @@ def params_from_base_suite_setup(request):
     version_list = liteserv_versions.split(',')
     host_list = liteserv_hosts.split(',')
     port_list = liteserv_ports.split(',')
-    device_enabled_list = set_device_enabled(run_on_device)
+    device_enabled_list = set_device_enabled(run_on_device, len(platform_list))
 
     if len(platform_list) != len(version_list) != len(host_list) != len(port_list):
         raise Exception("Provide equal no. of Parameters for host, port, version and platforms")

--- a/testsuites/CBLTester/p2p_tests/conftest.py
+++ b/testsuites/CBLTester/p2p_tests/conftest.py
@@ -131,8 +131,10 @@ def params_from_base_suite_setup(request):
 
             # Install TestServer app
             if device_enabled and (platform == "ios" or platform == "android"):
+                log_info("install on device")
                 testserver.install_device()
             else:
+                log_info("install on emulator")
                 testserver.install()
 
         testserver_list.append(testserver)
@@ -153,9 +155,11 @@ def params_from_base_suite_setup(request):
                 log_info("Starting TestServer...")
                 test_name_cp = test_name.replace("/", "-")
                 if device_enabled:
+                    log_info("start on device")
                     testserver.start_device("{}/logs/{}-{}-{}.txt".format(RESULTS_DIR, type(testserver).__name__,
                                                                           test_name_cp, datetime.datetime.now()))
                 else:
+                    log_info("start on emulator")
                     testserver.start("{}/logs/{}-{}-{}.txt".format(RESULTS_DIR, type(testserver).__name__, test_name_cp,
                                                                    datetime.datetime.now()))
         for base_url, i in zip(base_url_list, list(range(len(base_url_list)))):
@@ -266,8 +270,10 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
                                                              test_name_cp,
                                                              datetime.datetime.now())
                 if device_enabled:
+                    log_info("start on device")
                     testserver.start_device(log_filename)
                 else:
+                    log_info("start on emulator")
                     testserver.start(log_filename)
 
         for base_url, i in zip(base_url_list, list(range(len(base_url_list)))):

--- a/testsuites/CBLTester/p2p_tests/test_peer_to_peer.py
+++ b/testsuites/CBLTester/p2p_tests/test_peer_to_peer.py
@@ -198,7 +198,6 @@ def test_peer_to_peer_concurrent_replication(params_from_base_test_setup, server
     (100, True, "push", "MessageEndPoint"),
 ])
 def test_peer_to_peer_oneClient_toManyServers(params_from_base_test_setup, num_of_docs, continuous, replicator_type, endPointType):
-    pytest.skip('Setup is unavailable for 1-many or many-1 peer to peer test, will rollback later')
     """
         @summary:
         1. Create docs on client.
@@ -266,7 +265,6 @@ def test_peer_to_peer_oneClient_toManyServers(params_from_base_test_setup, num_o
     (100, True, "pull", "URLEndPoint"),
 ])
 def test_peer_to_peer_oneServer_toManyClients(params_from_base_test_setup, server_setup, num_of_docs, continuous, replicator_type, endPointType):
-    pytest.skip('Setup is unavailable for 1-many or many-1 peer to peer test, will rollback later')
     """
         @summary:
         1. Create docs on server.


### PR DESCRIPTION
#### Fixes #. cm-261 add device type per client

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- added a util function to convert comma separate device/emulator type to on-device true/false
- added run-on-device per testserver client in loop of conftest setup

