### PR TITLE
Fix/cm 485 close db live query failure

### DIFF
--- a/CBLClient/Query.py
+++ b/CBLClient/Query.py
@@ -447,11 +447,11 @@ class Query(object):
         args.setMemoryPointer("changeListener", change_listener)
         return self._client.invokeMethod("query_removeChangeListener", args)
 
-    def query_select_all(self, database):
+    def query_selectAll(self, database):
         args = Args()
         args.setMemoryPointer("database", database)
 
-        return self._client.invokeMethod("query_select_all", args)
+        return self._client.invokeMethod("query_selectAll", args)
 
     def query_get_live_query_delay_time(self, database):
         args = Args()

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_database.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_database.py
@@ -476,7 +476,7 @@ def test_db_close_on_active_replicator_and_live_query(params_from_base_test_setu
     sg_admin_url = params_from_base_test_setup["sg_admin_url"]
     sg_blip_url = params_from_base_test_setup["target_url"]
 
-    pytest.skip('skip this test due to issue CM-485')
+    # pytest.skip('skip this test due to issue CM-485')
 
     if liteserv_version < "2.8.0":
         pytest.skip('This test supports for a feature from hydrogen(2.8.0)')
@@ -511,6 +511,11 @@ def test_db_close_on_active_replicator_and_live_query(params_from_base_test_setu
     sg_client.create_user(sg_admin_url, sg_db, username2, password=password, channels=channel2)
     cookie2, session_id2 = sg_client.create_session(sg_admin_url, sg_db, username2)
 
+    # 3. register a live query to the cbl db
+    qy = Query(base_url)
+    query = qy.query_selectAll(cbl_db)
+    query_listener = qy.addChangeListener(query)
+
     # 2. start 2 replicators on 2 different channels, set all continous to True
     replicator = Replication(base_url)
     authenticator = Authenticator(base_url)
@@ -521,11 +526,6 @@ def test_db_close_on_active_replicator_and_live_query(params_from_base_test_setu
     replicator_authenticator2 = authenticator.authentication(session_id2, cookie2, authentication_type="session")
     repl2 = replicator.configure_and_replicate(source_db=cbl_db, replicator_authenticator=replicator_authenticator2, target_url=sg_blip_url,
                                                replication_type="push_pull", continuous=True, channels=channel2, wait_until_idle=False)
-
-    # 3. register a live query to the cbl db
-    qy = Query(base_url)
-    query = qy.query_select_all(cbl_db)
-    query_listener = qy.addChangeListener(query)
 
     log_info(replicator.getActivitylevel(repl1))
     log_info(replicator.getActivitylevel(repl2))

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_database.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_database.py
@@ -476,8 +476,6 @@ def test_db_close_on_active_replicator_and_live_query(params_from_base_test_setu
     sg_admin_url = params_from_base_test_setup["sg_admin_url"]
     sg_blip_url = params_from_base_test_setup["target_url"]
 
-    # pytest.skip('skip this test due to issue CM-485')
-
     if liteserv_version < "2.8.0":
         pytest.skip('This test supports for a feature from hydrogen(2.8.0)')
 
@@ -511,11 +509,6 @@ def test_db_close_on_active_replicator_and_live_query(params_from_base_test_setu
     sg_client.create_user(sg_admin_url, sg_db, username2, password=password, channels=channel2)
     cookie2, session_id2 = sg_client.create_session(sg_admin_url, sg_db, username2)
 
-    # 3. register a live query to the cbl db
-    qy = Query(base_url)
-    query = qy.query_selectAll(cbl_db)
-    query_listener = qy.addChangeListener(query)
-
     # 2. start 2 replicators on 2 different channels, set all continous to True
     replicator = Replication(base_url)
     authenticator = Authenticator(base_url)
@@ -526,6 +519,11 @@ def test_db_close_on_active_replicator_and_live_query(params_from_base_test_setu
     replicator_authenticator2 = authenticator.authentication(session_id2, cookie2, authentication_type="session")
     repl2 = replicator.configure_and_replicate(source_db=cbl_db, replicator_authenticator=replicator_authenticator2, target_url=sg_blip_url,
                                                replication_type="push_pull", continuous=True, channels=channel2, wait_until_idle=False)
+
+    # 3. register a live query to the cbl db
+    qy = Query(base_url)
+    query = qy.query_selectAll(cbl_db)
+    query_listener = qy.addChangeListener(query)
 
     log_info(replicator.getActivitylevel(repl1))
     log_info(replicator.getActivitylevel(repl2))
@@ -646,7 +644,6 @@ def test_db_delete_on_active_replicator_and_live_query(params_from_base_test_set
     sg_admin_url = params_from_base_test_setup["sg_admin_url"]
     sg_blip_url = params_from_base_test_setup["target_url"]
 
-    pytest.skip('skip this test due to issue CM-485')
     if liteserv_version < "2.8.0":
         pytest.skip('This test supports for a feature from hydrogen(2.8.0)')
 
@@ -693,7 +690,7 @@ def test_db_delete_on_active_replicator_and_live_query(params_from_base_test_set
 
     # 3. register a live query to the cbl db
     qy = Query(base_url)
-    query = qy.query_select_all(cbl_db)
+    query = qy.query_selectAll(cbl_db)
     query_listener = qy.addChangeListener(query)
 
     log_info(replicator.getActivitylevel(repl1))


### PR DESCRIPTION
#### Fixes #. cm-485 close or delete db live query failure

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- lift the skip command
- fixed the method name, underscore cause an issue to get mapped

