### PR TITLE
Fix/cm 470 log file collect failure

### DIFF
--- a/testsuites/CBLTester/CBL_Functional_tests/conftest.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/conftest.py
@@ -515,10 +515,13 @@ def params_from_base_suite_setup(request):
                 failed_test_list.append(test.rep_call.nodeid)
         zip_data = suite_cbllog.get_logs_in_zip()
         suite_log_zip_file = "Suite_test_log_{}.zip".format(str(time.time()))
-        log_info("Log file for failed Suite tests is: {}".format(suite_log_zip_file))
-        with open(suite_log_zip_file, 'wb') as fh:
-            fh.write(zip_data.encode())
-            fh.close()
+        if os.path.exists(suite_log_zip_file):
+            log_info("Log file for failed Suite tests is: {}".format(suite_log_zip_file))
+            with open(suite_log_zip_file, 'wb') as fh:
+                fh.write(zip_data.encode())
+                fh.close()
+        else:
+            log_info("Cannot find log file for failed Suite tests")
 
     if create_db_per_suite:
         # Delete CBL database
@@ -682,10 +685,13 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
             os.mkdir(log_directory)
         test_log_zip_file = "{}_{}.zip".format(test_id.split("::")[-1], str(time.time()))
         test_log = os.path.join(log_directory, test_log_zip_file)
-        log_info("Log file for failed test is: {}".format(test_log_zip_file))
-        with open(test_log, 'wb') as fh:
-            fh.write(zip_data.encode())
-            fh.close()
+        if os.path.exists(test_log):
+            log_info("Log file for failed test is: {}".format(test_log_zip_file))
+            with open(test_log, 'wb') as fh:
+                fh.write(zip_data.encode())
+                fh.close()
+        else:
+            log_info("Cannot find log file for failed test")
 
     log_info("Tearing down test")
     if create_db_per_test:


### PR DESCRIPTION
#### Fixes #. sometimes logs are not generated, open log file will cause post run failure. the fix will prevent test fail twice

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- added file exist condition check before opening.


