### PR TITLE
Fix/support cbs dp

### DIFF
--- a/libraries/provision/ansible/playbooks/install-couchbase-server-package.yml
+++ b/libraries/provision/ansible/playbooks/install-couchbase-server-package.yml
@@ -7,6 +7,7 @@
     couchbase_server_package_base_url:
     couchbase_server_package_name:
     ipv6_enabled:
+    cbs_dp_preview:
     couchbase_server_package_url: "{{ couchbase_server_package_base_url }}/{{ couchbase_server_package_name }}"
 
 
@@ -212,3 +213,7 @@
     - name: COUCHBASE SERVER | Enable auto failover (3.X to 5.X) | configure IPv6
       shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli setting-autofailover -c [{{ couchbase_server_primary_node }}]:{{ couchbase_server_admin_port }} --user={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --enable-auto-failover=1 --auto-failover-timeout=30"
       when: "{{ cb_major_version['stdout'] | search('\\b[3-5]\\b')}} and ipv6_enabled"
+
+    - name: COUCHBASE SERVER | Enable developer preview (6.X and up)
+      shell: yes | {{ couchbase_server_home_path }}/bin/couchbase-cli enable-developer-preview --enable -c localhost:{{ couchbase_server_admin_port }} -u {{ couchbase_server_admin }} -p {{ couchbase_server_password }}
+      when:  "(not {{ cb_major_version['stdout'] | search('\\b[1-5]\\b') }}) and {{ cbs_dp_preview }}"

--- a/libraries/provision/install_couchbase_server.py
+++ b/libraries/provision/install_couchbase_server.py
@@ -73,7 +73,8 @@ def install_couchbase_server(cluster_config, couchbase_server_config, cbs_platfo
         extra_vars={
             "couchbase_server_package_base_url": server_baseurl,
             "couchbase_server_package_name": server_package_name,
-            "ipv6_enabled": cluster["environment"]["ipv6_enabled"]
+            "ipv6_enabled": cluster["environment"]["ipv6_enabled"],
+            "cbs_dp_preview": cluster["environment"]["cbs_developer_preview"]
         }
     )
     if status != 0:

--- a/testsuites/CBLTester/CBL_Functional_tests/conftest.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/conftest.py
@@ -173,7 +173,7 @@ def pytest_addoption(parser):
                      help="Hides SGW product version when you hit SGW url",
                      default=False)
 
-    parser.addoption("--enable_cbs_developer_preview",
+    parser.addoption("--enable-cbs-developer-preview",
                      action="store_true",
                      help="Enabling CBS developer preview",
                      default=False)
@@ -221,7 +221,7 @@ def params_from_base_suite_setup(request):
     enable_encryption = request.config.getoption("--enable-encryption")
     encryption_password = request.config.getoption("--encryption-password")
     hide_product_version = request.config.getoption("--hide-product-version")
-    enable_cbs_developer_preview = request.config.getoption("--enable_cbs_developer_preview")
+    enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
 
     test_name = request.node.name
 

--- a/testsuites/CBLTester/CBL_Functional_tests/conftest.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/conftest.py
@@ -172,6 +172,12 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="Hides SGW product version when you hit SGW url",
                      default=False)
+
+    parser.addoption("--enable_cbs_developer_preview",
+                     action="store_true",
+                     help="Enabling CBS developer preview",
+                     default=False)
+
 # This will get called once before the first test that
 # runs with this as input parameters in this file
 # This setup will be called once for all tests in the
@@ -215,6 +221,7 @@ def params_from_base_suite_setup(request):
     enable_encryption = request.config.getoption("--enable-encryption")
     encryption_password = request.config.getoption("--encryption-password")
     hide_product_version = request.config.getoption("--hide-product-version")
+    enable_cbs_developer_preview = request.config.getoption("--enable_cbs_developer_preview")
 
     test_name = request.node.name
 
@@ -350,6 +357,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without suppress SGW product Version")
         persist_cluster_config_environment_prop(cluster_config, 'hide_product_version', False)
+
+    if enable_cbs_developer_preview:
+        log_info("Enable CBS developer preview")
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', True)
+    else:
+        log_info("Running without CBS developer preview")
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
 
     # As cblite jobs run with on Centos platform, adding by default centos to environment config
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)

--- a/testsuites/CBLTester/p2p_topology_specific_tests/conftest.py
+++ b/testsuites/CBLTester/p2p_topology_specific_tests/conftest.py
@@ -127,11 +127,17 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="delta-sync: Enable delta-sync for sync gateway")
 
+    parser.addoption("--enable_cbs_developer_preview",
+                     action="store_true",
+                     help="Enabling CBS developer preview",
+                     default=False)
 
 # This will get called once before the first test that
 # runs with this as input parameters in this file
 # This setup will be called once for all tests in the
 # testsuites/CBLTester/topology_sync_gateways/multiple_sync_gateways directory
+
+
 @pytest.fixture(scope="session")
 def params_from_base_suite_setup(request):
     liteserv_platform = request.config.getoption("--liteserv-platform")
@@ -158,9 +164,10 @@ def params_from_base_suite_setup(request):
     number_replicas = request.config.getoption("--number-replicas")
     enable_file_logging = request.config.getoption("--enable-file-logging")
     delta_sync_enabled = request.config.getoption("--delta-sync")
-
     enable_encryption = request.config.getoption("--enable-encryption")
     encryption_password = request.config.getoption("--encryption-password")
+    enable_cbs_developer_preview = request.config.getoption("--enable_cbs_developer_preview")
+
     liteserv_host_list = liteserv_host.split(',')
     liteserv_ports = liteserv_port.split(',')
     testserver = TestServerFactory.create(platform=liteserv_platform,
@@ -252,6 +259,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without delta sync")
         persist_cluster_config_environment_prop(cluster_config, 'delta_sync_enabled', False)
+
+    if enable_cbs_developer_preview:
+        log_info("Enable CBS developer preview")
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', True)
+    else:
+        log_info("Running without CBS developer preview")
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
 
     # As cblite jobs run with on Centos platform, adding by default centos to environment config
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)

--- a/testsuites/CBLTester/p2p_topology_specific_tests/conftest.py
+++ b/testsuites/CBLTester/p2p_topology_specific_tests/conftest.py
@@ -127,7 +127,7 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="delta-sync: Enable delta-sync for sync gateway")
 
-    parser.addoption("--enable_cbs_developer_preview",
+    parser.addoption("--enable-cbs-developer-preview",
                      action="store_true",
                      help="Enabling CBS developer preview",
                      default=False)
@@ -166,7 +166,7 @@ def params_from_base_suite_setup(request):
     delta_sync_enabled = request.config.getoption("--delta-sync")
     enable_encryption = request.config.getoption("--enable-encryption")
     encryption_password = request.config.getoption("--encryption-password")
-    enable_cbs_developer_preview = request.config.getoption("--enable_cbs_developer_preview")
+    enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
 
     liteserv_host_list = liteserv_host.split(',')
     liteserv_ports = liteserv_port.split(',')

--- a/testsuites/CBLTester/topology_specific_tests/conftest.py
+++ b/testsuites/CBLTester/topology_specific_tests/conftest.py
@@ -125,3 +125,8 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="Hides SGW product version when you hit SGW url",
                      default=False)
+
+    parser.addoption("--enable_cbs_developer_preview",
+                     action="store_true",
+                     help="Enabling CBS developer preview",
+                     default=False)

--- a/testsuites/CBLTester/topology_specific_tests/conftest.py
+++ b/testsuites/CBLTester/topology_specific_tests/conftest.py
@@ -126,7 +126,7 @@ def pytest_addoption(parser):
                      help="Hides SGW product version when you hit SGW url",
                      default=False)
 
-    parser.addoption("--enable_cbs_developer_preview",
+    parser.addoption("--enable-cbs-developer-preview",
                      action="store_true",
                      help="Enabling CBS developer preview",
                      default=False)

--- a/testsuites/CBLTester/upgrade_tests/conftest.py
+++ b/testsuites/CBLTester/upgrade_tests/conftest.py
@@ -131,7 +131,7 @@ def pytest_addoption(parser):
                      help="Hides SGW product version when you hit SGW url",
                      default=False)
 
-    parser.addoption("--enable_cbs_developer_preview",
+    parser.addoption("--enable-cbs-developer-preview",
                      action="store_true",
                      help="Enabling CBS developer preview",
                      default=False)
@@ -172,7 +172,7 @@ def params_from_base_suite_setup(request):
     second_liteserv_host = request.config.getoption("--second-liteserv-host")
     second_liteserv_version = request.config.getoption("--second-liteserv-version")
     second_liteserv_platform = request.config.getoption("--second-liteserv-platform")
-    enable_cbs_developer_preview = request.config.getoption("--enable_cbs_developer_preview")
+    enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
 
     test_name = request.node.name
     if enable_upgrade_app:

--- a/testsuites/CBLTester/upgrade_tests/conftest.py
+++ b/testsuites/CBLTester/upgrade_tests/conftest.py
@@ -131,11 +131,17 @@ def pytest_addoption(parser):
                      help="Hides SGW product version when you hit SGW url",
                      default=False)
 
+    parser.addoption("--enable_cbs_developer_preview",
+                     action="store_true",
+                     help="Enabling CBS developer preview",
+                     default=False)
 
 # This will get called once before the first test that
 # runs with this as input parameters in this file
 # This setup will be called once for all tests in the
 # testsuites/CBLTester/CBL_Functional_tests/ directory
+
+
 @pytest.fixture(scope="session")
 def params_from_base_suite_setup(request):
     liteserv_platform = request.config.getoption("--liteserv-platform")
@@ -166,6 +172,7 @@ def params_from_base_suite_setup(request):
     second_liteserv_host = request.config.getoption("--second-liteserv-host")
     second_liteserv_version = request.config.getoption("--second-liteserv-version")
     second_liteserv_platform = request.config.getoption("--second-liteserv-platform")
+    enable_cbs_developer_preview = request.config.getoption("--enable_cbs_developer_preview")
 
     test_name = request.node.name
     if enable_upgrade_app:
@@ -284,6 +291,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without suppress SGW product Version")
         persist_cluster_config_environment_prop(cluster_config, 'hide_product_version', False)
+
+    if enable_cbs_developer_preview:
+        log_info("Enable CBS developer preview")
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', True)
+    else:
+        log_info("Running without CBS developer preview")
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
 
     # As cblite jobs run with on Centos platform, adding by default centos to environment config
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -162,7 +162,7 @@ def pytest_addoption(parser):
                      help="Hides SGW product version when you hit SGW url",
                      default=False)
 
-    parser.addoption("--enable_cbs_developer_preview",
+    parser.addoption("--enable-cbs-developer-preview",
                      action="store_true",
                      help="Enabling CBS developer preview",
                      default=False)
@@ -204,7 +204,7 @@ def params_from_base_suite_setup(request):
     magma_storage_enabled = request.config.getoption("--magma-storage")
     prometheus_enabled = request.config.getoption("--prometheus-enable")
     hide_product_version = request.config.getoption("--hide-product-version")
-    enable_cbs_developer_preview = request.config.getoption("--enable_cbs_developer_preview")
+    enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -162,6 +162,11 @@ def pytest_addoption(parser):
                      help="Hides SGW product version when you hit SGW url",
                      default=False)
 
+    parser.addoption("--enable_cbs_developer_preview",
+                     action="store_true",
+                     help="Enabling CBS developer preview",
+                     default=False)
+
 # This will be called once for the at the beggining of the execution in the 'tests/' directory
 # and will be torn down, (code after the yeild) when all the test session has completed.
 # IMPORTANT: Tests in 'tests/' should be executed in their own test run and should not be
@@ -199,6 +204,7 @@ def params_from_base_suite_setup(request):
     magma_storage_enabled = request.config.getoption("--magma-storage")
     prometheus_enabled = request.config.getoption("--prometheus-enable")
     hide_product_version = request.config.getoption("--hide-product-version")
+    enable_cbs_developer_preview = request.config.getoption("--enable_cbs_developer_preview")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -227,6 +233,7 @@ def params_from_base_suite_setup(request):
     log_info("number_replicas: {}".format(number_replicas))
     log_info("delta_sync_enabled: {}".format(delta_sync_enabled))
     log_info("hide_product_version: {}".format(hide_product_version))
+    log_info("enable_cbs_developer_preview: {}".format(enable_cbs_developer_preview))
 
     # sg-ce is invalid for di mode
     if mode == "di" and sg_ce:
@@ -367,6 +374,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without suppress SGW product Version")
         persist_cluster_config_environment_prop(cluster_config, 'hide_product_version', False)
+
+    if enable_cbs_developer_preview:
+        log_info("Enable CBS developer preview")
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', True)
+    else:
+        log_info("Running without CBS developer preview")
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
 
     sg_config = sync_gateway_config_path_for_mode("sync_gateway_default_functional_tests", mode)
 

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -46,7 +46,7 @@ def params_from_base_suite_setup(request):
     magma_storage_enabled = request.config.getoption("--magma-storage")
     prometheus_enabled = request.config.getoption("--prometheus-enable")
     hide_product_version = request.config.getoption("--hide-product-version")
-    enable_cbs_developer_preview = request.config.getoption("--enable_cbs_developer_preview")
+    enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -46,6 +46,7 @@ def params_from_base_suite_setup(request):
     magma_storage_enabled = request.config.getoption("--magma-storage")
     prometheus_enabled = request.config.getoption("--prometheus-enable")
     hide_product_version = request.config.getoption("--hide-product-version")
+    enable_cbs_developer_preview = request.config.getoption("--enable_cbs_developer_preview")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -72,6 +73,7 @@ def params_from_base_suite_setup(request):
     log_info("delta_sync_enabled: {}".format(delta_sync_enabled))
     log_info("prometheus_enabled: {}".format(prometheus_enabled))
     log_info("hide_product_version: {}".format(hide_product_version))
+    log_info("enable_cbs_developer_preview: {}".format(enable_cbs_developer_preview))
 
     # sg-ce is invalid for di mode
     if mode == "di" and sg_ce:
@@ -193,6 +195,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without suppress SGW product Version")
         persist_cluster_config_environment_prop(cluster_config, 'hide_product_version', False)
+
+    if enable_cbs_developer_preview:
+        log_info("Enable CBS developer preview")
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', True)
+    else:
+        log_info("Running without CBS developer preview")
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
 
     if sync_gateway_version < "2.0.0" and no_conflicts_enabled:
         pytest.skip("Test cannot run with no-conflicts with sg version < 2.0.0")

--- a/testsuites/syncgateway/system/conftest.py
+++ b/testsuites/syncgateway/system/conftest.py
@@ -115,12 +115,18 @@ def pytest_addoption(parser):
                      help="Hides SGW product version when you hit SGW url",
                      default=False)
 
+    parser.addoption("--enable_cbs_developer_preview",
+                     action="store_true",
+                     help="Enabling CBS developer preview",
+                     default=False)
 
 # This will be called once for the at the beggining of the execution in the 'tests/' directory
 # and will be torn down, (code after the yeild) when all the test session has completed.
 # IMPORTANT: Tests in 'tests/' should be executed in their own test run and should not be
 # run in the same test run with 'topology_specific_tests/'. Doing so will make have unintended
 # side effects due to the session scope
+
+
 @pytest.fixture(scope="session")
 def params_from_base_suite_setup(request):
     log_info("Setting up 'params_from_base_suite_setup' ...")
@@ -148,6 +154,7 @@ def params_from_base_suite_setup(request):
     use_views = request.config.getoption("--use-views")
     number_replicas = request.config.getoption("--number-replicas")
     hide_product_version = request.config.getoption("--hide-product-version")
+    enable_cbs_developer_preview = request.config.getoption("--enable_cbs_developer_preview")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -162,6 +169,7 @@ def params_from_base_suite_setup(request):
     log_info("use_views: {}".format(use_views))
     log_info("number_replicas: {}".format(number_replicas))
     log_info("hide_product_version: {}".format(hide_product_version))
+    log_info("enable_cbs_developer_preview: {}".format(enable_cbs_developer_preview))
 
     # Make sure mode for sync_gateway is supported ('cc' or 'di')
     validate_sync_gateway_mode(mode)
@@ -232,6 +240,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without suppress SGW product Version")
         persist_cluster_config_environment_prop(cluster_config, 'hide_product_version', False)
+
+    if enable_cbs_developer_preview:
+        log_info("Enable CBS developer preview")
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', True)
+    else:
+        log_info("Running without CBS developer preview")
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
 
     sg_config = sync_gateway_config_path_for_mode("sync_gateway_default_functional_tests", mode)
 

--- a/testsuites/syncgateway/system/conftest.py
+++ b/testsuites/syncgateway/system/conftest.py
@@ -115,7 +115,7 @@ def pytest_addoption(parser):
                      help="Hides SGW product version when you hit SGW url",
                      default=False)
 
-    parser.addoption("--enable_cbs_developer_preview",
+    parser.addoption("--enable-cbs-developer-preview",
                      action="store_true",
                      help="Enabling CBS developer preview",
                      default=False)
@@ -154,7 +154,7 @@ def params_from_base_suite_setup(request):
     use_views = request.config.getoption("--use-views")
     number_replicas = request.config.getoption("--number-replicas")
     hide_product_version = request.config.getoption("--hide-product-version")
-    enable_cbs_developer_preview = request.config.getoption("--enable_cbs_developer_preview")
+    enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)

--- a/testsuites/syncgateway/upgrade/liteserv/conftest.py
+++ b/testsuites/syncgateway/upgrade/liteserv/conftest.py
@@ -143,7 +143,7 @@ def pytest_addoption(parser):
                      help="Hides SGW product version when you hit SGW url",
                      default=False)
 
-    parser.addoption("--enable_cbs_developer_preview",
+    parser.addoption("--enable-cbs-developer-preview",
                      action="store_true",
                      help="Enabling CBS developer preview",
                      default=False)
@@ -184,7 +184,7 @@ def params_from_base_suite_setup(request):
     delta_sync_enabled = request.config.getoption("--delta-sync")
     magma_storage_enabled = request.config.getoption("--magma-storage")
     hide_product_version = request.config.getoption("--hide-product-version")
-    enable_cbs_developer_preview = request.config.getoption("--enable_cbs_developer_preview")
+    enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_upgraded_version, sync_gateway_upgraded_version)

--- a/testsuites/syncgateway/upgrade/liteserv/conftest.py
+++ b/testsuites/syncgateway/upgrade/liteserv/conftest.py
@@ -143,12 +143,18 @@ def pytest_addoption(parser):
                      help="Hides SGW product version when you hit SGW url",
                      default=False)
 
+    parser.addoption("--enable_cbs_developer_preview",
+                     action="store_true",
+                     help="Enabling CBS developer preview",
+                     default=False)
 
 # This will be called once for the at the beggining of the execution in the 'tests/' directory
 # and will be torn down, (code after the yeild) when all the test session has completed.
 # IMPORTANT: Tests in 'tests/' should be executed in their own test run and should not be
 # run in the same test run with 'topology_specific_tests/'. Doing so will make have unintended
 # side effects due to the session scope
+
+
 @pytest.fixture(scope="session")
 def params_from_base_suite_setup(request):
     log_info("Setting up 'params_from_base_suite_setup' ...")
@@ -178,6 +184,7 @@ def params_from_base_suite_setup(request):
     delta_sync_enabled = request.config.getoption("--delta-sync")
     magma_storage_enabled = request.config.getoption("--magma-storage")
     hide_product_version = request.config.getoption("--hide-product-version")
+    enable_cbs_developer_preview = request.config.getoption("--enable_cbs_developer_preview")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_upgraded_version, sync_gateway_upgraded_version)
@@ -203,6 +210,7 @@ def params_from_base_suite_setup(request):
     log_info("number_replicas: {}".format(number_replicas))
     log_info("delta_sync_enabled: {}".format(delta_sync_enabled))
     log_info("hide_product_version: {}".format(hide_product_version))
+    log_info("enable_cbs_developer_preview: {}".format(enable_cbs_developer_preview))
 
     # Make sure mode for sync_gateway is supported ('cc' or 'di')
     validate_sync_gateway_mode(mode)
@@ -281,6 +289,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without suppress SGW product Version")
         persist_cluster_config_environment_prop(cluster_config, 'hide_product_version', False)
+
+    if enable_cbs_developer_preview:
+        log_info("Enable CBS developer preview")
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', True)
+    else:
+        log_info("Running without CBS developer preview")
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
 
     # SGW upgrade job run with on Centos platform, adding by default centos to environment config
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)

--- a/testsuites/syncgateway/upgrade/testserver/sg_single_sgw/conftest.py
+++ b/testsuites/syncgateway/upgrade/testserver/sg_single_sgw/conftest.py
@@ -148,6 +148,11 @@ def pytest_addoption(parser):
                      help="Hides SGW product version when you hit SGW url",
                      default=False)
 
+    parser.addoption("--enable_cbs_developer_preview",
+                     action="store_true",
+                     help="Enabling CBS developer preview",
+                     default=False)
+
 
 # This will get called once before the first test that
 # runs with this as input parameters in this file
@@ -194,6 +199,7 @@ def params_from_base_suite_setup(request):
     cbs_toy_build = request.config.getoption("--cbs-upgrade-toybuild")
     magma_storage_enabled = request.config.getoption("--magma-storage")
     hide_product_version = request.config.getoption("--hide-product-version")
+    enable_cbs_developer_preview = request.config.getoption("--enable_cbs_developer_preview")
 
     test_name = request.node.name
 
@@ -225,6 +231,7 @@ def params_from_base_suite_setup(request):
     log_info("device_enabled: {}".format(device_enabled))
     log_info("cbs_toy_build: {}".format(cbs_toy_build))
     log_info("hide_product_version: {}".format(hide_product_version))
+    log_info("enable_cbs_developer_preview: {}".format(enable_cbs_developer_preview))
 
     # if xattrs is specified but the post upgrade SG version doesn't support, don't continue
     if upgraded_xattrs_enabled and version_is_binary(sync_gateway_upgraded_version):
@@ -350,6 +357,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without suppress SGW product Version")
         persist_cluster_config_environment_prop(cluster_config, 'hide_product_version', False)
+
+    if enable_cbs_developer_preview:
+        log_info("Enable CBS developer preview")
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', True)
+    else:
+        log_info("Running without CBS developer preview")
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
 
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)
 

--- a/testsuites/syncgateway/upgrade/testserver/sg_single_sgw/conftest.py
+++ b/testsuites/syncgateway/upgrade/testserver/sg_single_sgw/conftest.py
@@ -148,7 +148,7 @@ def pytest_addoption(parser):
                      help="Hides SGW product version when you hit SGW url",
                      default=False)
 
-    parser.addoption("--enable_cbs_developer_preview",
+    parser.addoption("--enable-cbs-developer-preview",
                      action="store_true",
                      help="Enabling CBS developer preview",
                      default=False)
@@ -199,7 +199,7 @@ def params_from_base_suite_setup(request):
     cbs_toy_build = request.config.getoption("--cbs-upgrade-toybuild")
     magma_storage_enabled = request.config.getoption("--magma-storage")
     hide_product_version = request.config.getoption("--hide-product-version")
-    enable_cbs_developer_preview = request.config.getoption("--enable_cbs_developer_preview")
+    enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
 
     test_name = request.node.name
 

--- a/utilities/cluster_config_utils.py
+++ b/utilities/cluster_config_utils.py
@@ -51,7 +51,7 @@ def persist_cluster_config_environment_prop(cluster_config, property_name, value
     if property_name_check is True:
         valid_props = ["cbs_ssl_enabled", "xattrs_enabled", "sg_lb_enabled", "sync_gateway_version", "server_version",
                        "no_conflicts_enabled", "sync_gateway_ssl", "sg_use_views", "number_replicas",
-                       "delta_sync_enabled", "x509_certs", "hide_product_version"]
+                       "delta_sync_enabled", "x509_certs", "hide_product_version", "cbs_developer_preview"]
         if property_name not in valid_props:
             raise ProvisioningError("Make sure the property you are trying to change is one of: {}".format(valid_props))
 


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Added support for CBS developer preview to have magma run on SGW side
- Added support to all SGW and CBL conftest files

Jenkins jobs  with flag off : http://uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-functional-tests-xattrs-noConflicts-serverSsl/186/testReport/

Jenkins job with cbs dp preview flag on : 

http://uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-functional-tests-xattrs-deltaSync-ServerSsl_MAGMA/287/testReport/