### PR TITLE
Fix/non mobile ignore count new test

### DIFF
--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -738,12 +738,17 @@ class CouchbaseServer:
         log_info("Setting recover mode to 'delta' for server {}".format(server_to_recover.host))
         data = "otpNode=ns_1@{}&recoveryType=delta".format(server_to_recover.host)
         # Override session headers for this one off request
-        resp = self._session.post(
-            "{}/controller/setRecoveryType".format(self.url),
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            data=data
-        )
-
+        count = 0
+        max_retries = 5
+        while count < max_retries:
+            resp = self._session.post(
+                "{}/controller/setRecoveryType".format(self.url),
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                data=data
+            )
+            if resp.status_code == 200:
+                break
+            count += 1
         log_r(resp)
         resp.raise_for_status()
 
@@ -899,6 +904,7 @@ class CouchbaseServer:
         Return the base_url of the package download URL (everything except the filename)
         """
         released_versions = {
+            "6.6.0": "7924",
             "6.5.0": "4960",
             "6.0.3": "2893",
             "5.5.0": "2958",

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline.py
@@ -473,13 +473,8 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll(params_from_ba
     with concurrent.futures.ThreadPoolExecutor(max_workers=libraries.testkit.settings.MAX_REQUEST_WORKERS) as executor:
         futures = dict()
         futures[executor.submit(seth.start_longpoll_changes_tracking, termination_doc_id=None)] = "polling"
-        #  For windows, request is too slow, so have _offline request to start before creating docs
-        # if sg_platform == "windows":
-        #    futures[executor.submit(sg_client.take_db_offline, cluster_conf, "db")] = "db_offline_task"
         time.sleep(5)
         futures[executor.submit(doc_pusher.add_docs, num_docs, bulk)] = "docs_push"
-        # if sg_platform != "windows":
-        #     futures[executor.submit(sg_client.take_db_offline, cluster_conf, "db")] = "db_offline_task"
         futures[executor.submit(sg_client.take_db_offline, cluster_conf, "db")] = "db_offline_task"
         for future in concurrent.futures.as_completed(futures):
             task_name = futures[future]

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline.py
@@ -448,7 +448,7 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll(params_from_ba
 
     cluster_conf = params_from_base_test_setup["cluster_config"]
     mode = params_from_base_test_setup["mode"]
-    sg_platform = params_from_base_test_setup["sg_platform"]
+    # sg_platform = params_from_base_test_setup["sg_platform"]
 
     if mode == "di":
         pytest.skip("Offline tests not supported in Di mode -- see https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-300841425")
@@ -474,13 +474,13 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll(params_from_ba
         futures = dict()
         futures[executor.submit(seth.start_longpoll_changes_tracking, termination_doc_id=None)] = "polling"
         #  For windows, request is too slow, so have _offline request to start before creating docs
-        if sg_platform == "windows":
-            futures[executor.submit(sg_client.take_db_offline, cluster_conf, "db")] = "db_offline_task"
+        # if sg_platform == "windows":
+        #    futures[executor.submit(sg_client.take_db_offline, cluster_conf, "db")] = "db_offline_task"
         time.sleep(5)
         futures[executor.submit(doc_pusher.add_docs, num_docs, bulk)] = "docs_push"
-        if sg_platform != "windows":
-            futures[executor.submit(sg_client.take_db_offline, cluster_conf, "db")] = "db_offline_task"
-
+        # if sg_platform != "windows":
+        #     futures[executor.submit(sg_client.take_db_offline, cluster_conf, "db")] = "db_offline_task"
+        futures[executor.submit(sg_client.take_db_offline, cluster_conf, "db")] = "db_offline_task"
         for future in concurrent.futures.as_completed(futures):
             task_name = futures[future]
 

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline.py
@@ -448,7 +448,6 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll(params_from_ba
 
     cluster_conf = params_from_base_test_setup["cluster_config"]
     mode = params_from_base_test_setup["mode"]
-    # sg_platform = params_from_base_test_setup["sg_platform"]
 
     if mode == "di":
         pytest.skip("Offline tests not supported in Di mode -- see https://github.com/couchbase/sync_gateway/issues/2423#issuecomment-300841425")
@@ -526,7 +525,6 @@ def test_online_to_offline_changes_feed_controlled_close_longpoll(params_from_ba
     status = sg_client.bring_db_online(cluster_conf=cluster_conf, db="db")
     assert status == 0
 
-    #
     # Get all docs that have been pushed
     # Verify that changes returns all of them
     all_docs = doc_pusher.get_all_docs()

--- a/testsuites/syncgateway/functional/tests/test_mobile_opt_in.py
+++ b/testsuites/syncgateway/functional/tests/test_mobile_opt_in.py
@@ -398,9 +398,9 @@ def test_non_mobile_ignore_count(params_from_base_test_setup, sg_conf_name):
 
     if sg_platform == "macos":
         stdout = subprocess.check_output(command, shell=True)
-        assert int(stdout) == 1, "did not find the expected match on sg info logs"
+        assert int(stdout) == 1 + log1_num, "did not find the expected match on sg info logs"
         stdout = subprocess.check_output(command1, shell=True)
-        assert int(stdout) == 1, "did not find the expected match on sg info logs"
+        assert int(stdout) == 1 + log2_num, "did not find the expected match on sg info logs"
     else:
         _, stdout, _ = remote_executor.execute(command)
         assert int(stdout[0]) == 1 + log1_num, "did not find the expected match on sg info logs"

--- a/testsuites/syncgateway/functional/tests/test_mobile_opt_in.py
+++ b/testsuites/syncgateway/functional/tests/test_mobile_opt_in.py
@@ -331,10 +331,16 @@ def test_non_mobile_ignore_count(params_from_base_test_setup, sg_conf_name):
     assert non_mobile_ignore_count == 1, "non_mobile_ignore_count did not get expected count"
     command = "grep 'Cache: changeCache' /tmp/sg_logs/sg_info.log | wc -l"
     command1 = "grep 'does not have valid sync data' /tmp/sg_logs/sg_info.log | wc -l"
-    _, stdout, _ = remote_executor.execute(command)
-    log1_num = int(stdout[0])
-    _, stdout, _ = remote_executor.execute(command1)
-    log2_num = int(stdout[0])
+    if sg_platform == "macos":
+        stdout = subprocess.check_output(command, shell=True)
+        log1_num = int(stdout)
+        stdout = subprocess.check_output(command1, shell=True)
+        log2_num = int(stdout)
+    else:
+        _, stdout, _ = remote_executor.execute(command)
+        log1_num = int(stdout[0])
+        _, stdout, _ = remote_executor.execute(command1)
+        log2_num = int(stdout[0])
 
     # 3. Create another document('abc') on CBS and verify it is not imported and verify that info logs generate the log
     #    “Cache: changeCache: Doc “abc” does not have valid sync data”

--- a/testsuites/syncgateway/functional/tests/test_mobile_opt_in.py
+++ b/testsuites/syncgateway/functional/tests/test_mobile_opt_in.py
@@ -397,6 +397,7 @@ def test_non_mobile_ignore_count(params_from_base_test_setup, sg_conf_name):
     sdk_client.upsert(doc_id3, doc)
 
     if sg_platform == "macos":
+        time.sleep(2)
         stdout = subprocess.check_output(command, shell=True)
         assert int(stdout) == 1 + log1_num, "did not find the expected match on sg info logs"
         stdout = subprocess.check_output(command1, shell=True)

--- a/testsuites/syncgateway/functional/tests/test_mobile_opt_in.py
+++ b/testsuites/syncgateway/functional/tests/test_mobile_opt_in.py
@@ -265,9 +265,10 @@ def test_non_mobile_ignore_count(params_from_base_test_setup, sg_conf_name):
     mode = params_from_base_test_setup['mode']
     xattrs_enabled = params_from_base_test_setup['xattrs_enabled']
     sg_platform = params_from_base_test_setup['sg_platform']
+    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
 
     # This test should only run when using xattr meta storage
-    if xattrs_enabled:
+    if xattrs_enabled or sync_gateway_version < "3.0":
         pytest.skip('Cannot run with --xattrs flag')
 
     sg_config = sync_gateway_config_path_for_mode(sg_conf_name, mode)

--- a/testsuites/syncgateway/functional/tests/test_mobile_opt_in.py
+++ b/testsuites/syncgateway/functional/tests/test_mobile_opt_in.py
@@ -349,6 +349,7 @@ def test_non_mobile_ignore_count(params_from_base_test_setup, sg_conf_name):
     sdk_client.upsert(doc_id2, doc)
 
     if sg_platform == "macos":
+        time.sleep(2)
         stdout = subprocess.check_output(command, shell=True)
         assert int(stdout) == 1 + log1_num, "did not find the expected match on sg info logs"
         stdout = subprocess.check_output(command1, shell=True)

--- a/testsuites/syncgateway/functional/tests/test_mobile_opt_in.py
+++ b/testsuites/syncgateway/functional/tests/test_mobile_opt_in.py
@@ -380,10 +380,16 @@ def test_non_mobile_ignore_count(params_from_base_test_setup, sg_conf_name):
     status = cluster.sync_gateways[0].restart(config=sg_config, cluster_config=cluster_config)
     assert status == 0, "Syncgateway did not start after adding revs_limit  with no conflicts mode "
 
-    _, stdout, _ = remote_executor.execute(command)
-    log1_num = int(stdout[0])
-    _, stdout, _ = remote_executor.execute(command1)
-    log2_num = int(stdout[0])
+    if sg_platform == "macos":
+        stdout = subprocess.check_output(command, shell=True)
+        log1_num = int(stdout)
+        stdout = subprocess.check_output(command1, shell=True)
+        log2_num = int(stdout)
+    else:
+        _, stdout, _ = remote_executor.execute(command)
+        log1_num = int(stdout[0])
+        _, stdout, _ = remote_executor.execute(command1)
+        log2_num = int(stdout[0])
     # 7. Create document('def') and verify info logs show the message “Cache: changeCache: Doc “def” does not have valid sync data”
     #    verify “non_mobile_ignored_count” is 1
     doc_id3 = 'non_mobile_ignore_3'

--- a/testsuites/syncgateway/functional/tests/test_mobile_opt_in.py
+++ b/testsuites/syncgateway/functional/tests/test_mobile_opt_in.py
@@ -1,6 +1,7 @@
 
 
 import pytest
+import subprocess
 
 from couchbase.bucket import Bucket
 from requests.exceptions import HTTPError
@@ -13,6 +14,8 @@ from keywords.SyncGateway import SyncGateway
 from keywords.userinfo import UserInfo
 from keywords.utils import host_for_url, log_info
 from libraries.testkit.cluster import Cluster
+from keywords.remoteexecutor import RemoteExecutor
+from utilities.cluster_config_utils import load_cluster_config_json
 
 
 @pytest.mark.syncgateway
@@ -233,3 +236,153 @@ def test_mobile_opt_in(params_from_base_test_setup, sg_conf_name):
     # sg_client.update_doc(url=sg_url, db=sg_db, doc_id=doc_id8, number_updates=1, auth=test_auth_session)
     sg_get_doc9 = sg_client.get_doc(url=sg_url, db=sg_db, doc_id=doc_id9, auth=test_auth_session)
     assert sg_get_doc9['_rev'].startswith('1-') and sg_get_doc9['_id'] == doc_id9
+
+
+@pytest.mark.parametrize('sg_conf_name', [
+    'log_rotation_new'
+])
+def test_non_mobile_ignore_count(params_from_base_test_setup, sg_conf_name):
+    """
+    Scenario: Enable mobile opt in sync function in sync-gateway configuration file
+    1. Create doc in CBS with xattrs off and verify doc is not imported
+    2. Verify “non_mobile_ignored_count” is 0 on _expvar end point
+    3. Create another document('abc') on CBS and verify it is not imported and verify that info logs generate the log
+        “Cache: changeCache: Doc “abc” does not have valid sync data”
+    4. Verify “non_mobile_ignored_count” is 1 on _expvar end point
+    5. Create another document('xyz') and verify log is generated and “non_mobile_ignored_count” is 2
+    6. Restart SGW , Verify “non_mobile_ignored_count” is 0
+    7. Create document('def') and verify info logs show the message “Cache: changeCache: Doc “def” does not have valid sync data”
+       verify “non_mobile_ignored_count” is 1
+    8. Verify warn_count is 0
+    """
+
+    bucket_name = 'data-bucket'
+    sg_db = 'db'
+
+    cluster_config = params_from_base_test_setup['cluster_config']
+    cluster_topology = params_from_base_test_setup['cluster_topology']
+    mode = params_from_base_test_setup['mode']
+    xattrs_enabled = params_from_base_test_setup['xattrs_enabled']
+    sg_platform = params_from_base_test_setup['sg_platform']
+
+    # This test should only run when using xattr meta storage
+    if xattrs_enabled:
+        pytest.skip('Cannot run with --xattrs flag')
+
+    sg_config = sync_gateway_config_path_for_mode(sg_conf_name, mode)
+    sg_admin_url = cluster_topology['sync_gateways'][0]['admin']
+    sg_url = cluster_topology['sync_gateways'][0]['public']
+    cbs_url = cluster_topology['couchbase_servers'][0]
+
+    log_info('sg_conf: {}'.format(sg_config))
+    log_info('sg_admin_url: {}'.format(sg_admin_url))
+    log_info('sg_url: {}'.format(sg_url))
+    log_info('cbs_url: {}'.format(cbs_url))
+
+    cluster = Cluster(config=cluster_config)
+    cluster.reset(sg_config_path=sg_config)
+
+    # Create clients
+    sg_client = MobileRestClient()
+    cbs_ip = host_for_url(cbs_url)
+    if cluster.ipv6:
+        sdk_client = Bucket('couchbase://{}/{}?ipv6=allow'.format(cbs_ip, bucket_name), password='password', timeout=SDK_TIMEOUT)
+    else:
+        sdk_client = Bucket('couchbase://{}/{}'.format(cbs_ip, bucket_name), password='password', timeout=SDK_TIMEOUT)
+
+    # Create user / session
+    auto_user_info = UserInfo(name='autotest', password='pass', channels=['mobileOptIn'], roles=[])
+    sg_client.create_user(
+        url=sg_admin_url,
+        db=sg_db,
+        name=auto_user_info.name,
+        password=auto_user_info.password,
+        channels=auto_user_info.channels
+    )
+
+    test_auth_session = sg_client.create_session(
+        url=sg_admin_url,
+        db=sg_db,
+        name=auto_user_info.name
+    )
+
+    if sg_platform == "windows":
+        json_cluster = load_cluster_config_json(cluster_config)
+        sghost_username = json_cluster["sync_gateways:vars"]["ansible_user"]
+        sghost_password = json_cluster["sync_gateways:vars"]["ansible_password"]
+        remote_executor = RemoteExecutor(cluster.sync_gateways[0].ip, sg_platform, sghost_username, sghost_password)
+    else:
+        remote_executor = RemoteExecutor(cluster.sync_gateways[0].ip)
+
+    # 1. Create doc in CBS with xattrs off and verify doc is not imported
+    doc_id1 = 'non_mobile_ignore_1'
+    doc = document.create_doc(doc_id=doc_id1, channels=['non_mobile_ignore'])
+    sdk_client.upsert(doc_id1, doc)
+    try:
+        sg_client.get_doc(url=sg_url, db=sg_db, doc_id=doc_id1, auth=test_auth_session)
+        assert False, "doc imported to sync gateway with xttars on"
+    except HTTPError as e:
+        log_info("Got the Http error".format(e))
+
+    # 2. Verify “non_mobile_ignored_count” is 0 on _expvar end point
+    sg_expvars = sg_client.get_expvars(url=sg_admin_url)
+    non_mobile_ignore_count = sg_expvars["syncgateway"]["per_db"][sg_db]["cache"]["non_mobile_ignored_count"]
+    assert non_mobile_ignore_count == 1, "non_mobile_ignore_count did not get expected count"
+
+    # 3. Create another document('abc') on CBS and verify it is not imported and verify that info logs generate the log
+    #    “Cache: changeCache: Doc “abc” does not have valid sync data”
+    doc_id2 = 'non_mobile_ignore_2'
+    doc = document.create_doc(doc_id=doc_id2, channels=['non_mobile_ignore'])
+    sdk_client.upsert(doc_id2, doc)
+
+    command = "grep 'Cache: changeCache' /tmp/sg_logs/sg_info.log | wc -l"
+    command1 = "grep 'does not have valid sync data' /tmp/sg_logs/sg_info.log | wc -l"
+    if sg_platform == "macos":
+        stdout = subprocess.check_output(command, shell=True)
+        assert int(stdout) == 1, "did not find the expected match on sg info logs"
+        print("stdout for platform is ", int(stdout))
+        stdout = subprocess.check_output(command1, shell=True)
+        assert int(stdout) == 1, "did not find the expected match on sg info logs"
+    else:
+        if sg_platform == "windows":
+            command = "grep 'Cache: changeCache' C:\\\\tmp\\\\sg_logs\sg_info.log | wc -l"
+            command1 = "grep 'does not have valid sync data' C:\\\\tmp\\\\sg_logs\sg_info.log | wc -l"
+        _, stdout, _ = remote_executor.execute(command)
+        assert int(stdout[0]) > 0, "did not find the expected match on sg info logs"
+        log1_num = int(stdout[0])
+        _, stdout, _ = remote_executor.execute(command1)
+        log2_num = int(stdout[0])
+        assert int(stdout[0]) > 0, "did not find the expected match on sg info log"
+
+    # 4. Verify “non_mobile_ignored_count” is 1 on _expvar end point
+    sg_expvars = sg_client.get_expvars(url=sg_admin_url)
+    non_mobile_ignore_count = sg_expvars["syncgateway"]["per_db"][sg_db]["cache"]["non_mobile_ignored_count"]
+    assert non_mobile_ignore_count == 2, "non_mobile_ignore_count did not get expected count"
+
+    # 6. Restart SGW , Verify “non_mobile_ignored_count” is 0
+    status = cluster.sync_gateways[0].restart(config=sg_config, cluster_config=cluster_config)
+    assert status == 0, "Syncgateway did not start after adding revs_limit  with no conflicts mode "
+
+    # 7. Create document('def') and verify info logs show the message “Cache: changeCache: Doc “def” does not have valid sync data”
+    #    verify “non_mobile_ignored_count” is 1
+    doc_id3 = 'non_mobile_ignore_3'
+    doc = document.create_doc(doc_id=doc_id3, channels=['non_mobile_ignore'])
+    sdk_client.upsert(doc_id3, doc)
+
+    if sg_platform == "macos":
+        stdout = subprocess.check_output(command, shell=True)
+        assert int(stdout) == 1, "did not find the expected match on sg info logs"
+        stdout = subprocess.check_output(command1, shell=True)
+        assert int(stdout) == 1, "did not find the expected match on sg info logs"
+    else:
+        _, stdout, _ = remote_executor.execute(command)
+        assert int(stdout[0]) == 1 + log1_num, "did not find the expected match on sg info logs"
+        _, stdout, _ = remote_executor.execute(command1)
+        assert int(stdout[0]) == 1 + log2_num, "did not find the expected match on sg info log"
+
+    sg_expvars = sg_client.get_expvars(url=sg_admin_url)
+    non_mobile_ignore_count = sg_expvars["syncgateway"]["per_db"][sg_db]["cache"]["non_mobile_ignored_count"]
+    assert non_mobile_ignore_count == 1, "non_mobile_ignore_count did not get expected count"
+
+    # 8. Verify warn_count is 0
+    assert sg_expvars["syncgateway"]["global"]["resource_utilization"]["warn_count"] == 0, "warn_count is not 0"


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- added non mobile ignore count new test
- fixed SGW test which is failing on windows 
- fixed couchbase server recovery end point by adding retries which is failing inconsistently on regression 

http://uberjenkins.sc.couchbase.com:8080/job/win10-sync-gateway-functional-tests-base-cc/1050/
http://uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-functional-tests-topology-xattrs-userView-ServerSsl/2240/