### PR TITLE
add java support on macOS automation

### DIFF
--- a/keywords/TestServerJava.py
+++ b/keywords/TestServerJava.py
@@ -139,6 +139,13 @@ class TestServerJava(TestServerBase):
             status = self.ansible_runner.run_ansible_playbook("manage-testserver-java-desktop-msft.yml", extra_vars={
                 "service_status": "started"
             })
+        elif self.platform == "java-macosx":
+            # install jar file as a daemon service on macOS and start
+            status = self.ansible_runner.run_ansible_playbook("install-testserver-java-desktop-macos.yml", extra_vars={
+                "package_name": self.package_name,
+                "java_home": os.environ["JAVA_HOME"],
+                "jsvc_home": os.environ["JSVC_HOME"]
+            })
         else:
             # install jar file as a daemon service on non-Windows environment and start
             status = self.ansible_runner.run_ansible_playbook("install-testserver-java-desktop.yml", extra_vars={
@@ -158,6 +165,14 @@ class TestServerJava(TestServerBase):
             # stop TestServerJava Windows Service
             status = self.ansible_runner.run_ansible_playbook("manage-testserver-java-desktop-msft.yml", extra_vars={
                 "service_status": "stopped"
+            })
+        elif self.platform == "java-macosx":
+            # stop TestServerJava Daemon Service
+            status = self.ansible_runner.run_ansible_playbook("manage-testserver-java-desktop-macos.yml", extra_vars={
+                "service_status": "stop",
+                "package_name": self.package_name,
+                "java_home": os.environ["JAVA_HOME"],
+                "jsvc_home": os.environ["JSVC_HOME"]
             })
         else:
             # stop TestServerJava Daemon Service

--- a/keywords/TestServerJavaWS.py
+++ b/keywords/TestServerJavaWS.py
@@ -132,6 +132,13 @@ class TestServerJavaWS(TestServerBase):
                 "core_package_name": self.cbl_core_lib_name,
                 "build_name": self.build_name
             })
+        elif self.platform == "javaws-macosx":
+            # deploy jar/war files to Tomcat on macOS
+            status = self.ansible_runner.run_ansible_playbook("install-testserver-java-ws-macos.yml", extra_vars={
+                "war_package_name": self.package_name,
+                "core_package_name": self.cbl_core_lib_name,
+                "catalina_base": os.environ["CATALINA_BASE"]
+            })
         else:
             # deploy jar/war files to Tomcat on non-Windows
             status = self.ansible_runner.run_ansible_playbook("install-testserver-java-ws.yml", extra_vars={
@@ -152,6 +159,12 @@ class TestServerJavaWS(TestServerBase):
             # start Tomcat Windows Service
             status = self.ansible_runner.run_ansible_playbook("manage-testserver-java-ws-msft.yml", extra_vars={
                 "service_status": "started"
+            })
+        elif self.platform == "javaws-macosx":
+            # start Tomcat Server
+            status = self.ansible_runner.run_ansible_playbook("manage-testserver-java-ws-macos.yml", extra_vars={
+                "service_status": "start",
+                "catalina_base": os.environ["CATALINA_BASE"]
             })
         else:
             # start Tomcat Server
@@ -174,6 +187,12 @@ class TestServerJavaWS(TestServerBase):
             # stop Tomcat Windows Service
             status = self.ansible_runner.run_ansible_playbook("manage-testserver-java-ws-msft.yml", extra_vars={
                 "service_status": "stopped"
+            })
+        elif self.platform == "javaws-macosx":
+            # stop Tomcat Server
+            status = self.ansible_runner.run_ansible_playbook("manage-testserver-java-ws-macos.yml", extra_vars={
+                "service_status": "stop",
+                "catalina_base": os.environ["CATALINA_BASE"]
             })
         else:
             # stop Tomcat Server

--- a/libraries/provision/ansible/playbooks/install-testserver-java-desktop-macos.yml
+++ b/libraries/provision/ansible/playbooks/install-testserver-java-desktop-macos.yml
@@ -1,0 +1,41 @@
+- name: Install Testserver Java Desktop as Daemon Service
+  hosts: testserver
+  vars:
+    package_name:
+    java_home:
+    jsvc_home:
+  environment:
+    JAVA_HOME: "{{ java_home }}"
+    JSVC_HOME: "{{ jsvc_home }}"
+
+  tasks:
+  - debug: msg="JAVA_HOME location is {{ ansible_env.JAVA_HOME }}"
+  - debug: msg="JSVC_HOME location is {{ ansible_env.JSVC_HOME }}"
+
+  - name: Define the log output location
+    stat:
+      path: ~/javatestserver/output
+    register: output_dir
+
+  - name: create the log output directory if not exists
+    file:
+      path: ~/javatestserver/output
+      state: directory
+    when: output_dir.stat.exists == False
+
+  - name: Clean up any prerunning TestServer Java Daemon Service
+    shell: "ps aux | grep jsvc | awk '{print $2}' | xargs kill -9"
+    ignore_errors: yes
+
+  - name: Install and start TestServer Java Daemon Service
+    shell: "~/javatestserver/daemon_manager.sh start ~/javatestserver/{{ package_name }}.jar ~/javatestserver/output {{ ansible_env.JAVA_HOME }} {{ ansible_env.JSVC_HOME }} ~/javatestserver/"
+    when: ansible_distribution_major_version != "6"
+
+  - name: Install and start TestServer Java Daemon Service
+    shell: "~/javatestserver/daemon_manager.sh start ~/javatestserver/{{ package_name }}.jar ~/javatestserver/output {{ ansible_env.JAVA_HOME }} {{ ansible_env.JSVC_HOME }}"
+    when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "6"
+
+  - name: Wait for port 8080 to become open on the host, don't start checking for 2 seconds
+    wait_for:
+      port: 8080
+      delay: 2

--- a/libraries/provision/ansible/playbooks/install-testserver-java-ws-macos.yml
+++ b/libraries/provision/ansible/playbooks/install-testserver-java-ws-macos.yml
@@ -1,0 +1,81 @@
+- name: Install Testserver Java WebService to Tomcat
+  hosts: testserver
+  vars:
+    war_package_name:
+    core_package_name:
+    catalina_base:
+  environment:
+    CATALINA_BASE: "{{ catalina_base }}"
+
+  tasks:
+  - debug: msg="Tomcat home directory is {{ ansible_env.CATALINA_BASE }}"
+ 
+  - name: Stop Tomcat Service
+    shell: "{{ ansible_env.CATALINA_BASE }}/bin/catalina.sh stop 30 -force"
+    ignore_errors: yes
+
+  - name: Collect CouchbaseLite jar and supporting files
+    find:
+      paths: "{{ ansible_env.CATALINA_BASE }}/lib"
+      patterns: "couchbase-lite-java-ee-*.jar,json-*.jar,okhttp-*.jar,okio-*.jar"
+      recurse: True
+    register: cblite_jar
+
+  - name: Remove collected couchbase lite files
+    file:
+      path: "{{ item.path }}"
+      state: absent
+    with_items: "{{ cblite_jar.files }}"
+
+  - name: Remove TestServer webapp files
+    file:
+      path: "{{ ansible_env.CATALINA_BASE }}/webapps/ROOT"
+      state: absent
+
+  - name: Remove TestServer webapp files
+    file:
+      path: "{{ ansible_env.CATALINA_BASE }}/webapps/ROOT.war"
+      state: absent
+
+  - name: Remove TestServer log files and runtime libaries
+    file:
+      path: "{{ ansible_env.CATALINA_BASE }}/temp/TestServerTemp"
+      state: absent
+
+  - name: Remove TestServer runtime libaries
+    file:
+      path: "{{ ansible_env.CATALINA_BASE }}/temp/com.couchbase.lite.java"
+      state: absent
+
+  - name: Remove Tomcat logs
+    find:
+      paths: "{{ ansible_env.CATALINA_BASE }}/logs"
+      patterns: '*.*'
+      recurse: True
+    register: tomcat_log
+
+  - name: remove collected log files
+    file:
+      path: "{{ item.path }}"
+      state: absent
+    with_items: "{{ tomcat_log.files }}"
+
+  - name: Collect CouchbaseLite jar and supporting files in package to be installed
+    find:
+      paths: "~/javatestserver/{{ core_package_name }}/lib"
+      patterns: "*.jar"
+      recurse: True
+    register: new_cblite_jar
+
+  - name: Copy CouchbaseLite jar files to Tomcat
+    copy: 
+      src: "{{ item.path }}"
+      dest: "{{ ansible_env.CATALINA_BASE }}/lib"
+      remote_src: yes
+    with_items: "{{ new_cblite_jar.files }}"
+
+  - name: Copy TestServer war files to Tomcat
+    copy:
+      src: "~/javatestserver/{{ war_package_name }}.war"
+      dest: "{{ ansible_env.CATALINA_BASE }}/webapps/ROOT.war"
+      remote_src: yes

--- a/libraries/provision/ansible/playbooks/manage-testserver-java-desktop-macos.yml
+++ b/libraries/provision/ansible/playbooks/manage-testserver-java-desktop-macos.yml
@@ -1,0 +1,19 @@
+- name: Manage TestServer Java Desktop as Daemon Service
+  hosts: testserver
+  vars:
+    service_status:
+    package_name:
+    java_home:
+    jsvc_home:
+  environment:
+    JAVA_HOME: "{{ java_home }}"
+    JSVC_HOME: "{{ jsvc_home }}"
+
+  tasks:
+  - debug: msg="JAVA_HOME location is {{ ansible_env.JAVA_HOME }}"
+  - debug: msg="JSVC_HOME location is {{ ansible_env.JSVC_HOME }}"
+
+  - name: Stop TestServer Java Daemon Service
+    shell: "~/javatestserver/daemon_manager.sh stop ~/javatestserver/{{ package_name }}.jar ~/javatestserver/output {{ ansible_env.JAVA_HOME }} {{ ansible_env.JSVC_HOME }}"
+    when: "{{ service_status | search('stop') }}"
+    ignore_errors: yes

--- a/libraries/provision/ansible/playbooks/manage-testserver-java-ws-macos.yml
+++ b/libraries/provision/ansible/playbooks/manage-testserver-java-ws-macos.yml
@@ -1,0 +1,17 @@
+- name: Manage Tomcat which contains Testserver Java WebService
+  hosts: testserver
+  vars:
+    service_status:
+    catalina_base:
+  environment:
+    CATALINA_BASE: "{{ catalina_base }}"
+
+  tasks:
+  - name: Stop Tomcat Service
+    command: "{{ ansible_env.CATALINA_BASE }}/bin/catalina.sh stop 30 -force"
+    ignore_errors: yes
+  
+  - debug: msg="{{ ansible_env.CATALINA_BASE }}/bin/catalina.sh {{service_status}}"
+  - name: Start Tomcat Service
+    command: nohup {{ ansible_env.CATALINA_BASE }}/bin/catalina.sh start
+    when: "{{ service_status | search('start') }}"


### PR DESCRIPTION
#### Fixes #. cm-552 custom ansible script for java client run on macos

- [X] Ran `flake8`
- [X] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- added ansible environment variable setup for macos 
- added variables to pass environment variables to ansible playbook

