### PR TITLE
fix daemon service launching issue on centos 6

### DIFF
--- a/libraries/provision/ansible/playbooks/install-testserver-java-desktop.yml
+++ b/libraries/provision/ansible/playbooks/install-testserver-java-desktop.yml
@@ -13,6 +13,12 @@
       state: absent
     ignore_errors: yes
 
+  - name: Delete CouchbaseLite libraries from previous install
+    file:
+      path: ~/javatestserver/CouchbaseLiteTemp
+      state: absent
+    ignore_errors: yes
+
   - name: check /tmp/TestServerTemp directory exists
     stat:
       path: /tmp/TestServerTemp
@@ -45,6 +51,8 @@
 
   - name: Install and start TestServer Java Daemon Service
     shell: "~/javatestserver/daemon_manager.sh start ~/javatestserver/{{ package_name }}.jar ~/javatestserver/output {{ ansible_env.JAVA_HOME }} {{ ansible_env.JSVC_HOME }}"
+    args:
+      chdir: ~/javatestserver
     when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "6"
 
   - name: Wait for port 8080 to become open on the host, don't start checking for 2 seconds


### PR DESCRIPTION
#### Fix daemon service launching issue on centos 6.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

-  jsvc on centos 6 doesn't provide cmd argument option, add chdir in ansible to make up the issue.


