### PR TITLE
fix CM-753

### DIFF
--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_cache_management_multple_sgws.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_cache_management_multple_sgws.py
@@ -243,7 +243,6 @@ def test_sgw_high_availability(params_from_base_test_setup, setup_basic_sg_conf)
         assert sg1_import_count > diff_docs, "Not all docs imported"
         if prometheus_enabled and sync_gateway_version >= "2.8.0":
             assert verify_stat_on_prometheus("sgw_shared_bucket_import_import_count"), sg1_expvars["syncgateway"]["per_db"][sg_db]["shared_bucket_import"]["import_count"]
-            assert verify_stat_on_prometheus("sgw_gsi_views_allDocs_count"), num_docs
 
 
 def create_doc_via_sdk_individually(cbs_url, cbs_cluster, bucket_name, num_docs):


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

-  Test fix,   gsi is already covered in the  test_sg_replicate_basic_test
- 
- assert verify_stat_on_prometheus("sgw_gsi_views_access_count"), expvars["syncgateway"]["per_db"][DB1]["gsi_views"]["access_query_count"]
        replication_id = replication_result["replication_id"]
-

