### PR TITLE
call remove app before install

### DIFF
--- a/keywords/TestServerAndroid.py
+++ b/keywords/TestServerAndroid.py
@@ -75,6 +75,13 @@ class TestServerAndroid(TestServerBase):
 
         apk_path = "{}/{}".format(BINARY_DIR, self.apk_name)
         self.device_enabled = False
+
+        try:
+            log_info("remove the app before install, to ensure sandbox gets cleaned.")
+            self.remove()
+        except Exception as e:
+            log_info("remove the app before install didn't go success, but still continue ......")
+
         log_info("Installing: {}".format(apk_path))
 
         # If and apk is installed, attempt to remove it and reinstall.
@@ -82,7 +89,6 @@ class TestServerAndroid(TestServerBase):
         max_retries = 1
         count = 0
         while True:
-
             if count > max_retries:
                 raise LiteServError(".apk install failed!")
             try:
@@ -113,6 +119,12 @@ class TestServerAndroid(TestServerBase):
         self.device_enabled = True
         self.device_option = "-d"
         apk_path = "{}/{}".format(BINARY_DIR, self.apk_name)
+
+        try:
+            log_info("remove the app on device before install, to ensure sandbox gets cleaned.")
+            self.remove()
+        except Exception as e:
+            log_info("remove the app before install didn't go success, but still continue ......")
 
         log_info("Installing: {}".format(apk_path))
 
@@ -148,7 +160,7 @@ class TestServerAndroid(TestServerBase):
         """Removes the Test Server application from the running device
         """
         output = subprocess.check_output(["adb", "uninstall", self.installed_package_name])
-        if output.strip() != "Success":
+        if output.strip() != "Success" and output.strip() != b"Success":
             log_info(output)
             raise LiteServError("Error. Could not remove app.")
 


### PR DESCRIPTION
#### Fixes #. cm-455 remove android app before install to clean the sandbox

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- added the remove step before install. the reinstall flag "-r" doesn't guarantee sandbox data is completed deleted. 

