### PR TITLE
support for 7.1

### DIFF
--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -910,6 +910,8 @@ class CouchbaseServer:
             base_url = "{}/mad-hatter/{}".format(cbnas_base_url, build_number)
         elif version.startswith("7.0"):
             base_url = "{}/cheshire-cat/{}".format(cbnas_base_url, build_number)
+        elif version.startswith("7.1"):
+            base_url = "{}/neo/{}".format(cbnas_base_url, build_number)
         else:
             raise Exception(
                 "Unexpected couchbase server version: {}".format(version))


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- added URL for neo to support 7.1


