### PR TITLE
add condition check for rhel6

### DIFF
--- a/libraries/provision/ansible/playbooks/install-testserver-java-desktop.yml
+++ b/libraries/provision/ansible/playbooks/install-testserver-java-desktop.yml
@@ -53,7 +53,7 @@
     shell: "~/javatestserver/daemon_manager.sh start ~/javatestserver/{{ package_name }}.jar ~/javatestserver/output {{ ansible_env.JAVA_HOME }} {{ ansible_env.JSVC_HOME }}"
     args:
       chdir: ~/javatestserver
-    when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "6"
+    when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat") and ansible_distribution_major_version == "6"
 
   - name: Wait for port 8080 to become open on the host, don't start checking for 2 seconds
     wait_for:


### PR DESCRIPTION
#### Fixes #. support various version of jsvc commands

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- redhat 6 compatible jsvc is lower version, need to support different parameter set.
