### PR TITLE
add 2.8.0 as base version for upgrade

### DIFF
--- a/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
+++ b/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
@@ -309,7 +309,7 @@ def _upgrade_db(args):
     if base_liteserv_version > upgraded_liteserv_version:
         pytest.skip("Can't upgrade from higher version db to lower version db")
 
-    supported_base_liteserv = ["1.4", "2.0.0", "2.1.5", "2.5.0", "2.7.0", "2.7.1"]
+    supported_base_liteserv = ["1.4", "2.0.0", "2.1.5", "2.5.0", "2.7.0", "2.7.1", "2.8.0"]
     db = Database(base_url)
     if encrypted_db:
         if base_liteserv_version < "2.1.5":


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- added 2.8.0 to accepted base version for upgrade test

