### PR TITLE
Fix/cm-323 add ssl support to system test

### DIFF
--- a/testsuites/CBLTester/System_test_multiple_device/conftest.py
+++ b/testsuites/CBLTester/System_test_multiple_device/conftest.py
@@ -367,8 +367,14 @@ def params_from_base_suite_setup(request):
             logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=request.node.name)
             raise
 
-    # Create CBL databases on all devices
+    # update sgw urls to meet the runtime settings
+    cluster_topology = cluster_utils.get_cluster_topology(cluster_config)
+    sg_url = cluster_topology["sync_gateways"][0]["public"]
+    log_info("sg_url: {}".format(sg_url))
     sg_admin_url = cluster_topology["sync_gateways"][0]["admin"]
+    log_info("sg_admin_url: {}".format(sg_admin_url))
+
+    # Create CBL databases on all devices
     db_name_list = []
     cbl_db_list = []
     db_obj_list = []

--- a/testsuites/CBLTester/System_test_multiple_device/conftest.py
+++ b/testsuites/CBLTester/System_test_multiple_device/conftest.py
@@ -186,6 +186,10 @@ def pytest_addoption(parser):
                      help="Hides SGW product version when you hit SGW url",
                      default=False)
 
+    parser.addoption("--enable-cbs-developer-preview",
+                     action="store_true",
+                     help="Enabling CBS developer preview",
+                     default=False)
 
 # This will get called once before the first test that
 # runs with this as input parameters in this file
@@ -239,6 +243,7 @@ def params_from_base_suite_setup(request):
     num_of_docs_to_add = int(request.config.getoption("--num-of-docs-to-add"))
     hide_product_version = request.config.getoption("--hide-product-version")
     up_time = int(request.config.getoption("--up-time"))
+    enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
     # Changing up_time in days
     up_time = up_time * 24 * 60
     repl_status_check_sleep_time = int(request.config.getoption("--repl-status-check-sleep-time"))
@@ -348,6 +353,13 @@ def params_from_base_suite_setup(request):
         persist_cluster_config_environment_prop(cluster_config, 'sync_gateway_ssl', True)
         target_url = "wss://{}:4984/{}".format(sg_ip, sg_db)
         target_admin_url = "wss://{}:4985/{}".format(sg_ip, sg_db)
+
+    if enable_cbs_developer_preview:
+        log_info("Enable CBS developer preview")
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', True)
+    else:
+        log_info("Running without CBS developer preview")
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
 
     if sync_gateway_version < "2.0":
         pytest.skip('Does not work with sg < 2.0 , so skipping the test')

--- a/testsuites/CBLTester/System_test_multiple_device/test_system_testing.py
+++ b/testsuites/CBLTester/System_test_multiple_device/test_system_testing.py
@@ -74,7 +74,7 @@ def test_system(params_from_base_suite_setup):
     if not resume_cluster:
         # Reset cluster to ensure no data in system
         cluster.reset(sg_config_path=sg_config)
-        log_info("Using SG ur: {}".format(sg_admin_url))
+        log_info("Using SG url: {}".format(sg_admin_url))
         sg_client.create_user(sg_admin_url, sg_db, username, password, channels=channels_sg)
 
         # adding bulk docs to each db


### PR DESCRIPTION
#### Fixes # cm-323 add ssl support to system test

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- sg ssl enabling issue has been fixed

