### PR TITLE
Adding default metrics call on Sg

### DIFF
--- a/testsuites/syncgateway/functional/topology_specific_tests/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/conftest.py
@@ -95,7 +95,7 @@ def pytest_addoption(parser):
                      help="magma-storage: Enable magma storage on couchbase server")
 
     parser.addoption("--prometheus-enable",
-                     action="store",
+                     action="store_true",
                      help="prometheus-enable:Start prometheus metrics on SyncGateway")
 
     parser.addoption("--hide-product-version",

--- a/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
@@ -44,6 +44,7 @@ def params_from_base_suite_setup(request):
     cbs_platform = request.config.getoption("--cbs-platform")
     magma_storage_enabled = request.config.getoption("--magma-storage")
     hide_product_version = request.config.getoption("--hide-product-version")
+    prometheus_enabled = request.config.getoption("--prometheus-enable")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -70,6 +71,7 @@ def params_from_base_suite_setup(request):
     log_info("sg_platform: {}".format(sg_platform))
     log_info("cbs_platform: {}".format(cbs_platform))
     log_info("Delta_sync: {}".format(delta_sync_enabled))
+    log_info("prometheus_enabled: {}".format(prometheus_enabled))
 
     # sg-ce is invalid for di mode
     if mode == "di" and sg_ce:

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
@@ -42,6 +42,7 @@ def params_from_base_suite_setup(request):
     sg_platform = request.config.getoption("--sg-platform")
     magma_storage_enabled = request.config.getoption("--magma-storage")
     hide_product_version = request.config.getoption("--hide-product-version")
+    prometheus_enabled = request.config.getoption("--prometheus-enable")
 
     log_info("server_version: {}".format(server_version))
     log_info("sync_gateway_version: {}".format(sync_gateway_version))
@@ -60,6 +61,7 @@ def params_from_base_suite_setup(request):
     log_info("sa_installer_type: {}".format(sa_installer_type))
     log_info("delta_sync_enabled: {}".format(delta_sync_enabled))
     log_info("sg_platform: {}".format(sg_platform))
+    log_info("prometheus_enabled: {}".format(prometheus_enabled))
 
     # sg-ce is invalid for di mode
     if mode == "di" and sg_ce:

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
@@ -47,6 +47,7 @@ def params_from_base_suite_setup(request):
     cbs_platform = request.config.getoption("--cbs-platform")
     magma_storage_enabled = request.config.getoption("--magma-storage")
     hide_product_version = request.config.getoption("--hide-product-version")
+    prometheus_enabled = request.config.getoption("--prometheus-enable")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -74,6 +75,7 @@ def params_from_base_suite_setup(request):
     log_info("cbs_platform: {}".format(cbs_platform))
     log_info("Delta_sync: {}".format(delta_sync_enabled))
     log_info("hide_product_version: {}".format(hide_product_version))
+    log_info("prometheus_enabled: {}".format(prometheus_enabled))
 
     # sg-ce is invalid for di mode
     if mode == "di" and sg_ce:

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -244,7 +244,8 @@ def params_from_base_suite_setup(request):
            "sg_platform": sg_platform,
            "sync_gateway_version": sync_gateway_version,
            "sg_ce": sg_ce,
-           "prometheus_enabled": prometheus_enabled
+           "prometheus_enabled": prometheus_enabled,
+           "sg_ssl": sg_ssl
            }
 
     log_info("Tearing down 'params_from_base_suite_setup' ...")
@@ -275,6 +276,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     sync_gateway_version = params_from_base_suite_setup["sync_gateway_version"]
     sg_ce = params_from_base_suite_setup["sg_ce"]
     prometheus_enabled = params_from_base_suite_setup["prometheus_enabled"]
+    sg_ssl = params_from_base_suite_setup["sg_ssl"]
 
     test_name = request.node.name
     log_info("Setting up test '{}'".format(test_name))
@@ -286,7 +288,8 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
            "sg_platform": sg_platform,
            "sync_gateway_version": sync_gateway_version,
            "sg_ce": sg_ce,
-           "prometheus_enabled": prometheus_enabled
+           "prometheus_enabled": prometheus_enabled,
+           "sg_ssl": sg_ssl
            }
 
     # Code after the yeild will execute when each test finishes

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_sg_replicate.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_sg_replicate.py
@@ -158,7 +158,7 @@ def test_sg_replicate_basic_test(params_from_base_test_setup):
     if prometheus_enabled and sync_gateway_version >= "2.8.0":
         assert verify_stat_on_prometheus("sgw_resource_utilization_system_memory_total"), expvars["syncgateway"]["global"]["resource_utilization"]["system_memory_total"]
         assert verify_stat_on_prometheus("sgw_cache_chan_cache_max_entries"), expvars["syncgateway"]["per_db"][DB2]["cache"]["chan_cache_max_entries"]
-        assert verify_stat_on_prometheus("sgw_gsi_views_allDocs_count"), expvars["syncgateway"]["per_db"][DB2]["cache"]["chan_cache_max_entries"]
+        assert verify_stat_on_prometheus("sgw_gsi_views_access_count"), expvars["syncgateway"]["per_db"][DB1]["gsi_views"]["access_query_count"]
         replication_id = replication_result["replication_id"]
         expvars = sg_client.get_expvars(sg1.admin.admin_url)
         assert verify_stat_on_prometheus("sgw_replication_sgr_num_docs_pushed"), expvars["syncgateway"]["per_replication"][replication_id]["sgr_num_docs_pushed"]

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_sg_replicate.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_sg_replicate.py
@@ -162,7 +162,7 @@ def test_sg_replicate_basic_test(params_from_base_test_setup):
         replication_id = replication_result["replication_id"]
         expvars = sg_client.get_expvars(sg1.admin.admin_url)
         assert verify_stat_on_prometheus("sgw_replication_sgr_num_docs_pushed"), expvars["syncgateway"]["per_replication"][replication_id]["sgr_num_docs_pushed"]
-    else:
+    if not prometheus_enabled and sync_gateway_version >= "2.8.0":
         cluster = Cluster(config=cluster_config)
         remote_executor = RemoteExecutor(cluster.sync_gateways[0].ip)
         if sg_ssl:

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_sg_replicate.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_sg_replicate.py
@@ -179,7 +179,7 @@ def test_sg_replicate_basic_test(params_from_base_test_setup):
 @pytest.mark.channel
 @pytest.mark.basicauth
 @pytest.mark.changes
-def sg_replicate_basic_test_channels(params_from_base_test_setup):
+def test_sg_replicate_basic_test_channels(params_from_base_test_setup):
 
     cluster_config = params_from_base_test_setup["cluster_config"]
     mode = params_from_base_test_setup["mode"]

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_sg_replicate.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_sg_replicate.py
@@ -51,7 +51,6 @@ def test_sg_replicate_basic_test(params_from_base_test_setup):
         cluster_config=cluster_config,
         sg_config_path=config
     )
-    print(sg1)
     admin = Admin(sg1)
     admin.admin_url = sg1.url
 

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_sg_replicate.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_sg_replicate.py
@@ -162,6 +162,7 @@ def test_sg_replicate_basic_test(params_from_base_test_setup):
         replication_id = replication_result["replication_id"]
         expvars = sg_client.get_expvars(sg1.admin.admin_url)
         assert verify_stat_on_prometheus("sgw_replication_sgr_num_docs_pushed"), expvars["syncgateway"]["per_replication"][replication_id]["sgr_num_docs_pushed"]
+    else:
         cluster = Cluster(config=cluster_config)
         remote_executor = RemoteExecutor(cluster.sync_gateways[0].ip)
         if sg_ssl:


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Added assertion for ssl and non ssl default metrics call 
- Also changed promethus flag 
- uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-functional-tests-topology-xattrs-userView-ServerSsl/2247

http://uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-functional-tests-topology-xattrs-userView-ServerSsl/2252/testReport/