### PR TITLE
 Fixing failing topology tests in CBL

### DIFF
--- a/resources/sync_gateway_configs/listener_tests/multiple_sync_gateways_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/multiple_sync_gateways_cc.json
@@ -25,7 +25,7 @@
             {{ autoimport }}
             {{ xattrs }}
             {{ no_conflicts }}
-            "revs_limit": 20,
+            "revs_limit": 15,
             {{ sg_use_views }}
             {{ num_index_replicas }}
             {{ delta_sync }}

--- a/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -606,7 +606,7 @@ def setup_customized_teardown_test(params_from_base_test_setup):
             db.deleteDB(cbl_db1)
         if db.exists(cbl_db_name2, path2):
             db.deleteDB(cbl_db2)
-        if db.exists(cbl_db_name3, path2):
+        if db.exists(cbl_db_name3, path3):
             db.deleteDB(cbl_db3)
     except Exception as err:
         log_info("Exception occurred: {}".format(err))


### PR DESCRIPTION
#### Fixes #.
Currently on every CBL platform 3 topology tests are failing and this change fixes all failures

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Error run : http://uberjenkins.sc.couchbase.com:8080/job/CBLITE_DOTNET-Topology-Functional-XATTRS-tests/29/testReport/testsuites.CBLTester.topology_specific_tests.multiple_sync_gateways/test_replication_multiple_sgs/test_multiple_sgs_with_differrent_revs_limit_listener_tests_multiple_sync_gateways_10_/
Passed  execution: 
-http://uberjenkins.sc.couchbase.com:8080/job/CBLITE_DOTNET-Topology-Functional-XATTRS-tests/31/

