### PR TITLE
add flush iptables for load balancer nodes

### DIFF
--- a/libraries/provision/ansible/playbooks/flush-firewall.yml
+++ b/libraries/provision/ansible/playbooks/flush-firewall.yml
@@ -17,6 +17,15 @@
     ignore_errors: True
     when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Ubuntu" or ansible_distribution == "Debian"
 
+- hosts: load_balancers
+
+  tasks:
+  - name: OS | Flush Firewall on Centos
+    become: yes
+    command: iptables --flush
+    ignore_errors: True
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat" or ansible_distribution == "Ubuntu" or ansible_distribution == "Debian"
+
 - hosts: sync_gateways
 
   tasks:


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- when using dynamic vms, it creates new vms which loads with some firewall by default. We flush firewalls for sync gateways and couchbserver vms, but not for load balancer vms and it fails when using dynamic vms. This change will flush firewalls on load balancer vm

