### PR TITLE
Feature/cbl 2.8.x- repalce db for checking the replication

### DIFF
--- a/testsuites/CBLTester/CBL_Functional_tests/conftest.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/conftest.py
@@ -185,7 +185,6 @@ def params_from_base_suite_setup(request):
     use_local_testserver = request.config.getoption("--use-local-testserver")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
     mode = request.config.getoption("--mode")
-    prometheus_enable = request.config.getoption("--prometheus-enable")
     server_version = request.config.getoption("--server-version")
     enable_sample_bucket = request.config.getoption("--enable-sample-bucket")
     xattrs_enabled = request.config.getoption("--xattrs")

--- a/testsuites/CBLTester/upgrade_tests/conftest.py
+++ b/testsuites/CBLTester/upgrade_tests/conftest.py
@@ -361,7 +361,6 @@ def params_from_base_suite_setup(request):
         "utils_obj": utils_obj,
         "community_enabled": community_enabled,
         "debug_mode": debug_mode,
-        "testserver": testserver,
         "test_name_cp": test_name_cp,
         "sg_url": sg_url,
         "second_liteserv_host": second_liteserv_host,

--- a/testsuites/CBLTester/upgrade_tests/conftest.py
+++ b/testsuites/CBLTester/upgrade_tests/conftest.py
@@ -60,6 +60,14 @@ def pytest_addoption(parser):
                      action="store",
                      help="liteserv-host: the host to start liteserv on")
 
+    parser.addoption("--liteserv-platform",
+                     action="store",
+                     help="liteserv-platform: the platform to assign to the liteserv")
+
+    parser.addoption("--liteserv-host",
+                     action="store",
+                     help="liteserv-host: the host to start liteserv on")
+
     parser.addoption("--liteserv-port",
                      action="store",
                      help="liteserv-port: the port to assign to liteserv")
@@ -145,6 +153,9 @@ def params_from_base_suite_setup(request):
     delta_sync_enabled = request.config.getoption("--delta-sync")
     enable_file_logging = request.config.getoption("--enable-file-logging")
     enable_upgrade_app = request.config.getoption("--enable-upgrade-app")
+    second_liteserv_host = request.config.getoption("--sencond-liteserv-host")
+    second_liteserv_version = request.config.getoption("--second-liteserv-version")
+    second_liteserv_platform = request.config.getoption("--second-iteserv-platform")
 
     test_name = request.node.name
     if enable_upgrade_app:
@@ -351,13 +362,17 @@ def params_from_base_suite_setup(request):
         "community_enabled": community_enabled,
         "debug_mode": debug_mode,
         "testserver": testserver,
-        "test_name_cp": test_name_cp
+        "test_name_cp": test_name_cp,
+        "sg_url": sg_url,
+        "second_liteserv_host": second_liteserv_host,
+        "second_liteserv_version": second_liteserv_version,
+        "second_liteserv_platform": second_liteserv_platform
     }
 
     # Flush all the memory contents on the server app
     log_info("Flushing server memory")
     utils_obj.flushMemory()
-    log_info("Stopping the test server per suite")
-    testserver.stop()
-    # Delete png files under resources/data
+    # log_info("Stopping the test server per suite")
+    # testserver.stop()
+    # # Delete png files under resources/data
     clear_resources_pngs()

--- a/testsuites/CBLTester/upgrade_tests/conftest.py
+++ b/testsuites/CBLTester/upgrade_tests/conftest.py
@@ -110,6 +110,10 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="delta-sync: Enable delta-sync for sync gateway")
 
+    parser.addoption("--enable-upgrade-app",
+                     action="store_true",
+                     help="based on this conditions we install the old test server app first them new version of the app")
+
 
 # This will get called once before the first test that
 # runs with this as input parameters in this file
@@ -140,14 +144,24 @@ def params_from_base_suite_setup(request):
     number_replicas = request.config.getoption("--number-replicas")
     delta_sync_enabled = request.config.getoption("--delta-sync")
     enable_file_logging = request.config.getoption("--enable-file-logging")
+    enable_upgrade_app = request.config.getoption("--enable-upgrade-app")
 
     test_name = request.node.name
-    testserver = TestServerFactory.create(platform=liteserv_platform,
-                                          version_build=upgraded_liteserv_version,
+    if enable_upgrade_app:
+        testserver = TestServerFactory.create(platform=liteserv_platform,
+                                          version_build=base_liteserv_version,
                                           host=liteserv_host,
                                           port=liteserv_port,
                                           community_enabled=community_enabled,
                                           debug_mode=debug_mode)
+    else:
+        testserver = TestServerFactory.create(platform=liteserv_platform,
+                                              version_build=upgraded_liteserv_version,
+                                              host=liteserv_host,
+                                              port=liteserv_port,
+                                              community_enabled=community_enabled,
+                                              debug_mode=debug_mode)
+
     log_info("Downloading TestServer ...")
     # Download TestServer app
     testserver.download()
@@ -333,7 +347,11 @@ def params_from_base_suite_setup(request):
         "suite_db_log_files": suite_db_log_files,
         "db_password": db_password,
         "encrypted_db": encrypted_db,
-        "utils_obj": utils_obj
+        "utils_obj": utils_obj,
+        "community_enabled": community_enabled,
+        "debug_mode": debug_mode,
+        "testserver":  testserver,
+        "test_name_cp": test_name_cp
     }
 
     # Flush all the memory contents on the server app

--- a/testsuites/CBLTester/upgrade_tests/conftest.py
+++ b/testsuites/CBLTester/upgrade_tests/conftest.py
@@ -372,7 +372,7 @@ def params_from_base_suite_setup(request):
     # Flush all the memory contents on the server app
     log_info("Flushing server memory")
     utils_obj.flushMemory()
-    # log_info("Stopping the test server per suite")
-    # testserver.stop()
-    # # Delete png files under resources/data
+    log_info("Stopping the test server per suite")
+    testserver.stop()
+    # Delete png files under resources/data
     clear_resources_pngs()

--- a/testsuites/CBLTester/upgrade_tests/conftest.py
+++ b/testsuites/CBLTester/upgrade_tests/conftest.py
@@ -149,11 +149,11 @@ def params_from_base_suite_setup(request):
     test_name = request.node.name
     if enable_upgrade_app:
         testserver = TestServerFactory.create(platform=liteserv_platform,
-                                          version_build=base_liteserv_version,
-                                          host=liteserv_host,
-                                          port=liteserv_port,
-                                          community_enabled=community_enabled,
-                                          debug_mode=debug_mode)
+                                              version_build=base_liteserv_version,
+                                              host=liteserv_host,
+                                              port=liteserv_port,
+                                              community_enabled=community_enabled,
+                                              debug_mode=debug_mode)
     else:
         testserver = TestServerFactory.create(platform=liteserv_platform,
                                               version_build=upgraded_liteserv_version,
@@ -350,7 +350,7 @@ def params_from_base_suite_setup(request):
         "utils_obj": utils_obj,
         "community_enabled": community_enabled,
         "debug_mode": debug_mode,
-        "testserver":  testserver,
+        "testserver": testserver,
         "test_name_cp": test_name_cp
     }
 

--- a/testsuites/CBLTester/upgrade_tests/conftest.py
+++ b/testsuites/CBLTester/upgrade_tests/conftest.py
@@ -56,17 +56,17 @@ def pytest_addoption(parser):
                      default="password",
                      help="Provide password for encrypted db")
 
-    parser.addoption("--liteserv-host",
-                     action="store",
-                     help="liteserv-host: the host to start liteserv on")
-
-    parser.addoption("--liteserv-platform",
+    parser.addoption("--second-liteserv-platform",
                      action="store",
                      help="liteserv-platform: the platform to assign to the liteserv")
 
-    parser.addoption("--liteserv-host",
+    parser.addoption("--second-liteserv-host",
                      action="store",
                      help="liteserv-host: the host to start liteserv on")
+
+    parser.addoption("--second-liteserv-version",
+                     action="store",
+                     help="liteserv-version: the version to download / install for the liteserv")
 
     parser.addoption("--liteserv-port",
                      action="store",

--- a/testsuites/CBLTester/upgrade_tests/conftest.py
+++ b/testsuites/CBLTester/upgrade_tests/conftest.py
@@ -56,6 +56,10 @@ def pytest_addoption(parser):
                      default="password",
                      help="Provide password for encrypted db")
 
+    parser.addoption("--liteserv-host",
+                     action="store",
+                     help="liteserv-host: the host to start liteserv on")
+
     parser.addoption("--second-liteserv-platform",
                      action="store",
                      help="liteserv-platform: the platform to assign to the liteserv")
@@ -153,9 +157,9 @@ def params_from_base_suite_setup(request):
     delta_sync_enabled = request.config.getoption("--delta-sync")
     enable_file_logging = request.config.getoption("--enable-file-logging")
     enable_upgrade_app = request.config.getoption("--enable-upgrade-app")
-    second_liteserv_host = request.config.getoption("--sencond-liteserv-host")
+    second_liteserv_host = request.config.getoption("--second-liteserv-host")
     second_liteserv_version = request.config.getoption("--second-liteserv-version")
-    second_liteserv_platform = request.config.getoption("--second-iteserv-platform")
+    second_liteserv_platform = request.config.getoption("--second-liteserv-platform")
 
     test_name = request.node.name
     if enable_upgrade_app:

--- a/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
+++ b/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
@@ -311,7 +311,7 @@ def _upgrade_db(args):
     if base_liteserv_version > upgraded_liteserv_version:
         pytest.skip("Can't upgrade from higher version db to lower version db")
 
-    supported_base_liteserv = ["1.4", "2.0.0", "2.1.5", "2.5.0", "2.7.0"]
+    supported_base_liteserv = ["1.4", "2.0.0", "2.1.5", "2.5.0", "2.7.0", "2.7.1"]
     db = Database(base_url)
     if encrypted_db:
         if base_liteserv_version < "2.1.5":
@@ -411,10 +411,11 @@ def test_upgrade_testsever_app(params_from_base_suite_setup):
     upgraded_cbl_doc_count = db.getCount(source_db)
     cbl_doc_ids = db.getDocIds(source_db)
     cbl_db_docs = db.getDocuments(source_db, cbl_doc_ids)
-    assert upgraded_cbl_doc_count == base_cbl_doc_count, " Number of docs count is not matching"
+    assert upgraded_cbl_doc_count == 20, " Number of docs count is not matching"
     # Create few more docs and make sure the after upgrade we still create docs
     db.create_bulk_docs(2, "cbl-upgrade-docs_new", db=source_db, channels=channels_sg)
     upgraded_cbl_doc_count = db.getCount(source_db)
     assert upgraded_cbl_doc_count > base_cbl_doc_count, " Number of docs count is not matching"
-    log_info("*" * 20)
-    log_info(cbl_db_docs)
+    #
+    # log_info("*" * 20)
+    # log_info(cbl_db_docs, upgraded_cbl_doc_count)

--- a/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
+++ b/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
@@ -414,8 +414,9 @@ def test_upgrade_cbl(params_from_base_suite_setup):
     upgraded_cbl_doc_count = db.getCount(source_db)
     cbl_doc_ids = db.getDocIds(source_db)
     cbl_db_docs = db.getDocuments(source_db, cbl_doc_ids)
-    db.create_bulk_docs(2, "cbl-upgrade-docs_new", db=source_db, channels=channels_sg)
     assert upgraded_cbl_doc_count == base_cbl_doc_count, " Number of docs count is not matching"
+    # Create few more docs and make sure the after upgrade we still create docs
+    db.create_bulk_docs(2, "cbl-upgrade-docs_new", db=source_db, channels=channels_sg)
     upgraded_cbl_doc_count = db.getCount(source_db)
     assert upgraded_cbl_doc_count > base_cbl_doc_count, " Number of docs count is not matching"
     log_info("*" * 20)

--- a/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
+++ b/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
@@ -359,7 +359,7 @@ def _upgrade_db(args):
 
 @pytest.mark.listener
 @pytest.mark.upgrade_test
-def test_upgrade_cbl(params_from_base_suite_setup):
+def test_upgrade_testsever_app(params_from_base_suite_setup):
     base_url = params_from_base_suite_setup["base_url"]
     cbl_db = "upgrade_db" + str(time.time())
     # Create CBL database
@@ -384,11 +384,11 @@ def test_upgrade_cbl(params_from_base_suite_setup):
     time.sleep(2)
     base_cbl_doc_count = db.getCount(source_db)
     testserver2 = TestServerFactory.create(platform=liteserv_platform,
-                                          version_build=upgraded_liteserv_version,
-                                          host=liteserv_host,
-                                          port=liteserv_port,
-                                          community_enabled=community_enabled,
-                                          debug_mode=debug_mode)
+                                           version_build=upgraded_liteserv_version,
+                                           host=liteserv_host,
+                                           port=liteserv_port,
+                                           community_enabled=community_enabled,
+                                           debug_mode=debug_mode)
     log_info("Downloading TestServer ...")
     # Download TestServer app
     testserver2.download()
@@ -402,12 +402,12 @@ def test_upgrade_cbl(params_from_base_suite_setup):
 
     if device_enabled:
         testserver2.start_device("{}/logs/{}-{}-{}.txt".format(RESULTS_DIR, type(testserver).__name__,
-                                                              test_name_cp,
-                                                              datetime.datetime.now()))
+                                                               test_name_cp,
+                                                               datetime.datetime.now()))
     else:
         testserver2.start("{}/logs/{}-{}-{}.txt".format(RESULTS_DIR, type(testserver).__name__,
-                                                       test_name_cp,
-                                                       datetime.datetime.now()))
+                                                        test_name_cp,
+                                                        datetime.datetime.now()))
 
     db = Database(base_url)
     source_db = db.create(cbl_db)
@@ -421,4 +421,3 @@ def test_upgrade_cbl(params_from_base_suite_setup):
     assert upgraded_cbl_doc_count > base_cbl_doc_count, " Number of docs count is not matching"
     log_info("*" * 20)
     log_info(cbl_db_docs)
-

--- a/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
+++ b/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
@@ -397,14 +397,11 @@ def test_upgrade_testsever_app(params_from_base_suite_setup):
     # Install TestServer app
     if device_enabled:
         testserver2.install_device()
-    else:
-        testserver2.install()
-
-    if device_enabled:
         testserver2.start_device("{}/logs/{}-{}-{}.txt".format(RESULTS_DIR, type(testserver).__name__,
                                                                test_name_cp,
                                                                datetime.datetime.now()))
     else:
+        testserver2.install()
         testserver2.start("{}/logs/{}-{}-{}.txt".format(RESULTS_DIR, type(testserver).__name__,
                                                         test_name_cp,
                                                         datetime.datetime.now()))

--- a/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
+++ b/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
@@ -569,4 +569,3 @@ def test_switch_dbs_with_two_cbl_platforms(params_from_base_suite_setup):
         repl) == 0, "Replicator getCompleted doc should be zero, it shouldn't start from zero"
     assert second_cbl_doc_count == cbl_doc_count, "After moving the DBs docs are updating "
     replicator.stop(repl)
-

--- a/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
+++ b/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
@@ -2,6 +2,7 @@ import pytest
 import random
 import time
 from collections import OrderedDict
+import datetime
 
 from couchbase.bucket import Bucket
 from couchbase.n1ql import N1QLQuery
@@ -14,6 +15,8 @@ from keywords.constants import SDK_TIMEOUT
 from keywords.couchbaseserver import CouchbaseServer
 from keywords.utils import log_info
 from libraries.testkit.cluster import Cluster
+from keywords.TestServerFactory import TestServerFactory
+from keywords.constants import RESULTS_DIR
 from testsuites.CBLTester.CBL_Functional_tests.SuiteSetup_FunctionalTests.test_query import test_get_doc_ids, \
     test_any_operator, test_doc_get, test_get_docs_with_limit_offset, test_multiple_selects, test_query_where_and_or, \
     test_query_pattern_like, test_query_pattern_regex, test_query_isNullOrMissing, test_query_ordering, \
@@ -352,3 +355,69 @@ def _upgrade_db(args):
     cbl_db = db.create(upgrade_cbl_db_name, db_config)
     assert isinstance(cbl_db, MemoryPointer), "Failed to migrate db from previous version of CBL"
     return cbl_db, upgrade_cbl_db_name
+
+
+@pytest.mark.listener
+@pytest.mark.upgrade_test
+def test_upgrade_cbl(params_from_base_suite_setup):
+    base_url = params_from_base_suite_setup["base_url"]
+    cbl_db = "upgrade_db" + str(time.time())
+    # Create CBL database
+    db = Database(base_url)
+
+    log_info("Creating a Database {}".format(cbl_db))
+    source_db = db.create(cbl_db)
+
+    upgraded_liteserv_version = params_from_base_suite_setup["upgraded_liteserv_version"]
+    liteserv_platform = params_from_base_suite_setup["liteserv_platform"]
+    liteserv_host = params_from_base_suite_setup["liteserv_host"]
+    liteserv_port = params_from_base_suite_setup["liteserv_port"]
+    debug_mode = params_from_base_suite_setup["debug_mode"]
+    device_enabled = params_from_base_suite_setup["device_enabled"]
+    community_enabled = params_from_base_suite_setup["community_enabled"]
+    testserver = params_from_base_suite_setup["testserver"]
+    test_name_cp = params_from_base_suite_setup["test_name_cp"]
+    channels_sg = ["ABC"]
+    # Create CBL database
+    db.create_bulk_docs(20, "cbl-upgrade-docs", db=source_db, channels=channels_sg)
+
+    time.sleep(2)
+    base_cbl_doc_count = db.getCount(source_db)
+    testserver2 = TestServerFactory.create(platform=liteserv_platform,
+                                          version_build=upgraded_liteserv_version,
+                                          host=liteserv_host,
+                                          port=liteserv_port,
+                                          community_enabled=community_enabled,
+                                          debug_mode=debug_mode)
+    log_info("Downloading TestServer ...")
+    # Download TestServer app
+    testserver2.download()
+
+    log_info("Installing TestServer ...")
+    # Install TestServer app
+    if device_enabled:
+        testserver2.install_device()
+    else:
+        testserver2.install()
+
+    if device_enabled:
+        testserver2.start_device("{}/logs/{}-{}-{}.txt".format(RESULTS_DIR, type(testserver).__name__,
+                                                              test_name_cp,
+                                                              datetime.datetime.now()))
+    else:
+        testserver2.start("{}/logs/{}-{}-{}.txt".format(RESULTS_DIR, type(testserver).__name__,
+                                                       test_name_cp,
+                                                       datetime.datetime.now()))
+
+    db = Database(base_url)
+    source_db = db.create(cbl_db)
+    upgraded_cbl_doc_count = db.getCount(source_db)
+    cbl_doc_ids = db.getDocIds(source_db)
+    cbl_db_docs = db.getDocuments(source_db, cbl_doc_ids)
+    db.create_bulk_docs(2, "cbl-upgrade-docs_new", db=source_db, channels=channels_sg)
+    assert upgraded_cbl_doc_count == base_cbl_doc_count, " Number of docs count is not matching"
+    upgraded_cbl_doc_count = db.getCount(source_db)
+    assert upgraded_cbl_doc_count > base_cbl_doc_count, " Number of docs count is not matching"
+    log_info("*" * 20)
+    log_info(cbl_db_docs)
+

--- a/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
+++ b/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
@@ -380,8 +380,6 @@ def test_upgrade_testsever_app(params_from_base_suite_setup):
     channels_sg = ["ABC"]
     # Create CBL database
     db.create_bulk_docs(20, "cbl-upgrade-docs", db=source_db, channels=channels_sg)
-
-    time.sleep(2)
     base_cbl_doc_count = db.getCount(source_db)
     testserver2 = TestServerFactory.create(platform=liteserv_platform,
                                            version_build=upgraded_liteserv_version,
@@ -416,6 +414,3 @@ def test_upgrade_testsever_app(params_from_base_suite_setup):
     db.create_bulk_docs(2, "cbl-upgrade-docs_new", db=source_db, channels=channels_sg)
     upgraded_cbl_doc_count = db.getCount(source_db)
     assert upgraded_cbl_doc_count > base_cbl_doc_count, " Number of docs count is not matching"
-    #
-    # log_info("*" * 20)
-    # log_info(cbl_db_docs, upgraded_cbl_doc_count)

--- a/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
+++ b/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
@@ -365,13 +365,10 @@ def test_upgrade_testsever_app(params_from_base_suite_setup):
     """
         @summary:
         Added to address issues like CBL-1406
-        1. Create docs in SG
-        2. Verify CBL docs got replicated to SG
-        3. Verify sg docs not replicated to CBL
-        4. Start second CBL (use different platform)
-        5. Copy DB from 1st CBL to 2nd CBL
-        6. Start the same SG replicator
-        7. Verify docs are not replicated again in the 2nd CBL
+        1. Create docs in cbl
+        2. Upgrade the cbl to any new version
+        3. Verify that doc count is marching with before the upgrade
+        4. Verify after the upgrade we are able to add more docs
 
     """
 

--- a/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
+++ b/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
@@ -467,14 +467,12 @@ def test_switch_dbs_with_two_cbl_platforms(params_from_base_suite_setup):
 
     cbl_db_name = "upgrade_db" + str(time.time())
     # Create CBL database
-
     log_info("Creating a Database {}".format(cbl_db_name))
     cbl_db_obj = db.create(cbl_db_name)
 
     c = cluster.Cluster(config=cluster_config)
     sg_config = sync_gateway_config_path_for_mode("custom_sync/grant_access_one", mode)
     c.reset(sg_config_path=sg_config)
-
     channels = ["ABC"]
 
     sg_client = MobileRestClient()
@@ -517,7 +515,6 @@ def test_switch_dbs_with_two_cbl_platforms(params_from_base_suite_setup):
     for doc in cbl_doc_ids:
         assert doc in sg_ids
     prebuilt_db_path = db.getPath(cbl_db_obj)
-
     log_info("prebuilt_db_path", prebuilt_db_path)
 
     testserver2 = TestServerFactory.create(platform=second_liteserv_platform,
@@ -546,7 +543,6 @@ def test_switch_dbs_with_two_cbl_platforms(params_from_base_suite_setup):
     db = Database(base_url)
     temp_db_name = "temp_db_name"
     cbl2_db_obj = db.create(temp_db_name)
-    # upgraded_cbl_doc_count = db.getCount(cbl2_db_obj)
 
     new_db_path = db.getPath(cbl2_db_obj)
     db.deleteDB(cbl2_db_obj)
@@ -560,7 +556,6 @@ def test_switch_dbs_with_two_cbl_platforms(params_from_base_suite_setup):
                                        channels=channels)
 
     second_cbl_doc_count = db.getCount(new_cbl_db_obj)
-
     repl = replicator.create(repl_config)
     log_info("Starting replicator")
     replicator.start(repl)
@@ -569,3 +564,4 @@ def test_switch_dbs_with_two_cbl_platforms(params_from_base_suite_setup):
         repl) == 0, "Replicator getCompleted doc should be zero, it shouldn't start from zero"
     assert second_cbl_doc_count == cbl_doc_count, "After moving the DBs docs are updating "
     replicator.stop(repl)
+    testserver2.stop()


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- New test for the DB replace in between the cbl platforms
- Added test description for previous test
- pytest -s --timeout 600 --base-liteserv-version=2.8.0-273 --upgraded-liteserv-version=3.0.0-54 --liteserv-host=10.0.0.36 --liteserv-port=8080 --liteserv-platform=ios --enable-file-logging --sync-gateway-version=2.8.0-365 --mode=cc --server-version=6.5.1-6299 testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py -k test_switch_dbs_with_two_cbl_platforms --skip-provisioning --second-liteserv-host=10.11.172.112 --second-liteserv-version=2.8.1 --second-liteserv-platform=android

