### PR TITLE
added custom topology cluster config for cbl

### DIFF
--- a/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -137,6 +137,11 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="If set, will enable SSL communication between server and Sync Gateway")
 
+    parser.addoption("--cluster-config",
+                     action="store",
+                     help="Provide a custom cluster config",
+                     default="multiple_sync_gateways_")
+
 # This will get called once before the first test that
 # runs with this as input parameters in this file
 # This setup will be called once for all tests in the
@@ -172,6 +177,7 @@ def params_from_base_suite_setup(request):
     cbs_ce = request.config.getoption("--cbs-ce")
     sg_ce = request.config.getoption("--sg-ce")
     cbs_ssl = request.config.getoption("--server-ssl")
+    cluster_config = request.config.getoption("--cluster-config")
 
     enable_encryption = request.config.getoption("--enable-encryption")
     encryption_password = request.config.getoption("--encryption-password")
@@ -195,7 +201,7 @@ def params_from_base_suite_setup(request):
             testserver.install()
 
     base_url = "http://{}:{}".format(liteserv_host, liteserv_port)
-    cluster_config = "{}/four_sync_gateways_{}".format(CLUSTER_CONFIGS_DIR, mode)
+    cluster_config = "{}/{}{}".format(CLUSTER_CONFIGS_DIR, cluster_config, mode)
     no_conflicts_enabled = request.config.getoption("--no-conflicts")
     cluster_utils = ClusterKeywords(cluster_config)
     cluster_topology = cluster_utils.get_cluster_topology(cluster_config)


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- made change to use default cluster config to cbl tests and sg-replicate2 has to send cluster config in the pytest command
-
http://uberjenkins.sc.couchbase.com:8080/job/CBLITE_iOS-Listener-TestServer-Topology-specific-Functional-CBLITE-SSL-DELTA-SYNC-tests/30/testReport/
