### PR TITLE
cm-472 fix error message evaluation for javaws

### DIFF
--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
@@ -1343,8 +1343,10 @@ def test_replication_wrong_blip(params_from_base_test_setup):
     with pytest.raises(Exception) as ex:
         replicator.configure(cbl_db, sg_blip_url, continuous=True, channels=channels, replicator_authenticator=replicator_authenticator)
     ex_data = str(ex.value)
-    if liteserv_platform == "ios":
-        assert "Invalid scheme for URLEndpoint url (ht2tp" in ex_data
+
+    if liteserv_platform == "ios" or liteserv_platform.startswith("javaws-"):
+        assert "Invalid scheme for URLEndpoint url" in ex_data
+        assert "ht2tp" in ex_data
         assert "must be either 'ws:' or 'wss:'" in ex_data
     else:
         assert ex_data.startswith('400 Client Error: Bad Request for url:')


### PR DESCRIPTION
#### Fixes #. cm-472 java webservice error message handling

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- java webservice error message can be checked for specific exception cause now.
- make javaws and ios the same assertion criteria

