### PR TITLE
Fix/webhook and windowsssh

### DIFF
--- a/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
@@ -460,7 +460,7 @@ def test_log_200mb(params_from_base_test_setup, sg_conf_name):
         _, stdout, _ = remote_executor.execute(command)
         output = stdout[0].strip()
         # A backup file should be created with 200MB
-        if (log == "sg_debug" or log == "sg_info") and (sg_platform != "windows" or sg_platform != "macos"):
+        if (log == "sg_debug" or log == "sg_info") and (sg_platform != "windows" and sg_platform != "macos"):
             assert int(output) == int(SG_LOGS_FILES_NUM[log]) + 1
         else:
             assert output == SG_LOGS_FILES_NUM[log]
@@ -809,7 +809,7 @@ def get_sgLogs_fileNum(SG_LOGS_MAXAGE, remote_executor, sg_platform="centos", sg
 
 def send_request_to_sgw(sg_one_url, sg_admin_url, remote_executor, sg_platform="centos"):
     if sg_platform == "windows":
-        command = "for ((i=1;i <= 3000;i += 1)); do curl -s {}/ABCD/ > /dev/null; done".format(sg_one_url)
+        command = "for ((i=1;i <= 2000;i += 1)); do curl -s {}/ABCD/ > /dev/null; done".format(sg_one_url)
         os.system(command)
         command = "for ((i=1;i <= 2000;i += 1)); do curl -s -H 'Accept: application/json' {}/db/ > /dev/null; done".format(sg_admin_url)
         os.system(command)

--- a/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
@@ -809,7 +809,7 @@ def get_sgLogs_fileNum(SG_LOGS_MAXAGE, remote_executor, sg_platform="centos", sg
 
 def send_request_to_sgw(sg_one_url, sg_admin_url, remote_executor, sg_platform="centos"):
     if sg_platform == "windows":
-        command = "for ((i=1;i <= 2000;i += 1)); do curl -s {}/ABCD/ > /dev/null; done".format(sg_one_url)
+        command = "for ((i=1;i <= 3000;i += 1)); do curl -s {}/ABCD/ > /dev/null; done".format(sg_one_url)
         os.system(command)
         command = "for ((i=1;i <= 2000;i += 1)); do curl -s -H 'Accept: application/json' {}/db/ > /dev/null; done".format(sg_admin_url)
         os.system(command)

--- a/testsuites/syncgateway/functional/tests/test_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_webhooks.py
@@ -330,10 +330,11 @@ def test_webhook_filter_external_js(params_from_base_test_setup, setup_webserver
     sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
     ssl_enabled = params_from_base_test_setup["ssl_enabled"]
     webhook_server = setup_webserver["webhook_server"]
+    xattrs_enabled = params_from_base_test_setup["xattrs_enabled"]
     sg_conf_name = "webhooks/webhook_filter_external_js"
 
-    if sync_gateway_version < "3.0.0":
-        pytest.skip("this feature not available below 3.0.0")
+    if sync_gateway_version < "3.0.0" or not xattrs_enabled:
+        pytest.skip("this feature cannot run with SGW version below 3.0.0 or xattrs not enabled")
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
     cluster_helper = ClusterKeywords(cluster_config)
     cluster_hosts = cluster_helper.get_cluster_topology(cluster_config)
@@ -352,9 +353,7 @@ def test_webhook_filter_external_js(params_from_base_test_setup, setup_webserver
     bucket = cluster.servers[0].get_bucket_names()[0]
     sdk_client = get_sdk_client_with_bucket(ssl_enabled, cluster, cbs_ip, bucket)
     js_func_key = "\"filter\":\""
-    # path = "http://{}:5007/webhookFilter".format(get_local_ip())
-    jscode_external_ip = "172.23.104.165"
-    path = "http://{}:5007/webhookFilter".format(jscode_external_ip)
+    path = "http://{}:5007/webhookFilter".format(get_local_ip())
     path = js_func_key + path + "\","
     temp_sg_config, _ = copy_sgconf_to_temp(sg_conf, mode)
     temp_sg_config = replace_string_on_sgw_config(temp_sg_config, "{{ webhook_filter }}", path)
@@ -427,10 +426,12 @@ def test_webhook_filter_external_https_js(params_from_base_test_setup, setup_web
     sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
     ssl_enabled = params_from_base_test_setup["ssl_enabled"]
     webhook_server = setup_webserver_js_sslon["webhook_server"]
+    xattrs_enabled = params_from_base_test_setup["xattrs_enabled"]
     sg_conf_name = "webhooks/webhook_filter_external_js"
 
-    if sync_gateway_version < "3.0.0":
-        pytest.skip('this feature not available below 3.0.0')
+    if sync_gateway_version < "3.0.0" or not xattrs_enabled:
+        pytest.skip("this feature cannot run with SGW version below 3.0.0 or xattrs not enabled")
+
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
     cluster_helper = ClusterKeywords(cluster_config)
     cluster_hosts = cluster_helper.get_cluster_topology(cluster_config)

--- a/testsuites/syncgateway/functional/tests/test_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_webhooks.py
@@ -509,13 +509,13 @@ def test_webhook_filter_external_https_js(params_from_base_test_setup, setup_web
 def setup_webserver():
     webhook_server = WebServer()
     webhook_server.start()
-    # process = subprocess.Popen(args=["nohup", "python", "libraries/utilities/host_sgw_jscode.py", "--start", "&"], stdout=subprocess.PIPE)
+    process = subprocess.Popen(args=["nohup", "python", "libraries/utilities/host_sgw_jscode.py", "--start", "&"], stdout=subprocess.PIPE)
     yield{
         "webhook_server": webhook_server
     }
 
     webhook_server.stop()
-    # process.kill()
+    process.kill()
 
 
 @pytest.fixture(scope="function")

--- a/testsuites/syncgateway/functional/tests/test_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_webhooks.py
@@ -352,7 +352,9 @@ def test_webhook_filter_external_js(params_from_base_test_setup, setup_webserver
     bucket = cluster.servers[0].get_bucket_names()[0]
     sdk_client = get_sdk_client_with_bucket(ssl_enabled, cluster, cbs_ip, bucket)
     js_func_key = "\"filter\":\""
-    path = "http://{}:5007/webhookFilter".format(get_local_ip())
+    # path = "http://{}:5007/webhookFilter".format(get_local_ip())
+    jscode_external_ip = "172.23.104.165"
+    path = "http://{}:5007/webhookFilter".format(jscode_external_ip)
     path = js_func_key + path + "\","
     temp_sg_config, _ = copy_sgconf_to_temp(sg_conf, mode)
     temp_sg_config = replace_string_on_sgw_config(temp_sg_config, "{{ webhook_filter }}", path)
@@ -506,13 +508,13 @@ def test_webhook_filter_external_https_js(params_from_base_test_setup, setup_web
 def setup_webserver():
     webhook_server = WebServer()
     webhook_server.start()
-    process = subprocess.Popen(args=["nohup", "python", "libraries/utilities/host_sgw_jscode.py", "--start", "&"], stdout=subprocess.PIPE)
+    # process = subprocess.Popen(args=["nohup", "python", "libraries/utilities/host_sgw_jscode.py", "--start", "&"], stdout=subprocess.PIPE)
     yield{
         "webhook_server": webhook_server
     }
 
     webhook_server.stop()
-    process.kill()
+    # process.kill()
 
 
 @pytest.fixture(scope="function")

--- a/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/test_load_balancer.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/test_load_balancer.py
@@ -18,6 +18,7 @@ from libraries.testkit.cluster import Cluster
 @pytest.mark.changes
 @pytest.mark.session
 @pytest.mark.channel
+@pytest.mark.oscertify
 def test_load_balance_sanity(params_from_base_test_setup):
 
     cluster_config = params_from_base_test_setup["cluster_config"]

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/test_multiple_servers.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/test_multiple_servers.py
@@ -23,6 +23,7 @@ from utilities.cluster_config_utils import get_sg_version
 @pytest.mark.session
 @pytest.mark.channel
 @pytest.mark.bulkops
+@pytest.mark.oscertify
 def test_rebalance_sanity(params_from_base_test_setup):
 
     cluster_config = params_from_base_test_setup["cluster_config"]

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_bucket_shadow.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_bucket_shadow.py
@@ -232,6 +232,7 @@ def test_bucket_shadow_low_revs_limit(params_from_base_test_setup):
 @pytest.mark.bucketshadow
 @pytest.mark.channel
 @pytest.mark.basicauth
+@pytest.mark.oscertify
 def test_bucket_shadow_multiple_sync_gateways(params_from_base_test_setup):
 
     cluster_config = params_from_base_test_setup["cluster_config"]

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_sg_replicate.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_sg_replicate.py
@@ -35,6 +35,7 @@ DB2 = "db2"
 @pytest.mark.channel
 @pytest.mark.basicauth
 @pytest.mark.changes
+@pytest.mark.oscertify
 def test_sg_replicate_basic_test(params_from_base_test_setup):
 
     cluster_config = params_from_base_test_setup["cluster_config"]


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- fixed webhook js tests to skip if xattrs are disabled as webserver with js enabled and xattrs enabled does not work
- fixed windows 200mb test and ssh exception issue which is missing ansible username and password for curl command for Prometheus call

http://uberjenkins.sc.couchbase.com:8080/job/win-sync-gateway-topology-tests/116/testReport/ -- windows fix for curl command for prometheus 
http://uberjenkins.sc.couchbase.com:8080/job/win2019-sync-gateway-functional-tests-base-cc/1200/testReport/ - 200mb fix
