### PR TITLE
updated the test to have sgw fail when disabled xattrs with xattrs key enabled

### DIFF
--- a/testsuites/syncgateway/functional/tests/test_sgw_config.py
+++ b/testsuites/syncgateway/functional/tests/test_sgw_config.py
@@ -245,6 +245,7 @@ def test_invalid_external_jspath(params_from_base_test_setup, setup_jsserver):
     cluster_helper = ClusterKeywords(cluster_config)
     cluster_hosts = cluster_helper.get_cluster_topology(cluster_config)
     sg_url = cluster_hosts["sync_gateways"][0]["public"]
+    flag = False
 
     if sync_gateway_version < "3.0.0":
         pytest.skip("this feature not available below 3.0.0")
@@ -268,10 +269,13 @@ def test_invalid_external_jspath(params_from_base_test_setup, setup_jsserver):
 
     try:
         requests.get(sg_url, timeout=30)
-        assert False, "Sync gateway started successfully with invalid external jsfile "
+        flag = True
     except Exception as he:
         log_info(str(he))
         log_info("Expected to have sync gateway fail to start")
+
+    if flag:
+        assert False, "Sync gateway started successfully with invalid external jsfile"
 
 
 @pytest.mark.syncgateway

--- a/testsuites/syncgateway/functional/tests/test_sgw_config.py
+++ b/testsuites/syncgateway/functional/tests/test_sgw_config.py
@@ -3,7 +3,7 @@ import time
 import os
 import requests
 import subprocess
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, ConnectionError
 
 from keywords.utils import log_info, get_local_ip
 from keywords.ClusterKeywords import ClusterKeywords
@@ -245,7 +245,6 @@ def test_invalid_external_jspath(params_from_base_test_setup, setup_jsserver):
     cluster_helper = ClusterKeywords(cluster_config)
     cluster_hosts = cluster_helper.get_cluster_topology(cluster_config)
     sg_url = cluster_hosts["sync_gateways"][0]["public"]
-    flag = False
 
     if sync_gateway_version < "3.0.0":
         pytest.skip("this feature not available below 3.0.0")
@@ -269,13 +268,10 @@ def test_invalid_external_jspath(params_from_base_test_setup, setup_jsserver):
 
     try:
         requests.get(sg_url, timeout=30)
-        flag = True
-    except Exception as he:
+        assert False, "Sync gateway started successfully with invalid external jsfile"
+    except ConnectionError as he:
         log_info(str(he))
         log_info("Expected to have sync gateway fail to start")
-
-    if flag:
-        assert False, "Sync gateway started successfully with invalid external jsfile"
 
 
 @pytest.mark.syncgateway

--- a/testsuites/syncgateway/functional/tests/test_xattrs_grants.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs_grants.py
@@ -707,7 +707,6 @@ def test_xattrs_key_with_disabled_xattrs(params_from_base_test_setup):
     mode = params_from_base_test_setup["mode"]
     sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
     xattrs_enabled = params_from_base_test_setup["xattrs_enabled"]
-    flag = False
 
     if sync_gateway_version < "3.0.0" or xattrs_enabled:
         pytest.skip('SGW version is not 3.0 and above or xattrs has to be disabled')
@@ -732,13 +731,10 @@ def test_xattrs_key_with_disabled_xattrs(params_from_base_test_setup):
 
     try:
         requests.get(sg_url, timeout=30)
-        flag = True
-    except Exception as he:
+        assert False, "Sync gateway started successfully with xattrs disabled and xattrs key enabled "
+    except ConnectionError as he:
         log_info(str(he))
         log_info("Expected to have sync gateway fail to start")
-
-    if flag:
-        assert False, "Sync gateway started successfully with xattrs disabled and xattrs key enabled "
 
 
 @pytest.mark.channels


### PR DESCRIPTION
…y enabled

#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- separate out the test as it is different behavior from other tests


