### PR TITLE
skip reset checkpoint test, api has been removed in 3.0

### DIFF
--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
@@ -2985,7 +2985,10 @@ def test_resetCheckpointFailure(params_from_base_test_setup):
     liteserv_platform = params_from_base_test_setup["liteserv_platform"]
     liteserv_version = params_from_base_test_setup["liteserv_version"]
     if liteserv_version < "2.1":
-        pytest.skip('database encryption feature not available with version < 2.1')
+        pytest.skip('resetCheckpointFailure feature not available with version < 2.1')
+
+    if liteserv_version >= "3.0":
+        pytest.skip('resetCheckpointFailure API has been deprecated in 2.8 and removed in 3.0')
 
     if(liteserv_platform.lower() == "ios"):
         pytest.skip('ResetCheckPoint API does not throw exception in iOS if replicator is not stopped, so skipping test')


### PR DESCRIPTION
#### Fixes cm-784

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- resetCheckpoint api has been removed in 3.0, set the test case skip for version 3.0+


