### PR TITLE
fix the windows platform log dir name

### DIFF
--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_cbl_log_redaction.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_cbl_log_redaction.py
@@ -138,7 +138,7 @@ def verify_password_masked(liteserv_platform, log_file, password, test_cbllog):
            outside runner's file directory
     """
     delimiter = "/"
-    if liteserv_platform == "net-msft" or liteserv_platform == "uwp":
+    if "-msft" in liteserv_platform or liteserv_platform == "uwp":
         delimiter = "\\"
     log_dir = log_file.split(delimiter)[-1]
     log_full_path_dir = "/tmp/cbl-logs/"


### PR DESCRIPTION
#### Fixes cm-791. java webservice on windows log directory format

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- java webservice on windows log directory format

