### PR TITLE
adding clean up scripts to remove all cached *.cblite2 files

### DIFF
--- a/libraries/provision/ansible/playbooks/install-testserver-java-desktop.yml
+++ b/libraries/provision/ansible/playbooks/install-testserver-java-desktop.yml
@@ -7,6 +7,23 @@
   - debug: msg="JAVA_HOME location is {{ ansible_env.JAVA_HOME }}"
   - debug: msg="JSVC_HOME location is {{ ansible_env.JSVC_HOME }}"
 
+  - name: Delete any cblite2 filed generated in previous tests
+    file:
+      path: ~/javatestserver/*.cblite2
+      state: absent
+    ignore_errors: yes
+
+  - name: check /tmp/TestServerTemp directory exists
+    stat:
+      path: /tmp/TestServerTemp
+    register: testserver_tmp
+
+  - name: delete previously catched cblite2 files
+    file:
+      path: /tmp/TestServerTemp
+      state: absent
+    when: testserver_tmp.stat.exists == True
+
   - name: Define the log output location
     stat:
       path: ~/javatestserver/output

--- a/libraries/provision/ansible/playbooks/install-testserver-java-ws-macos.yml
+++ b/libraries/provision/ansible/playbooks/install-testserver-java-ws-macos.yml
@@ -60,6 +60,19 @@
       state: absent
     with_items: "{{ tomcat_log.files }}"
 
+  - name: Remove cblite2 files
+    find:
+      paths: "{{ ansible_env.CATALINA_BASE }}"
+      patterns: '*.cblite2'
+      recurse: True
+    register: cblite2_files
+  
+  - name: remove cblite2 filed cached at tomcat root
+    file:
+      path: "{{ item.path }}"
+      state: absent
+    with_items: "{{ cblite2_files.files }}"
+
   - name: Collect CouchbaseLite jar and supporting files in package to be installed
     find:
       paths: "~/javatestserver/{{ core_package_name }}/lib"

--- a/libraries/provision/ansible/playbooks/install-testserver-java-ws-msft.yml
+++ b/libraries/provision/ansible/playbooks/install-testserver-java-ws-msft.yml
@@ -44,6 +44,10 @@
     win_shell:
       Remove-Item "{{ ansible_env.CATALINA_BASE }}\\logs\\*.*"
 
+  - name: Remove cached cblite2 files
+    win_shell:
+      Remove-Item "{{ ansible_env.CATALINA_BASE }}\\*.cblite2"
+
   - debug: msg="Copy TestServer war file"
   - win_shell: copy C:\Users\{{ ansible_user }}\Desktop\TestServer\{{ build_name }}\{{ war_package_name }}.war "{{ ansible_env.CATALINA_BASE }}\\webapps\\ROOT.war"
 

--- a/libraries/provision/ansible/playbooks/install-testserver-java-ws.yml
+++ b/libraries/provision/ansible/playbooks/install-testserver-java-ws.yml
@@ -11,6 +11,12 @@
     shell: "{{ ansible_env.CATALINA_BASE }}/bin/catalina.sh stop 30 -force"
     ignore_errors: yes
 
+  - name: Delete any cblite2 filed generated in previous tests
+    file:
+      path: ~/*.cblite2
+      state: absent
+    ignore_errors: yes
+
   - name: Collect CouchbaseLite jar and supporting files
     find:
       paths: "{{ ansible_env.CATALINA_BASE }}/lib"
@@ -56,6 +62,19 @@
       path: "{{ item.path }}"
       state: absent
     with_items: "{{ tomcat_log.files }}"
+
+  - name: Remove cblite2 files
+    find:
+      paths: "{{ ansible_env.CATALINA_BASE }}"
+      patterns: '*.cblite2'
+      recurse: True
+    register: cblite2_files
+  
+  - name: remove cblite2 filed cached at tomcat root
+    file:
+      path: "{{ item.path }}"
+      state: absent
+    with_items: "{{ cblite2_files.files }}"
 
   - name: Collect CouchbaseLite jar and supporting files in package to be installed
     find:


### PR DESCRIPTION
#### Fixes #. clean up database files for java

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- clean up *.cblite2 files for java 

