### PR TITLE
Fix/test cm-433 

### DIFF
--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_custom_conflicts.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_custom_conflicts.py
@@ -696,8 +696,8 @@ def test_non_blocking_custom_conflicts_resolution(params_from_base_test_setup, r
             assert "random" not in cbl_doc, "CCR failed to resolve conflict with delayed local win"
             assert "cbl_random" not in sg_doc, "CCR failed to resolve conflict with delayed local win"
             log_info(
-                cbl_doc["update_during_CCR"] + "resolve conflict with delayed local win" + new_docs_body[doc_id][1][
-                    "update_during_CCR"])
+                cbl_doc["update_during_CCR"] + "resolve conflict with delayed local win" + str(new_docs_body[doc_id][1][
+                    "update_during_CCR"]))
             assert new_docs_body[doc_id][1]["update_during_CCR"] == cbl_doc["update_during_CCR"], "CCR failed to " \
                                                                                                   "resolve conflict " \
                                                                                                   "with delayed " \

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_predective_queries.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_predective_queries.py
@@ -126,8 +126,9 @@ def test_predictiveQueries_euclideanCosineDistance(params_from_base_test_setup, 
         euclidean_value = result_euclidean_dist[list(result_euclidean_dist.keys())[0]]
         square_euclidean_value = result_square_euclidean_dist[list(result_square_euclidean_dist.keys())[0]]
         consine_distance_value = result_consine_distance[list(result_consine_distance.keys())[0]]
-        assert str(euclidean_result) in str(euclidean_value), "euclidean distance did not get the right value for coordinates {}".format(coordinates)
-        assert square_euclidean_value == squareEuclidean_result, "square euclidean distance did not get the right value for coordinates {}".format(coordinates)
+        assert square_euclidean_value == squareEuclidean_result, "square euclidean distance did not get the right value for coordinates {}".format(
+            coordinates)
+        assert str(euclidean_result) in str(euclidean_value), "euclidean distance did not get the right value for coordinates {} - failing due to CBL-1354".format(coordinates)
         assert str(cosine_result) in str(consine_distance_value), "cosine distance did not get the right value for coordinates"
     else:
         assert not result_euclidean_dist, "euclidean distance did not get the right value for euclidean coordinates {}".format(coordinates)

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication_eventing.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication_eventing.py
@@ -536,7 +536,7 @@ def test_push_replication_for_20mb_doc(params_from_base_test_setup, attachment_g
                                            generator="simple", attachments_generator=attachment_generator,
                                            attachment_file_list=attachment_file_list)
 
-    if str(attachment_generator) not in "load_from_data_dir":
+    if "load_from_data_dir" not in str(attachment_generator):
         doc_body_4mb = doc_generators.doc_size_byBytes(25000000)  # 25MB data generated
         cbl_db_docs = db.getDocuments(cbl_db, created_docs_ids)
         for doc in cbl_db_docs:


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

-  test_custom_conflicts.py change to avoid the intermittent string concatenation error
-  Predictive value  change -> moved the passing assertions up and added the bug to assert messages

All are individual test changes tested locally 

