### PR TITLE
Fix/mac server fixes

### DIFF
--- a/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
@@ -310,7 +310,11 @@ def test_log_maxage_timestamp_ignored(params_from_base_test_setup, sg_conf_name)
     # Change the timestamps for SG logs when SG stopped (Name is unchanged)
     for log in SG_LOGS_MAXAGE:
         file_name = "/tmp/sg_logs/{}.log".format(log)
-        command = "sudo touch -d \"{} days ago\" {}".format(SG_LOGS_MAXAGE[log], file_name)
+        if sg_platform == "macos":
+            age = [log] * 24
+            command = "sudo touch -A -{}0000 {}".format(age, file_name)
+        else:
+            command = "sudo touch -d \"{} days ago\" {}".format([log], file_name)
         remote_executor.execute(command)
 
     sg_helper.start_sync_gateways(cluster_config=cluster_conf, url=sg_one_url, config=temp_conf)

--- a/testsuites/syncgateway/functional/tests/test_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_webhooks.py
@@ -390,7 +390,7 @@ def test_webhook_filter_external_js(params_from_base_test_setup, setup_webserver
     sdk_client.upsert_multi(sdk_docs)
 
     count = 0
-    retries = 5
+    retries = 8
     while count < retries:
         data = webhook_server.get_data()
         # Remove unwanted data from the response

--- a/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
@@ -276,11 +276,13 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     cluster_config = params_from_base_suite_setup["cluster_config"]
     mode = params_from_base_suite_setup["mode"]
     sg_platform = params_from_base_suite_setup["sg_platform"]
+    sg_ce = params_from_base_suite_setup["sg_ce"]
 
     yield {
         "cluster_config": cluster_config,
         "mode": mode,
-        "sg_platform": sg_platform
+        "sg_platform": sg_platform,
+        "sg_ce": sg_ce
     }
 
     log_info("Tearing down test '{}'".format(test_name))

--- a/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
@@ -250,7 +250,7 @@ def params_from_base_suite_setup(request):
         expected_sync_gateway_version=sync_gateway_version
     )
 
-    yield {"cluster_config": cluster_config, "mode": mode, "sg_platform": sg_platform}
+    yield {"cluster_config": cluster_config, "mode": mode, "sg_platform": sg_platform, "sg_ce": sg_ce}
 
     log_info("Tearing down 'params_from_base_suite_setup' ...")
 

--- a/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/test_load_balancer.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/test_load_balancer.py
@@ -97,7 +97,10 @@ def test_sgw_down_with_load_balancer(params_from_base_test_setup, sgw_down_with_
     cluster_config = sgw_down_with_load_balancer_teardown["cluster_config"]
     sg1 = sgw_down_with_load_balancer_teardown["sg1"]
     sg_conf_path = sgw_down_with_load_balancer_teardown["sg_conf_path"]
+    sg_ce = params_from_base_test_setup["sg_ce"]
 
+    if sg_ce:
+        pytest.skip('--sg-ce is enabled. This test runs only on enterprise edition of sgw')
     # 1. Have 2 SGWs having load balancer with shared_bucket_access=true and have CBS set up
     cluster_utils = ClusterKeywords(cluster_config)
     cluster_topology = cluster_utils.get_cluster_topology(cluster_config)


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- fixed mac tests
- transient issues on mac
- transient issues with server calls like rebalance and recoverytype - added retries
- disabled test to run on CE as it is EE test

