### PR TITLE
removed assertion of teardown to avoid showing test failure twice

### DIFF
--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -525,5 +525,3 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     if collect_logs or request.node.rep_call.failed or len(errors) != 0:
         logging_helper = Logging()
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
-
-    assert len(errors) == 0

--- a/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
@@ -274,5 +274,3 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     if collect_logs or request.node.rep_call.failed or len(errors) != 0:
         logging_helper = Logging()
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
-
-    assert len(errors) == 0

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
@@ -249,5 +249,3 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     if collect_logs or request.node.rep_call.failed or len(errors) != 0:
         logging_helper = Logging()
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
-
-    assert len(errors) == 0

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
@@ -266,5 +266,3 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     if collect_logs or request.node.rep_call.failed or len(errors) != 0:
         logging_helper = Logging()
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
-
-    assert len(errors) == 0

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -291,5 +291,3 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     if collect_logs or request.node.rep_call.failed or len(errors) != 0:
         logging_helper = Logging()
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
-
-    assert len(errors) == 0

--- a/testsuites/syncgateway/system/conftest.py
+++ b/testsuites/syncgateway/system/conftest.py
@@ -328,8 +328,6 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     if collect_logs or request.node.rep_call.failed or len(errors) != 0:
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
 
-    assert len(errors) == 0
-
     # Scan logs
     # SG logs for panic, data race
     # System logs for OOM

--- a/testsuites/syncgateway/upgrade/liteserv/conftest.py
+++ b/testsuites/syncgateway/upgrade/liteserv/conftest.py
@@ -12,7 +12,6 @@ from keywords.SyncGateway import (sync_gateway_config_path_for_mode,
 from keywords.tklogging import Logging
 from keywords.utils import check_xattr_support, log_info, version_is_binary, clear_resources_pngs
 from libraries.NetworkUtils import NetworkUtils
-from libraries.testkit import cluster
 from utilities.cluster_config_utils import persist_cluster_config_environment_prop
 from keywords.exceptions import LogScanningError
 from libraries.provision.ansible_runner import AnsibleRunner
@@ -424,15 +423,9 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     network_utils = NetworkUtils()
     network_utils.list_connections()
 
-    # Verify all sync_gateways and sg_accels are reachable
-    c = cluster.Cluster(cluster_config)
-    errors = c.verify_alive(mode)
-
     # Fetch logs
     logging_helper = Logging()
     logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)
-
-    assert len(errors) == 0
 
     # Scan logs
     # SG logs for panic, data race


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Teardown should not have assertion which is causing tests to show failure twice
- Removed assertion at teardown
-  http://uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-functional-tests-topology-cc/367/testReport/
- http://uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-upgrade/303/testReport/

