### PR TITLE
Fix/centralized persistent config flag

### DIFF
--- a/keywords/SyncGateway.py
+++ b/keywords/SyncGateway.py
@@ -920,22 +920,22 @@ class SyncGateway(object):
         if is_delta_sync_enabled(cluster_config) and version >= "2.5.0":
             playbook_vars["delta_sync"] = '"delta_sync": { "enabled": true},'
 
-        if get_sg_version(cluster_config) >= "2.8.0":
+        if version >= "2.8.0":
             playbook_vars["prometheus"] = '"metricsInterface": ":4986",'
 
-        if is_hide_prod_version_enabled(cluster_config) and get_sg_version(cluster_config) >= "2.8.1":
+        if is_hide_prod_version_enabled(cluster_config) and version >= "2.8.1":
             playbook_vars["hide_product_version"] = '"hide_product_version": true,'
 
-        if is_centralized_persistent_config_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+        if is_centralized_persistent_config_disabled(cluster_config) and version >= "3.0.0":
             playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
 
-        if is_server_tls_skip_verify_enabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+        if is_server_tls_skip_verify_enabled(cluster_config) and version >= "3.0.0":
             playbook_vars["server_tls_skip_verify"] = '"server_tls_skip_verify": true,'
 
-        if is_tls_server_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+        if is_tls_server_disabled(cluster_config) and version >= "3.0.0":
             playbook_vars["disable_tls_server"] = '"use_tls_server": false,'
 
-        if is_admin_auth_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+        if is_admin_auth_disabled(cluster_config) and version >= "3.0.0":
             playbook_vars["disable_admin_auth"] = '"admin_interface_authentication": false,    \n"metrics_interface_authentication": false,'
 
         # Deploy config

--- a/keywords/SyncGateway.py
+++ b/keywords/SyncGateway.py
@@ -24,7 +24,7 @@ from keywords.utils import host_for_url
 from keywords import document
 from keywords.utils import random_string
 from utilities.cluster_config_utils import copy_sgconf_to_temp, replace_string_on_sgw_config, get_cluster
-from utilities.cluster_config_utils import is_centralized_persistent_config_disabled, is_server_tls_skip_verify_enabled, is_admin_auth_disabled, is_tls_server_disabled, is_tls_client_disabled
+from utilities.cluster_config_utils import is_centralized_persistent_config_disabled, is_server_tls_skip_verify_enabled, is_admin_auth_disabled, is_tls_server_disabled
 
 
 def validate_sync_gateway_mode(mode):
@@ -253,7 +253,6 @@ def load_sync_gateway_config(sg_conf, server_url, cluster_config):
         disable_persistent_config_prop = ""
         server_tls_skip_verify_prop = ""
         disable_tls_server_prop = ""
-        disable_tls_client_prop = ""
         disable_admin_auth_prop = ""
         metrics_auth_prop = ""
 
@@ -326,9 +325,6 @@ def load_sync_gateway_config(sg_conf, server_url, cluster_config):
         if is_tls_server_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
             disable_tls_server_prop = '"use_tls_server": false,'
 
-        if is_tls_client_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-            disable_tls_client_prop = '"use_tls_client": false,'
-
         if is_admin_auth_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
             disable_admin_auth_prop = '"admin_interface_authentication": false,\n"metrics_interface_authentication": false,'
 
@@ -359,7 +355,6 @@ def load_sync_gateway_config(sg_conf, server_url, cluster_config):
             disable_persistent_config=disable_persistent_config_prop,
             server_tls_skip_verify=server_tls_skip_verify_prop,
             tls_server=disable_tls_server_prop,
-            tls_client=disable_tls_client_prop,
             admin_auth=disable_admin_auth_prop,
             metrics_auth=metrics_auth_prop
         )
@@ -452,7 +447,6 @@ class SyncGateway(object):
             "disable_persistent_config": "",
             "server_tls_skip_verify": "",
             "disable_tls_server": "",
-            "disable_tls_client": "",
             "disable_admin_auth": ""
         }
         sg_platform = get_sg_platform(cluster_config)
@@ -550,9 +544,6 @@ class SyncGateway(object):
 
         if is_tls_server_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
             playbook_vars["disable_tls_server"] = '"use_tls_server": false,'
-
-        if is_tls_client_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-            playbook_vars["disable_tls_client"] = '"use_tls_client": false,'
 
         if is_admin_auth_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
             playbook_vars["disable_admin_auth"] = '"admin_interface_authentication": false,    \n"metrics_interface_authentication": false,'
@@ -699,7 +690,6 @@ class SyncGateway(object):
             "disable_persistent_config": "",
             "server_tls_skip_verify": "",
             "disable_tls_server": "",
-            "disable_tls_client": "",
             "disable_admin_auth": ""
         }
 
@@ -794,9 +784,6 @@ class SyncGateway(object):
         if is_tls_server_disabled(cluster_config) and version >= "3.0.0":
             playbook_vars["disable_tls_server"] = '"use_tls_server": false,'
 
-        if is_tls_client_disabled(cluster_config) and version >= "3.0.0":
-            playbook_vars["disable_tls_client"] = '"use_tls_client": false,'
-
         if is_admin_auth_disabled(cluster_config) and version >= "3.0.0":
             playbook_vars["disable_admin_auth"] = '"admin_interface_authentication": false,    \n"metrics_interface_authentication": false,'
 
@@ -864,7 +851,6 @@ class SyncGateway(object):
             "disable_persistent_config": "",
             "server_tls_skip_verify": "",
             "disable_tls_server": "",
-            "disable_tls_client": "",
             "disable_admin_auth": ""
         }
 
@@ -948,9 +934,6 @@ class SyncGateway(object):
 
         if is_tls_server_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
             playbook_vars["disable_tls_server"] = '"use_tls_server": false,'
-
-        if is_tls_client_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-            playbook_vars["disable_tls_client"] = '"use_tls_client": false,'
 
         if is_admin_auth_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
             playbook_vars["disable_admin_auth"] = '"admin_interface_authentication": false,    \n"metrics_interface_authentication": false,'

--- a/keywords/SyncGateway.py
+++ b/keywords/SyncGateway.py
@@ -312,7 +312,7 @@ def load_sync_gateway_config(sg_conf, server_url, cluster_config):
         if is_hide_prod_version_enabled(cluster_config) and get_sg_version(cluster_config) >= "2.8.1":
             hide_prod_version_prop = '"hide_product_version": true,'
 
-        if is_centralized_persistent_config_disabled(cluster_config):
+        if is_centralized_persistent_config_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
             disable_persistent_config_prop = '"disable_persistent_config": true,'
 
         temp = template.render(
@@ -516,7 +516,7 @@ class SyncGateway(object):
         if is_hide_prod_version_enabled(cluster_config) and get_sg_version(cluster_config) >= "2.8.1":
             playbook_vars["hide_product_version"] = '"hide_product_version": true,'
 
-        if is_centralized_persistent_config_disabled(cluster_config):
+        if is_centralized_persistent_config_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
             playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
 
         if url is not None:
@@ -743,7 +743,7 @@ class SyncGateway(object):
         if is_hide_prod_version_enabled(cluster_config) and get_sg_version(cluster_config) >= "2.8.1":
             playbook_vars["hide_product_version"] = '"hide_product_version": true,'
 
-        if is_centralized_persistent_config_disabled(cluster_config):
+        if is_centralized_persistent_config_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
             playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
 
         if url is not None:
@@ -882,7 +882,7 @@ class SyncGateway(object):
         if is_hide_prod_version_enabled(cluster_config) and get_sg_version(cluster_config) >= "2.8.1":
             playbook_vars["hide_product_version"] = '"hide_product_version": true,'
 
-        if is_centralized_persistent_config_disabled(cluster_config):
+        if is_centralized_persistent_config_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
             playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
 
         # Deploy config

--- a/keywords/SyncGateway.py
+++ b/keywords/SyncGateway.py
@@ -779,25 +779,25 @@ class SyncGateway(object):
         if is_delta_sync_enabled(cluster_config) and version >= "2.5.0":
             playbook_vars["delta_sync"] = '"delta_sync": { "enabled": true},'
 
-        if get_sg_version(cluster_config) >= "2.8.0":
+        if version >= "2.8.0":
             playbook_vars["prometheus"] = '"metricsInterface": ":4986",'
 
-        if is_hide_prod_version_enabled(cluster_config) and get_sg_version(cluster_config) >= "2.8.1":
+        if is_hide_prod_version_enabled(cluster_config) and version >= "2.8.1":
             playbook_vars["hide_product_version"] = '"hide_product_version": true,'
 
-        if is_centralized_persistent_config_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+        if is_centralized_persistent_config_disabled(cluster_config) and version >= "3.0.0":
             playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
 
-        if is_server_tls_skip_verify_enabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+        if is_server_tls_skip_verify_enabled(cluster_config) and version >= "3.0.0":
             playbook_vars["server_tls_skip_verify"] = '"server_tls_skip_verify": true,'
 
-        if is_tls_server_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+        if is_tls_server_disabled(cluster_config) and version >= "3.0.0":
             playbook_vars["disable_tls_server"] = '"use_tls_server": false,'
 
-        if is_tls_client_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+        if is_tls_client_disabled(cluster_config) and version >= "3.0.0":
             playbook_vars["disable_tls_client"] = '"use_tls_client": false,'
 
-        if is_admin_auth_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+        if is_admin_auth_disabled(cluster_config) and version >= "3.0.0":
             playbook_vars["disable_admin_auth"] = '"admin_interface_authentication": false,    \n"metrics_interface_authentication": false,'
 
         if url is not None:

--- a/keywords/SyncGateway.py
+++ b/keywords/SyncGateway.py
@@ -24,7 +24,7 @@ from keywords.utils import host_for_url
 from keywords import document
 from keywords.utils import random_string
 from utilities.cluster_config_utils import copy_sgconf_to_temp, replace_string_on_sgw_config, get_cluster
-from utilities.cluster_config_utils import is_centralized_persistent_config_disabled
+from utilities.cluster_config_utils import is_centralized_persistent_config_disabled, is_server_tls_skip_verify_enabled, is_admin_auth_disabled, is_tls_server_disabled, is_tls_client_disabled
 
 
 def validate_sync_gateway_mode(mode):
@@ -251,6 +251,11 @@ def load_sync_gateway_config(sg_conf, server_url, cluster_config):
         delta_sync_prop = ""
         hide_prod_version_prop = ""
         disable_persistent_config_prop = ""
+        server_tls_skip_verify_prop = ""
+        tls_server_prop = ""
+        tls_client_prop = ""
+        admin_auth_prop = ""
+        metrics_auth_prop = ""
 
         sg_platform = get_sg_platform(cluster_config)
         if get_sg_version(cluster_config) >= "2.1.0":
@@ -315,6 +320,19 @@ def load_sync_gateway_config(sg_conf, server_url, cluster_config):
         if is_centralized_persistent_config_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
             disable_persistent_config_prop = '"disable_persistent_config": true,'
 
+        if is_server_tls_skip_verify_enabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            server_tls_skip_verify_prop = '"server_tls_skip_verify": true,'
+
+        if is_tls_server_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            tls_server_prop = '"use_tls_server": false,'
+
+        if is_tls_client_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            tls_client_prop = '"use_tls_client": false,'
+
+        if is_admin_auth_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            admin_auth_prop = '"admin_interface_authentication": false,'
+            metrics_auth_prop = '"metrics_interface_authentication": false,'
+
         temp = template.render(
             couchbase_server_primary_node=couchbase_server_primary_node,
             is_index_writer="false",
@@ -339,7 +357,12 @@ def load_sync_gateway_config(sg_conf, server_url, cluster_config):
             revs_limit=revs_limit_prop,
             delta_sync=delta_sync_prop,
             hide_prod_version=hide_prod_version_prop,
-            disable_persistent_config=disable_persistent_config_prop
+            disable_persistent_config=disable_persistent_config_prop,
+            server_tls_skip_verify=server_tls_skip_verify_prop,
+            tls_server=tls_server_prop,
+            tls_client=tls_client_prop,
+            admin_auth=admin_auth_prop,
+            metrics_auth=metrics_auth_prop
         )
         data = json.loads(temp)
 
@@ -427,7 +450,12 @@ class SyncGateway(object):
             "delta_sync": "",
             "prometheus": "",
             "hide_product_version": "",
-            "disable_persistent_config": ""
+            "disable_persistent_config": "",
+            "server_tls_skip_verify": "",
+            "tls_server": "",
+            "tls_client": "",
+            "admin_auth": "",
+            "metrics_auth": ""
         }
         sg_platform = get_sg_platform(cluster_config)
         if get_sg_version(cluster_config) >= "2.1.0":
@@ -518,6 +546,19 @@ class SyncGateway(object):
 
         if is_centralized_persistent_config_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
             playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
+
+        if is_server_tls_skip_verify_enabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            playbook_vars["server_tls_skip_verify"] = '"server_tls_skip_verify": true,'
+
+        if is_tls_server_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            playbook_vars["tls_server"] = '"use_tls_server": false,'
+
+        if is_tls_client_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            playbook_vars["tls_client"] = '"use_tls_client": false,'
+
+        if is_admin_auth_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            playbook_vars["admin_auth"] = '"admin_interface_authentication": false,'
+            playbook_vars["metrics_auth"] = '"metrics_interface_authentication": false,'
 
         if url is not None:
             target = hostname_for_url(cluster_config, url)
@@ -658,7 +699,12 @@ class SyncGateway(object):
             "delta_sync": "",
             "prometheus": "",
             "hide_product_version": "",
-            "disable_persistent_config": ""
+            "disable_persistent_config": "",
+            "server_tls_skip_verify": "",
+            "tls_server": "",
+            "tls_client": "",
+            "admin_auth": "",
+            "metrics_auth": ""
         }
 
         sync_gateway_base_url, sync_gateway_package_name, sg_accel_package_name = sg_config.sync_gateway_base_url_and_package()
@@ -746,6 +792,19 @@ class SyncGateway(object):
         if is_centralized_persistent_config_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
             playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
 
+        if is_server_tls_skip_verify_enabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            playbook_vars["server_tls_skip_verify"] = '"server_tls_skip_verify": true,'
+
+        if is_tls_server_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            playbook_vars["tls_server"] = '"use_tls_server": false,'
+
+        if is_tls_client_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            playbook_vars["tls_client"] = '"use_tls_client": false,'
+
+        if is_admin_auth_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            playbook_vars["admin_auth"] = '"admin_interface_authentication": false,'
+            playbook_vars["metrics_auth"] = '"metrics_interface_authentication": false,'
+
         if url is not None:
             target = hostname_for_url(cluster_config, url)
             log_info("Upgrading sync_gateway/sg_accel on {} ...".format(target))
@@ -807,7 +866,12 @@ class SyncGateway(object):
             "delta_sync": "",
             "prometheus": "",
             "hide_product_version": "",
-            "disable_persistent_config": ""
+            "disable_persistent_config": "",
+            "server_tls_skip_verify": "",
+            "tls_server": "",
+            "tls_client": "",
+            "admin_auth": "",
+            "metrics_auth": ""
         }
 
         playbook_vars["username"] = '"username": "{}",'.format(bucket_names[0])
@@ -884,6 +948,19 @@ class SyncGateway(object):
 
         if is_centralized_persistent_config_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
             playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
+
+        if is_server_tls_skip_verify_enabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            playbook_vars["server_tls_skip_verify"] = '"server_tls_skip_verify": true,'
+
+        if is_tls_server_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            playbook_vars["tls_server"] = '"use_tls_server": false,'
+
+        if is_tls_client_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            playbook_vars["tls_client"] = '"use_tls_client": false,'
+
+        if is_admin_auth_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            playbook_vars["admin_auth"] = '"admin_interface_authentication": false,'
+            playbook_vars["metrics_auth"] = '"metrics_interface_authentication": false,'
 
         # Deploy config
         if url is not None:

--- a/keywords/SyncGateway.py
+++ b/keywords/SyncGateway.py
@@ -252,9 +252,9 @@ def load_sync_gateway_config(sg_conf, server_url, cluster_config):
         hide_prod_version_prop = ""
         disable_persistent_config_prop = ""
         server_tls_skip_verify_prop = ""
-        tls_server_prop = ""
-        tls_client_prop = ""
-        admin_auth_prop = ""
+        disable_tls_server_prop = ""
+        disable_tls_client_prop = ""
+        disable_admin_auth_prop = ""
         metrics_auth_prop = ""
 
         sg_platform = get_sg_platform(cluster_config)
@@ -324,14 +324,13 @@ def load_sync_gateway_config(sg_conf, server_url, cluster_config):
             server_tls_skip_verify_prop = '"server_tls_skip_verify": true,'
 
         if is_tls_server_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-            tls_server_prop = '"use_tls_server": false,'
+            disable_tls_server_prop = '"use_tls_server": false,'
 
         if is_tls_client_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-            tls_client_prop = '"use_tls_client": false,'
+            disable_tls_client_prop = '"use_tls_client": false,'
 
         if is_admin_auth_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-            admin_auth_prop = '"admin_interface_authentication": false,'
-            metrics_auth_prop = '"metrics_interface_authentication": false,'
+            disable_admin_auth_prop = '"admin_interface_authentication": false,\n"metrics_interface_authentication": false,'
 
         temp = template.render(
             couchbase_server_primary_node=couchbase_server_primary_node,
@@ -359,9 +358,9 @@ def load_sync_gateway_config(sg_conf, server_url, cluster_config):
             hide_prod_version=hide_prod_version_prop,
             disable_persistent_config=disable_persistent_config_prop,
             server_tls_skip_verify=server_tls_skip_verify_prop,
-            tls_server=tls_server_prop,
-            tls_client=tls_client_prop,
-            admin_auth=admin_auth_prop,
+            tls_server=disable_tls_server_prop,
+            tls_client=disable_tls_client_prop,
+            admin_auth=disable_admin_auth_prop,
             metrics_auth=metrics_auth_prop
         )
         data = json.loads(temp)
@@ -452,10 +451,9 @@ class SyncGateway(object):
             "hide_product_version": "",
             "disable_persistent_config": "",
             "server_tls_skip_verify": "",
-            "tls_server": "",
-            "tls_client": "",
-            "admin_auth": "",
-            "metrics_auth": ""
+            "disable_tls_server": "",
+            "disable_tls_client": "",
+            "disable_admin_auth": ""
         }
         sg_platform = get_sg_platform(cluster_config)
         if get_sg_version(cluster_config) >= "2.1.0":
@@ -551,14 +549,13 @@ class SyncGateway(object):
             playbook_vars["server_tls_skip_verify"] = '"server_tls_skip_verify": true,'
 
         if is_tls_server_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-            playbook_vars["tls_server"] = '"use_tls_server": false,'
+            playbook_vars["disable_tls_server"] = '"use_tls_server": false,'
 
         if is_tls_client_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-            playbook_vars["tls_client"] = '"use_tls_client": false,'
+            playbook_vars["disable_tls_client"] = '"use_tls_client": false,'
 
         if is_admin_auth_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-            playbook_vars["admin_auth"] = '"admin_interface_authentication": false,'
-            playbook_vars["metrics_auth"] = '"metrics_interface_authentication": false,'
+            playbook_vars["disable_admin_auth"] = '"admin_interface_authentication": false,    \n"metrics_interface_authentication": false,'
 
         if url is not None:
             target = hostname_for_url(cluster_config, url)
@@ -701,10 +698,9 @@ class SyncGateway(object):
             "hide_product_version": "",
             "disable_persistent_config": "",
             "server_tls_skip_verify": "",
-            "tls_server": "",
-            "tls_client": "",
-            "admin_auth": "",
-            "metrics_auth": ""
+            "disable_tls_server": "",
+            "disable_tls_client": "",
+            "disable_admin_auth": ""
         }
 
         sync_gateway_base_url, sync_gateway_package_name, sg_accel_package_name = sg_config.sync_gateway_base_url_and_package()
@@ -796,14 +792,13 @@ class SyncGateway(object):
             playbook_vars["server_tls_skip_verify"] = '"server_tls_skip_verify": true,'
 
         if is_tls_server_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-            playbook_vars["tls_server"] = '"use_tls_server": false,'
+            playbook_vars["disable_tls_server"] = '"use_tls_server": false,'
 
         if is_tls_client_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-            playbook_vars["tls_client"] = '"use_tls_client": false,'
+            playbook_vars["disable_tls_client"] = '"use_tls_client": false,'
 
         if is_admin_auth_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-            playbook_vars["admin_auth"] = '"admin_interface_authentication": false,'
-            playbook_vars["metrics_auth"] = '"metrics_interface_authentication": false,'
+            playbook_vars["disable_admin_auth"] = '"admin_interface_authentication": false,    \n"metrics_interface_authentication": false,'
 
         if url is not None:
             target = hostname_for_url(cluster_config, url)
@@ -868,10 +863,9 @@ class SyncGateway(object):
             "hide_product_version": "",
             "disable_persistent_config": "",
             "server_tls_skip_verify": "",
-            "tls_server": "",
-            "tls_client": "",
-            "admin_auth": "",
-            "metrics_auth": ""
+            "disable_tls_server": "",
+            "disable_tls_client": "",
+            "disable_admin_auth": ""
         }
 
         playbook_vars["username"] = '"username": "{}",'.format(bucket_names[0])
@@ -953,14 +947,13 @@ class SyncGateway(object):
             playbook_vars["server_tls_skip_verify"] = '"server_tls_skip_verify": true,'
 
         if is_tls_server_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-            playbook_vars["tls_server"] = '"use_tls_server": false,'
+            playbook_vars["disable_tls_server"] = '"use_tls_server": false,'
 
         if is_tls_client_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-            playbook_vars["tls_client"] = '"use_tls_client": false,'
+            playbook_vars["disable_tls_client"] = '"use_tls_client": false,'
 
         if is_admin_auth_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-            playbook_vars["admin_auth"] = '"admin_interface_authentication": false,'
-            playbook_vars["metrics_auth"] = '"metrics_interface_authentication": false,'
+            playbook_vars["disable_admin_auth"] = '"admin_interface_authentication": false,    \n"metrics_interface_authentication": false,'
 
         # Deploy config
         if url is not None:

--- a/libraries/provision/install_sync_gateway.py
+++ b/libraries/provision/install_sync_gateway.py
@@ -14,7 +14,7 @@ from keywords.constants import SYNC_GATEWAY_CERT
 from utilities.cluster_config_utils import is_cbs_ssl_enabled, is_xattrs_enabled, no_conflicts_enabled, get_revs_limit, sg_ssl_enabled
 from utilities.cluster_config_utils import is_hide_prod_version_enabled, get_cbs_primary_nodes_str
 from utilities.cluster_config_utils import get_sg_version, get_sg_replicas, get_sg_use_views, get_redact_level, is_x509_auth, generate_x509_certs, is_delta_sync_enabled
-from utilities.cluster_config_utils import is_centralized_persistent_config_disabled
+from utilities.cluster_config_utils import is_centralized_persistent_config_disabled, is_server_tls_skip_verify_enabled, is_admin_auth_disabled, is_tls_server_disabled, is_tls_client_disabled
 
 
 class SyncGatewayConfig:
@@ -195,7 +195,12 @@ def install_sync_gateway(cluster_config, sync_gateway_config, sg_ce=False,
         "delta_sync": "",
         "prometheus": "",
         "hide_product_version": "",
-        "disable_persistent_config": ""
+        "disable_persistent_config": "",
+        "server_tls_skip_verify": "",
+        "tls_server": "",
+        "tls_client": "",
+        "admin_auth": "",
+        "metrics_auth": ""
     }
 
     if get_sg_version(cluster_config) >= "2.1.0":
@@ -288,6 +293,19 @@ def install_sync_gateway(cluster_config, sync_gateway_config, sg_ce=False,
 
     if is_centralized_persistent_config_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
         playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
+
+    if is_server_tls_skip_verify_enabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+        playbook_vars["server_tls_skip_verify"] = '"server_tls_skip_verify": true,'
+
+    if is_tls_server_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+        playbook_vars["tls_server"] = '"use_tls_server": false,'
+
+    if is_tls_client_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+        playbook_vars["tls_client"] = '"use_tls_client": false,'
+
+    if is_admin_auth_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+        playbook_vars["admin_auth"] = '"admin_interface_authentication": false,'
+        playbook_vars["metrics_auth"] = '"metrics_interface_authentication": false,'
 
     # Install Sync Gateway via Source or Package
     if sync_gateway_config.commit is not None:

--- a/libraries/provision/install_sync_gateway.py
+++ b/libraries/provision/install_sync_gateway.py
@@ -197,10 +197,9 @@ def install_sync_gateway(cluster_config, sync_gateway_config, sg_ce=False,
         "hide_product_version": "",
         "disable_persistent_config": "",
         "server_tls_skip_verify": "",
-        "tls_server": "",
-        "tls_client": "",
-        "admin_auth": "",
-        "metrics_auth": ""
+        "disable_tls_server": "",
+        "disable_tls_client": "",
+        "disable_admin_auth": ""
     }
 
     if get_sg_version(cluster_config) >= "2.1.0":
@@ -298,14 +297,13 @@ def install_sync_gateway(cluster_config, sync_gateway_config, sg_ce=False,
         playbook_vars["server_tls_skip_verify"] = '"server_tls_skip_verify": true,'
 
     if is_tls_server_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-        playbook_vars["tls_server"] = '"use_tls_server": false,'
+        playbook_vars["disable_tls_server"] = '"use_tls_server": false,'
 
     if is_tls_client_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-        playbook_vars["tls_client"] = '"use_tls_client": false,'
+        playbook_vars["disable_tls_client"] = '"use_tls_client": false,'
 
     if is_admin_auth_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-        playbook_vars["admin_auth"] = '"admin_interface_authentication": false,'
-        playbook_vars["metrics_auth"] = '"metrics_interface_authentication": false,'
+        playbook_vars["disable_admin_auth"] = '"admin_interface_authentication": false,    \n"metrics_interface_authentication": false,'
 
     # Install Sync Gateway via Source or Package
     if sync_gateway_config.commit is not None:

--- a/libraries/provision/install_sync_gateway.py
+++ b/libraries/provision/install_sync_gateway.py
@@ -14,6 +14,7 @@ from keywords.constants import SYNC_GATEWAY_CERT
 from utilities.cluster_config_utils import is_cbs_ssl_enabled, is_xattrs_enabled, no_conflicts_enabled, get_revs_limit, sg_ssl_enabled
 from utilities.cluster_config_utils import is_hide_prod_version_enabled, get_cbs_primary_nodes_str
 from utilities.cluster_config_utils import get_sg_version, get_sg_replicas, get_sg_use_views, get_redact_level, is_x509_auth, generate_x509_certs, is_delta_sync_enabled
+from utilities.cluster_config_utils import is_centralized_persistent_config_disabled
 
 
 class SyncGatewayConfig:
@@ -193,7 +194,8 @@ def install_sync_gateway(cluster_config, sync_gateway_config, sg_ce=False,
         "couchbase_server_primary_node": couchbase_server_primary_node,
         "delta_sync": "",
         "prometheus": "",
-        "hide_product_version": ""
+        "hide_product_version": "",
+        "disable_persistent_config": ""
     }
 
     if get_sg_version(cluster_config) >= "2.1.0":
@@ -282,7 +284,10 @@ def install_sync_gateway(cluster_config, sync_gateway_config, sg_ce=False,
         playbook_vars["prometheus"] = '"metricsInterface": ":4986",'
 
     if is_hide_prod_version_enabled(cluster_config) and get_sg_version(cluster_config) >= "2.8.1":
-            playbook_vars["hide_product_version"] = '"hide_product_version": true,'
+        playbook_vars["hide_product_version"] = '"hide_product_version": true,'
+
+    if is_centralized_persistent_config_disabled(cluster_config):
+        playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
 
     # Install Sync Gateway via Source or Package
     if sync_gateway_config.commit is not None:

--- a/libraries/provision/install_sync_gateway.py
+++ b/libraries/provision/install_sync_gateway.py
@@ -286,7 +286,7 @@ def install_sync_gateway(cluster_config, sync_gateway_config, sg_ce=False,
     if is_hide_prod_version_enabled(cluster_config) and get_sg_version(cluster_config) >= "2.8.1":
         playbook_vars["hide_product_version"] = '"hide_product_version": true,'
 
-    if is_centralized_persistent_config_disabled(cluster_config):
+    if is_centralized_persistent_config_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
         playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
 
     # Install Sync Gateway via Source or Package

--- a/libraries/provision/install_sync_gateway.py
+++ b/libraries/provision/install_sync_gateway.py
@@ -14,7 +14,7 @@ from keywords.constants import SYNC_GATEWAY_CERT
 from utilities.cluster_config_utils import is_cbs_ssl_enabled, is_xattrs_enabled, no_conflicts_enabled, get_revs_limit, sg_ssl_enabled
 from utilities.cluster_config_utils import is_hide_prod_version_enabled, get_cbs_primary_nodes_str
 from utilities.cluster_config_utils import get_sg_version, get_sg_replicas, get_sg_use_views, get_redact_level, is_x509_auth, generate_x509_certs, is_delta_sync_enabled
-from utilities.cluster_config_utils import is_centralized_persistent_config_disabled, is_server_tls_skip_verify_enabled, is_admin_auth_disabled, is_tls_server_disabled, is_tls_client_disabled
+from utilities.cluster_config_utils import is_centralized_persistent_config_disabled, is_server_tls_skip_verify_enabled, is_admin_auth_disabled, is_tls_server_disabled
 
 
 class SyncGatewayConfig:
@@ -198,7 +198,6 @@ def install_sync_gateway(cluster_config, sync_gateway_config, sg_ce=False,
         "disable_persistent_config": "",
         "server_tls_skip_verify": "",
         "disable_tls_server": "",
-        "disable_tls_client": "",
         "disable_admin_auth": ""
     }
 
@@ -298,9 +297,6 @@ def install_sync_gateway(cluster_config, sync_gateway_config, sg_ce=False,
 
     if is_tls_server_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
         playbook_vars["disable_tls_server"] = '"use_tls_server": false,'
-
-    if is_tls_client_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-        playbook_vars["disable_tls_client"] = '"use_tls_client": false,'
 
     if is_admin_auth_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
         playbook_vars["disable_admin_auth"] = '"admin_interface_authentication": false,    \n"metrics_interface_authentication": false,'

--- a/libraries/provision/provision_cluster.py
+++ b/libraries/provision/provision_cluster.py
@@ -117,7 +117,7 @@ def provision_cluster(cluster_config, couchbase_server_config, sync_gateway_conf
 def provision_cluster_aws(cluster_config, couchbase_server_config, sync_gateway_config, sg_ssl=False, sg_lb=False, cbs_ssl=False, use_views=False,
                           xattrs_enabled=False, no_conflicts_enabled=False, delta_sync_enabled=False, number_replicas=0, sg_ce=False,
                           cbs_platform="centos7", sg_platform="centos", sg_installer_type="msi", sa_platform="centos",
-                          sa_installer_type="msi", cbs_ce=False, aws=False, skip_couchbase_provision=False, enable_cbs_developer_preview=False):
+                          sa_installer_type="msi", cbs_ce=False, aws=False, skip_couchbase_provision=False, enable_cbs_developer_preview=False, disable_persistent_config=False):
 
     if sg_ssl:
         log_info("Enabling SSL on sync gateway")
@@ -181,6 +181,13 @@ def provision_cluster_aws(cluster_config, couchbase_server_config, sync_gateway_
     else:
         log_info("Running without CBS developer preview")
         persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
+
+    if disable_persistent_config:
+        log_info(" disable persistent config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', True)
+    else:
+        log_info("Running without Centralized Persistent Config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
 
     provision_cluster(cluster_config=cluster_conf, couchbase_server_config=server_config,
                       sync_gateway_config=sync_gateway_conf, cbs_platform=opts.cbs_platform, aws=aws)

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -19,7 +19,7 @@ from utilities.cluster_config_utils import get_load_balancer_ip, no_conflicts_en
 from utilities.cluster_config_utils import generate_x509_certs, is_x509_auth, get_cbs_primary_nodes_str, is_hide_prod_version_enabled
 from keywords.constants import SYNC_GATEWAY_CERT
 from utilities.cluster_config_utils import get_sg_replicas, get_sg_use_views, get_sg_version
-from utilities.cluster_config_utils import is_centralized_persistent_config_disabled, is_server_tls_skip_verify_enabled, is_admin_auth_disabled, is_tls_server_disabled, is_tls_client_disabled
+from utilities.cluster_config_utils import is_centralized_persistent_config_disabled, is_server_tls_skip_verify_enabled, is_admin_auth_disabled, is_tls_server_disabled
 
 
 class Cluster:
@@ -210,7 +210,6 @@ class Cluster:
             "disable_persistent_config": "",
             "server_tls_skip_verify": "",
             "disable_tls_server": "",
-            "disable_tls_client": "",
             "disable_admin_auth": ""
         }
 
@@ -309,9 +308,6 @@ class Cluster:
 
         if is_tls_server_disabled(self._cluster_config) and get_sg_version(self._cluster_config) >= "3.0.0":
             playbook_vars["disable_tls_server"] = '"use_tls_server": false,'
-
-        if is_tls_client_disabled(self._cluster_config) and get_sg_version(self._cluster_config) >= "3.0.0":
-            playbook_vars["disable_tls_client"] = '"use_tls_client": false,'
 
         if is_admin_auth_disabled(self._cluster_config) and get_sg_version(self._cluster_config) >= "3.0.0":
             playbook_vars["disable_admin_auth"] = '"admin_interface_authentication": false,    \n"metrics_interface_authentication": false,'

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -297,7 +297,7 @@ class Cluster:
         if is_hide_prod_version_enabled(self._cluster_config) and get_sg_version(self._cluster_config) >= "2.8.1":
             playbook_vars["hide_product_version"] = '"hide_product_version": true,'
 
-        if is_centralized_persistent_config_disabled(self._cluster_config):
+        if is_centralized_persistent_config_disabled(self._cluster_config) and get_sg_version(self._cluster_config) >= "3.0.0":
             playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
 
         # Sleep for a few seconds for the indexes to teardown

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -209,10 +209,9 @@ class Cluster:
             "hide_product_version": "",
             "disable_persistent_config": "",
             "server_tls_skip_verify": "",
-            "tls_server": "",
-            "tls_client": "",
-            "admin_auth": "",
-            "metrics_auth": ""
+            "disable_tls_server": "",
+            "disable_tls_client": "",
+            "disable_admin_auth": ""
         }
 
         sg_platform = get_sg_platform(self._cluster_config)
@@ -309,14 +308,13 @@ class Cluster:
             playbook_vars["server_tls_skip_verify"] = '"server_tls_skip_verify": true,'
 
         if is_tls_server_disabled(self._cluster_config) and get_sg_version(self._cluster_config) >= "3.0.0":
-            playbook_vars["tls_server"] = '"use_tls_server": false,'
+            playbook_vars["disable_tls_server"] = '"use_tls_server": false,'
 
         if is_tls_client_disabled(self._cluster_config) and get_sg_version(self._cluster_config) >= "3.0.0":
-            playbook_vars["tls_client"] = '"use_tls_client": false,'
+            playbook_vars["disable_tls_client"] = '"use_tls_client": false,'
 
         if is_admin_auth_disabled(self._cluster_config) and get_sg_version(self._cluster_config) >= "3.0.0":
-            playbook_vars["admin_auth"] = '"admin_interface_authentication": false,'
-            playbook_vars["metrics_auth"] = '"metrics_interface_authentication": false,'
+            playbook_vars["disable_admin_auth"] = '"admin_interface_authentication": false,    \n"metrics_interface_authentication": false,'
 
         # Sleep for a few seconds for the indexes to teardown
         time.sleep(5)

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -19,6 +19,7 @@ from utilities.cluster_config_utils import get_load_balancer_ip, no_conflicts_en
 from utilities.cluster_config_utils import generate_x509_certs, is_x509_auth, get_cbs_primary_nodes_str, is_hide_prod_version_enabled
 from keywords.constants import SYNC_GATEWAY_CERT
 from utilities.cluster_config_utils import get_sg_replicas, get_sg_use_views, get_sg_version
+from utilities.cluster_config_utils import is_centralized_persistent_config_disabled
 
 
 class Cluster:
@@ -205,7 +206,8 @@ class Cluster:
             "couchbase_server_primary_node": couchbase_server_primary_node,
             "delta_sync": "",
             "prometheus": "",
-            "hide_product_version": ""
+            "hide_product_version": "",
+            "disable_persistent_config": ""
         }
 
         sg_platform = get_sg_platform(self._cluster_config)
@@ -294,6 +296,9 @@ class Cluster:
 
         if is_hide_prod_version_enabled(self._cluster_config) and get_sg_version(self._cluster_config) >= "2.8.1":
             playbook_vars["hide_product_version"] = '"hide_product_version": true,'
+
+        if is_centralized_persistent_config_disabled(self._cluster_config):
+            playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
 
         # Sleep for a few seconds for the indexes to teardown
         time.sleep(5)

--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -19,7 +19,7 @@ from utilities.cluster_config_utils import get_load_balancer_ip, no_conflicts_en
 from utilities.cluster_config_utils import generate_x509_certs, is_x509_auth, get_cbs_primary_nodes_str, is_hide_prod_version_enabled
 from keywords.constants import SYNC_GATEWAY_CERT
 from utilities.cluster_config_utils import get_sg_replicas, get_sg_use_views, get_sg_version
-from utilities.cluster_config_utils import is_centralized_persistent_config_disabled
+from utilities.cluster_config_utils import is_centralized_persistent_config_disabled, is_server_tls_skip_verify_enabled, is_admin_auth_disabled, is_tls_server_disabled, is_tls_client_disabled
 
 
 class Cluster:
@@ -207,7 +207,12 @@ class Cluster:
             "delta_sync": "",
             "prometheus": "",
             "hide_product_version": "",
-            "disable_persistent_config": ""
+            "disable_persistent_config": "",
+            "server_tls_skip_verify": "",
+            "tls_server": "",
+            "tls_client": "",
+            "admin_auth": "",
+            "metrics_auth": ""
         }
 
         sg_platform = get_sg_platform(self._cluster_config)
@@ -299,6 +304,19 @@ class Cluster:
 
         if is_centralized_persistent_config_disabled(self._cluster_config) and get_sg_version(self._cluster_config) >= "3.0.0":
             playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
+
+        if is_server_tls_skip_verify_enabled(self._cluster_config) and get_sg_version(self._cluster_config) >= "3.0.0":
+            playbook_vars["server_tls_skip_verify"] = '"server_tls_skip_verify": true,'
+
+        if is_tls_server_disabled(self._cluster_config) and get_sg_version(self._cluster_config) >= "3.0.0":
+            playbook_vars["tls_server"] = '"use_tls_server": false,'
+
+        if is_tls_client_disabled(self._cluster_config) and get_sg_version(self._cluster_config) >= "3.0.0":
+            playbook_vars["tls_client"] = '"use_tls_client": false,'
+
+        if is_admin_auth_disabled(self._cluster_config) and get_sg_version(self._cluster_config) >= "3.0.0":
+            playbook_vars["admin_auth"] = '"admin_interface_authentication": false,'
+            playbook_vars["metrics_auth"] = '"metrics_interface_authentication": false,'
 
         # Sleep for a few seconds for the indexes to teardown
         time.sleep(5)

--- a/libraries/testkit/syncgateway.py
+++ b/libraries/testkit/syncgateway.py
@@ -176,7 +176,7 @@ class SyncGateway:
         if is_hide_prod_version_enabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "2.8.1":
             playbook_vars["hide_product_version"] = '"hide_product_version": true,'
 
-        if is_centralized_persistent_config_disabled(self.cluster_config):
+        if is_centralized_persistent_config_disabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "3.0.0":
             playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
 
         if is_cbs_ssl_enabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "1.5.0":
@@ -232,7 +232,8 @@ class SyncGateway:
             "couchbase_server_primary_node": self.couchbase_server_primary_node,
             "delta_sync": "",
             "prometheus": "",
-            "hide_product_version": ""
+            "hide_product_version": "",
+            "disable_persistent_config": ""
         }
         sg_platform = get_sg_platform(self.cluster_config)
         if sg_ssl_enabled(self.cluster_config):
@@ -308,6 +309,9 @@ class SyncGateway:
 
         if is_hide_prod_version_enabled(cluster_config) and get_sg_version(cluster_config) >= "2.8.1":
             playbook_vars["hide_product_version"] = '"hide_product_version": true,'
+
+        if is_centralized_persistent_config_disabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "3.0.0":
+            playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
 
         if is_cbs_ssl_enabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "1.5.0":
             playbook_vars["server_scheme"] = "couchbases"

--- a/libraries/testkit/syncgateway.py
+++ b/libraries/testkit/syncgateway.py
@@ -19,7 +19,7 @@ from utilities.cluster_config_utils import get_sg_replicas, get_sg_use_views, ge
 from keywords.utils import add_cbs_to_sg_config_server_field, log_info, random_string
 from keywords.constants import SYNC_GATEWAY_CERT
 from keywords.exceptions import ProvisioningError
-from utilities.cluster_config_utils import is_centralized_persistent_config_disabled, is_server_tls_skip_verify_enabled, is_admin_auth_disabled, is_tls_server_disabled, is_tls_client_disabled
+from utilities.cluster_config_utils import is_centralized_persistent_config_disabled, is_server_tls_skip_verify_enabled, is_admin_auth_disabled, is_tls_server_disabled
 
 log = logging.getLogger(libraries.testkit.settings.LOGGER)
 
@@ -99,7 +99,6 @@ class SyncGateway:
             "disable_persistent_config": "",
             "server_tls_skip_verify": "",
             "disable_tls_server": "",
-            "disable_tls_client": "",
             "disable_admin_auth": ""
         }
 
@@ -188,9 +187,6 @@ class SyncGateway:
         if is_tls_server_disabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "3.0.0":
             playbook_vars["disable_tls_server"] = '"use_tls_server": false,'
 
-        if is_tls_client_disabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "3.0.0":
-            playbook_vars["disable_tls_client"] = '"use_tls_client": false,'
-
         if is_admin_auth_disabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "3.0.0":
             playbook_vars["disable_admin_auth"] = '"admin_interface_authentication": false,    \n"metrics_interface_authentication": false,'
 
@@ -251,7 +247,6 @@ class SyncGateway:
             "disable_persistent_config": "",
             "server_tls_skip_verify": "",
             "disable_tls_server": "",
-            "disable_tls_client": "",
             "disable_admin_auth": ""
         }
         sg_platform = get_sg_platform(self.cluster_config)
@@ -337,9 +332,6 @@ class SyncGateway:
 
         if is_tls_server_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
             playbook_vars["disable_tls_server"] = '"use_tls_server": false,'
-
-        if is_tls_client_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-            playbook_vars["disable_tls_client"] = '"use_tls_client": false,'
 
         if is_admin_auth_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
             playbook_vars["disable_admin_auth"] = '"admin_interface_authentication": false,    \n"metrics_interface_authentication": false,'

--- a/libraries/testkit/syncgateway.py
+++ b/libraries/testkit/syncgateway.py
@@ -98,11 +98,9 @@ class SyncGateway:
             "hide_product_version": "",
             "disable_persistent_config": "",
             "server_tls_skip_verify": "",
-            "tls_server": "",
-            "tls_client": "",
-            "admin_auth": "",
-            "metrics_auth": ""
-
+            "disable_tls_server": "",
+            "disable_tls_client": "",
+            "disable_admin_auth": ""
         }
 
         if sg_ssl_enabled(self.cluster_config):
@@ -188,14 +186,13 @@ class SyncGateway:
             playbook_vars["server_tls_skip_verify"] = '"server_tls_skip_verify": true,'
 
         if is_tls_server_disabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "3.0.0":
-            playbook_vars["tls_server"] = '"use_tls_server": false,'
+            playbook_vars["disable_tls_server"] = '"use_tls_server": false,'
 
         if is_tls_client_disabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "3.0.0":
-            playbook_vars["tls_client"] = '"use_tls_client": false,'
+            playbook_vars["disable_tls_client"] = '"use_tls_client": false,'
 
         if is_admin_auth_disabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "3.0.0":
-            playbook_vars["admin_auth"] = '"admin_interface_authentication": false,'
-            playbook_vars["metrics_auth"] = '"metrics_interface_authentication": false,'
+            playbook_vars["disable_admin_auth"] = '"admin_interface_authentication": false,    \n"metrics_interface_authentication": false,'
 
         if is_cbs_ssl_enabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "1.5.0":
             playbook_vars["server_scheme"] = "couchbases"
@@ -253,10 +250,9 @@ class SyncGateway:
             "hide_product_version": "",
             "disable_persistent_config": "",
             "server_tls_skip_verify": "",
-            "tls_server": "",
-            "tls_client": "",
-            "admin_auth": "",
-            "metrics_auth": ""
+            "disable_tls_server": "",
+            "disable_tls_client": "",
+            "disable_admin_auth": ""
         }
         sg_platform = get_sg_platform(self.cluster_config)
         if sg_ssl_enabled(self.cluster_config):
@@ -340,14 +336,13 @@ class SyncGateway:
             playbook_vars["server_tls_skip_verify"] = '"server_tls_skip_verify": true,'
 
         if is_tls_server_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-            playbook_vars["tls_server"] = '"use_tls_server": false,'
+            playbook_vars["disable_tls_server"] = '"use_tls_server": false,'
 
         if is_tls_client_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-            playbook_vars["tls_client"] = '"use_tls_client": false,'
+            playbook_vars["disable_tls_client"] = '"use_tls_client": false,'
 
         if is_admin_auth_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
-            playbook_vars["admin_auth"] = '"admin_interface_authentication": false,'
-            playbook_vars["metrics_auth"] = '"metrics_interface_authentication": false,'
+            playbook_vars["disable_admin_auth"] = '"admin_interface_authentication": false,    \n"metrics_interface_authentication": false,'
 
         if is_cbs_ssl_enabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "1.5.0":
             playbook_vars["server_scheme"] = "couchbases"

--- a/libraries/testkit/syncgateway.py
+++ b/libraries/testkit/syncgateway.py
@@ -19,6 +19,7 @@ from utilities.cluster_config_utils import get_sg_replicas, get_sg_use_views, ge
 from keywords.utils import add_cbs_to_sg_config_server_field, log_info, random_string
 from keywords.constants import SYNC_GATEWAY_CERT
 from keywords.exceptions import ProvisioningError
+from utilities.cluster_config_utils import is_centralized_persistent_config_disabled
 
 log = logging.getLogger(libraries.testkit.settings.LOGGER)
 
@@ -94,7 +95,8 @@ class SyncGateway:
             "couchbase_server_primary_node": self.couchbase_server_primary_node,
             "delta_sync": "",
             "prometheus": "",
-            "hide_product_version": ""
+            "hide_product_version": "",
+            "disable_persistent_config": ""
 
         }
 
@@ -173,6 +175,9 @@ class SyncGateway:
 
         if is_hide_prod_version_enabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "2.8.1":
             playbook_vars["hide_product_version"] = '"hide_product_version": true,'
+
+        if is_centralized_persistent_config_disabled(self._cluster_config):
+            playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
 
         if is_cbs_ssl_enabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "1.5.0":
             playbook_vars["server_scheme"] = "couchbases"

--- a/libraries/testkit/syncgateway.py
+++ b/libraries/testkit/syncgateway.py
@@ -19,7 +19,7 @@ from utilities.cluster_config_utils import get_sg_replicas, get_sg_use_views, ge
 from keywords.utils import add_cbs_to_sg_config_server_field, log_info, random_string
 from keywords.constants import SYNC_GATEWAY_CERT
 from keywords.exceptions import ProvisioningError
-from utilities.cluster_config_utils import is_centralized_persistent_config_disabled
+from utilities.cluster_config_utils import is_centralized_persistent_config_disabled, is_server_tls_skip_verify_enabled, is_admin_auth_disabled, is_tls_server_disabled, is_tls_client_disabled
 
 log = logging.getLogger(libraries.testkit.settings.LOGGER)
 
@@ -96,7 +96,12 @@ class SyncGateway:
             "delta_sync": "",
             "prometheus": "",
             "hide_product_version": "",
-            "disable_persistent_config": ""
+            "disable_persistent_config": "",
+            "server_tls_skip_verify": "",
+            "tls_server": "",
+            "tls_client": "",
+            "admin_auth": "",
+            "metrics_auth": ""
 
         }
 
@@ -179,6 +184,19 @@ class SyncGateway:
         if is_centralized_persistent_config_disabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "3.0.0":
             playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
 
+        if is_server_tls_skip_verify_enabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "3.0.0":
+            playbook_vars["server_tls_skip_verify"] = '"server_tls_skip_verify": true,'
+
+        if is_tls_server_disabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "3.0.0":
+            playbook_vars["tls_server"] = '"use_tls_server": false,'
+
+        if is_tls_client_disabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "3.0.0":
+            playbook_vars["tls_client"] = '"use_tls_client": false,'
+
+        if is_admin_auth_disabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "3.0.0":
+            playbook_vars["admin_auth"] = '"admin_interface_authentication": false,'
+            playbook_vars["metrics_auth"] = '"metrics_interface_authentication": false,'
+
         if is_cbs_ssl_enabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "1.5.0":
             playbook_vars["server_scheme"] = "couchbases"
             playbook_vars["server_port"] = 11207
@@ -233,7 +251,12 @@ class SyncGateway:
             "delta_sync": "",
             "prometheus": "",
             "hide_product_version": "",
-            "disable_persistent_config": ""
+            "disable_persistent_config": "",
+            "server_tls_skip_verify": "",
+            "tls_server": "",
+            "tls_client": "",
+            "admin_auth": "",
+            "metrics_auth": ""
         }
         sg_platform = get_sg_platform(self.cluster_config)
         if sg_ssl_enabled(self.cluster_config):
@@ -312,6 +335,19 @@ class SyncGateway:
 
         if is_centralized_persistent_config_disabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "3.0.0":
             playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
+
+        if is_server_tls_skip_verify_enabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            playbook_vars["server_tls_skip_verify"] = '"server_tls_skip_verify": true,'
+
+        if is_tls_server_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            playbook_vars["tls_server"] = '"use_tls_server": false,'
+
+        if is_tls_client_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            playbook_vars["tls_client"] = '"use_tls_client": false,'
+
+        if is_admin_auth_disabled(cluster_config) and get_sg_version(cluster_config) >= "3.0.0":
+            playbook_vars["admin_auth"] = '"admin_interface_authentication": false,'
+            playbook_vars["metrics_auth"] = '"metrics_interface_authentication": false,'
 
         if is_cbs_ssl_enabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "1.5.0":
             playbook_vars["server_scheme"] = "couchbases"

--- a/libraries/testkit/syncgateway.py
+++ b/libraries/testkit/syncgateway.py
@@ -176,7 +176,7 @@ class SyncGateway:
         if is_hide_prod_version_enabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "2.8.1":
             playbook_vars["hide_product_version"] = '"hide_product_version": true,'
 
-        if is_centralized_persistent_config_disabled(self._cluster_config):
+        if is_centralized_persistent_config_disabled(self.cluster_config):
             playbook_vars["disable_persistent_config"] = '"disable_persistent_config": true,'
 
         if is_cbs_ssl_enabled(self.cluster_config) and get_sg_version(self.cluster_config) >= "1.5.0":

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_dcp_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_dcp_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_dcp_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_dcp_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_dcp_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_default_dcp_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_multiple_dbs_unique_buckets_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_false_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_false_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_false_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_false_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_false_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_false_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_true_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_true_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_true_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_true_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_true_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/bucket_online_offline_offline_true_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_all_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_all_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_all_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_all_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_all_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_all_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_restricted_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_restricted_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_restricted_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_restricted_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_restricted_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_access_restricted_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_invalid_db_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_invalid_db_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_invalid_db_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_invalid_db_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_invalid_db_cc.json
+++ b/resources/sync_gateway_configs/bucket_online_offline/db_online_offline_invalid_db_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/access_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/access_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/access_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/access_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/custom_sync/access_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/access_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/grant_access_one_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/grant_access_one_cc.json
@@ -8,6 +8,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/grant_access_one_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/grant_access_one_cc.json
@@ -10,7 +10,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/custom_sync/grant_access_one_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/grant_access_one_cc.json
@@ -7,6 +7,7 @@
     {{ prometheus }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_access_sanity_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_access_sanity_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_access_sanity_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_access_sanity_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_access_sanity_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_access_sanity_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_di.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_di.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_di.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_di.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_di.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_channel_sanity_di.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_olddoc_delete_check_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_olddoc_delete_check_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_olddoc_delete_check_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_olddoc_delete_check_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_olddoc_delete_check_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_olddoc_delete_check_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_one_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_one_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_one_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_one_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_one_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_one_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_require_roles_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_require_roles_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_require_roles_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_require_roles_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_require_roles_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_require_roles_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_role_sanity_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_role_sanity_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_role_sanity_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_role_sanity_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_role_sanity_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_custom_sync_role_sanity_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_externalize_js_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_externalize_js_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_externalize_js_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_externalize_js_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/custom_sync/sync_gateway_externalize_js_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/sync_gateway_externalize_js_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/wake_changes_access_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/wake_changes_access_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/wake_changes_access_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/wake_changes_access_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/custom_sync/wake_changes_access_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/wake_changes_access_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/wake_changes_roles_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/wake_changes_roles_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/custom_sync/wake_changes_roles_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/wake_changes_roles_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/custom_sync/wake_changes_roles_cc.json
+++ b/resources/sync_gateway_configs/custom_sync/wake_changes_roles_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/default.json
+++ b/resources/sync_gateway_configs/default.json
@@ -2,5 +2,9 @@
 	{{ logging }}
 	{{ hide_product_version }}
 	{{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
 	"databases": {}
 }

--- a/resources/sync_gateway_configs/default.json
+++ b/resources/sync_gateway_configs/default.json
@@ -1,5 +1,6 @@
 {
 	{{ logging }}
 	{{ hide_product_version }}
+	{{ disable_persistent_config }}
 	"databases": {}
 }

--- a/resources/sync_gateway_configs/default.json
+++ b/resources/sync_gateway_configs/default.json
@@ -4,7 +4,6 @@
 	{{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
 	"databases": {}
 }

--- a/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_2min_rev_cc.json
+++ b/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_2min_rev_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_2min_rev_cc.json
+++ b/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_2min_rev_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_2min_rev_cc.json
+++ b/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_2min_rev_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_enabled_cc.json
+++ b/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_enabled_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_enabled_cc.json
+++ b/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_enabled_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_enabled_cc.json
+++ b/resources/sync_gateway_configs/delta_sync/sync_gateway_delta_sync_enabled_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/dist_index_config_local.json
+++ b/resources/sync_gateway_configs/dist_index_config_local.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "cluster_config": {
         "server":"http://127.0.0.1:8091",
         "data_dir":".",

--- a/resources/sync_gateway_configs/dist_index_config_local.json
+++ b/resources/sync_gateway_configs/dist_index_config_local.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "cluster_config": {
         "server":"http://127.0.0.1:8091",
         "data_dir":".",

--- a/resources/sync_gateway_configs/dist_index_config_local.json
+++ b/resources/sync_gateway_configs/dist_index_config_local.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "cluster_config": {
         "server":"http://127.0.0.1:8091",

--- a/resources/sync_gateway_configs/grocery_sync_conf.json
+++ b/resources/sync_gateway_configs/grocery_sync_conf.json
@@ -1,6 +1,7 @@
 {
 	{{ logging }}
 	{{ hide_product_version }}
+	{{ disable_persistent_config }}
 	"databases": {
 		"grocery-sync": {
 			"server": "walrus:",

--- a/resources/sync_gateway_configs/grocery_sync_conf.json
+++ b/resources/sync_gateway_configs/grocery_sync_conf.json
@@ -2,6 +2,10 @@
 	{{ logging }}
 	{{ hide_product_version }}
 	{{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
 	"databases": {
 		"grocery-sync": {
 			"server": "walrus:",

--- a/resources/sync_gateway_configs/grocery_sync_conf.json
+++ b/resources/sync_gateway_configs/grocery_sync_conf.json
@@ -4,7 +4,6 @@
 	{{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
 	"databases": {
 		"grocery-sync": {

--- a/resources/sync_gateway_configs/import_false_cc.json
+++ b/resources/sync_gateway_configs/import_false_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ no_conflicts }}

--- a/resources/sync_gateway_configs/import_false_cc.json
+++ b/resources/sync_gateway_configs/import_false_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/import_false_cc.json
+++ b/resources/sync_gateway_configs/import_false_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ no_conflicts }}

--- a/resources/sync_gateway_configs/listener_tests/four_sync_gateways_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/four_sync_gateways_cc.json
@@ -6,7 +6,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/listener_tests/four_sync_gateways_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/four_sync_gateways_cc.json
@@ -3,6 +3,7 @@
     "adminInterface": "0.0.0.0:4985",
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/listener_tests/four_sync_gateways_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/four_sync_gateways_cc.json
@@ -4,6 +4,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_cc.json
@@ -8,7 +8,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_cc.json
@@ -5,6 +5,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_cc.json
@@ -6,6 +6,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_no_conflicts_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_no_conflicts_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_no_conflicts_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_no_conflicts_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_no_conflicts_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_no_conflicts_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_revslimit_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_revslimit_cc.json
@@ -8,7 +8,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_revslimit_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_revslimit_cc.json
@@ -5,6 +5,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_revslimit_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_revslimit_cc.json
@@ -6,6 +6,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_user_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_user_cc.json
@@ -6,6 +6,10 @@
   {{ logging }}
   {{ hide_product_version }}
   {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
   "databases": {
     "db": {
       {{ autoimport }}

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_user_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_user_cc.json
@@ -8,7 +8,6 @@
   {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
   "databases": {
     "db": {

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_user_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_user_cc.json
@@ -5,6 +5,7 @@
   {{ sslkey }}
   {{ logging }}
   {{ hide_product_version }}
+  {{ disable_persistent_config }}
   "databases": {
     "db": {
       {{ autoimport }}

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_with_replications_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_with_replications_cc.json
@@ -8,7 +8,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_with_replications_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_with_replications_cc.json
@@ -6,6 +6,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ replace_with_replications }}

--- a/resources/sync_gateway_configs/listener_tests/listener_tests_with_replications_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/listener_tests_with_replications_cc.json
@@ -5,6 +5,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ replace_with_replications }}

--- a/resources/sync_gateway_configs/listener_tests/multiple_sync_gateways_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/multiple_sync_gateways_cc.json
@@ -5,6 +5,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "sg_db1":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/listener_tests/multiple_sync_gateways_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/multiple_sync_gateways_cc.json
@@ -6,6 +6,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "sg_db1":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/listener_tests/multiple_sync_gateways_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/multiple_sync_gateways_cc.json
@@ -8,7 +8,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "sg_db1":{

--- a/resources/sync_gateway_configs/listener_tests/sg_replicate_custom_conflict_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/sg_replicate_custom_conflict_cc.json
@@ -5,6 +5,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "sg_db1":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/listener_tests/sg_replicate_custom_conflict_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/sg_replicate_custom_conflict_cc.json
@@ -6,6 +6,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "sg_db1":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/listener_tests/sg_replicate_custom_conflict_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/sg_replicate_custom_conflict_cc.json
@@ -8,7 +8,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "sg_db1":{

--- a/resources/sync_gateway_configs/listener_tests/sg_replicate_sgw_cluster1_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/sg_replicate_sgw_cluster1_cc.json
@@ -6,6 +6,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ prometheus }}
     "databases":{
         "sg_db1":{

--- a/resources/sync_gateway_configs/listener_tests/sg_replicate_sgw_cluster1_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/sg_replicate_sgw_cluster1_cc.json
@@ -8,7 +8,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ prometheus }}
     "databases":{

--- a/resources/sync_gateway_configs/listener_tests/sg_replicate_sgw_cluster1_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/sg_replicate_sgw_cluster1_cc.json
@@ -5,6 +5,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ prometheus }}
     "databases":{
         "sg_db1":{

--- a/resources/sync_gateway_configs/listener_tests/sg_replicate_sgw_cluster2_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/sg_replicate_sgw_cluster2_cc.json
@@ -5,6 +5,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ prometheus }}
     "databases":{
         "sg_db2":{

--- a/resources/sync_gateway_configs/listener_tests/sg_replicate_sgw_cluster2_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/sg_replicate_sgw_cluster2_cc.json
@@ -6,6 +6,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ prometheus }}
     "databases":{
         "sg_db2":{

--- a/resources/sync_gateway_configs/listener_tests/sg_replicate_sgw_cluster2_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/sg_replicate_sgw_cluster2_cc.json
@@ -8,7 +8,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ prometheus }}
     "databases":{

--- a/resources/sync_gateway_configs/listener_tests/sg_replicate_sgw_cluster_databucket_3_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/sg_replicate_sgw_cluster_databucket_3_cc.json
@@ -6,6 +6,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "sg_db3":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/listener_tests/sg_replicate_sgw_cluster_databucket_3_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/sg_replicate_sgw_cluster_databucket_3_cc.json
@@ -8,7 +8,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "sg_db3":{

--- a/resources/sync_gateway_configs/listener_tests/sg_replicate_sgw_cluster_databucket_3_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/sg_replicate_sgw_cluster_databucket_3_cc.json
@@ -5,6 +5,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "sg_db3":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/listener_tests/three_sync_gateways_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/three_sync_gateways_cc.json
@@ -6,7 +6,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/listener_tests/three_sync_gateways_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/three_sync_gateways_cc.json
@@ -3,6 +3,7 @@
     "adminInterface": "0.0.0.0:4985",
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/listener_tests/three_sync_gateways_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/three_sync_gateways_cc.json
@@ -4,6 +4,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/log_redaction_cc.json
+++ b/resources/sync_gateway_configs/log_redaction_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/log_redaction_cc.json
+++ b/resources/sync_gateway_configs/log_redaction_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/log_redaction_cc.json
+++ b/resources/sync_gateway_configs/log_redaction_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/log_rotation_new_cc.json
+++ b/resources/sync_gateway_configs/log_rotation_new_cc.json
@@ -1,6 +1,10 @@
 {
   "interface":":4984",
   "adminInterface": "0.0.0.0:4985",
+  {{ disable_persistent_config }}
+  {{ server_tls_skip_verify }}
+  {{ disable_tls_server }}
+  {{ disable_admin_auth }}
   "logging": {
     "log_file_path": "/tmp/sg_logs",
     "console": {

--- a/resources/sync_gateway_configs/missing_num_shards_di.json
+++ b/resources/sync_gateway_configs/missing_num_shards_di.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",

--- a/resources/sync_gateway_configs/missing_num_shards_di.json
+++ b/resources/sync_gateway_configs/missing_num_shards_di.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/missing_num_shards_di.json
+++ b/resources/sync_gateway_configs/missing_num_shards_di.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/multiple_dbs_shared_data_shared_index_cc.json
+++ b/resources/sync_gateway_configs/multiple_dbs_shared_data_shared_index_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases": {

--- a/resources/sync_gateway_configs/multiple_dbs_shared_data_shared_index_cc.json
+++ b/resources/sync_gateway_configs/multiple_dbs_shared_data_shared_index_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases": {

--- a/resources/sync_gateway_configs/multiple_dbs_shared_data_shared_index_cc.json
+++ b/resources/sync_gateway_configs/multiple_dbs_shared_data_shared_index_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_cc.json
+++ b/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases": {

--- a/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_cc.json
+++ b/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases": {

--- a/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_cc.json
+++ b/resources/sync_gateway_configs/multiple_dbs_unique_data_unique_index_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/performance/sync_gateway_default_performance_cc.json
+++ b/resources/sync_gateway_configs/performance/sync_gateway_default_performance_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/performance/sync_gateway_default_performance_cc.json
+++ b/resources/sync_gateway_configs/performance/sync_gateway_default_performance_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/performance/sync_gateway_default_performance_cc.json
+++ b/resources/sync_gateway_configs/performance/sync_gateway_default_performance_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/performance/sync_gateway_default_performance_di.json
+++ b/resources/sync_gateway_configs/performance/sync_gateway_default_performance_di.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",

--- a/resources/sync_gateway_configs/performance/sync_gateway_default_performance_di.json
+++ b/resources/sync_gateway_configs/performance/sync_gateway_default_performance_di.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/performance/sync_gateway_default_performance_di.json
+++ b/resources/sync_gateway_configs/performance/sync_gateway_default_performance_di.json
@@ -6,6 +6,7 @@
     "compressResponses": true,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "cluster_config": {
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
         "data_dir":".",

--- a/resources/sync_gateway_configs/reject_all_cc.json
+++ b/resources/sync_gateway_configs/reject_all_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/reject_all_cc.json
+++ b/resources/sync_gateway_configs/reject_all_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/reject_all_cc.json
+++ b/resources/sync_gateway_configs/reject_all_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/sync-gateway-config-travelsample.json
+++ b/resources/sync_gateway_configs/sync-gateway-config-travelsample.json
@@ -2,6 +2,7 @@
   "interface":":4984",
   {{ logging }}
   {{ hide_product_version }}
+  {{ disable_persistent_config }}
   {{ sslcert }}
   {{ sslkey }}
   "databases": {

--- a/resources/sync_gateway_configs/sync-gateway-config-travelsample.json
+++ b/resources/sync_gateway_configs/sync-gateway-config-travelsample.json
@@ -3,6 +3,10 @@
   {{ logging }}
   {{ hide_product_version }}
   {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
   {{ sslcert }}
   {{ sslkey }}
   "databases": {

--- a/resources/sync_gateway_configs/sync-gateway-config-travelsample.json
+++ b/resources/sync_gateway_configs/sync-gateway-config-travelsample.json
@@ -5,7 +5,6 @@
   {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
   {{ sslcert }}
   {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_allow_conflicts_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_allow_conflicts_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_allow_conflicts_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_allow_conflicts_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_allow_conflicts_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_allow_conflicts_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/sync_gateway_blip_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_blip_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/sync_gateway_blip_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_blip_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_blip_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_blip_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/sync_gateway_bucketshadow_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_bucketshadow_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ no_conflicts }}

--- a/resources/sync_gateway_configs/sync_gateway_bucketshadow_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_bucketshadow_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/sync_gateway_bucketshadow_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_bucketshadow_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ no_conflicts }}

--- a/resources/sync_gateway_configs/sync_gateway_bucketshadow_low_revs_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_bucketshadow_low_revs_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ no_conflicts }}

--- a/resources/sync_gateway_configs/sync_gateway_bucketshadow_low_revs_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_bucketshadow_low_revs_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/sync_gateway_bucketshadow_low_revs_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_bucketshadow_low_revs_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ no_conflicts }}

--- a/resources/sync_gateway_configs/sync_gateway_channel_cache_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_channel_cache_cc.json
@@ -6,6 +6,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db": {
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_channel_cache_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_channel_cache_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db": {

--- a/resources/sync_gateway_configs/sync_gateway_channel_cache_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_channel_cache_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db": {
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_default_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_default_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_default_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_cc.json
@@ -10,6 +10,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_cc.json
@@ -12,7 +12,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_cc.json
@@ -9,6 +9,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_couchbase_protocol_withport_11210_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_couchbase_protocol_withport_11210_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_couchbase_protocol_withport_11210_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_couchbase_protocol_withport_11210_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_couchbase_protocol_withport_11210_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_couchbase_protocol_withport_11210_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_no_port_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_no_port_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_no_port_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_no_port_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_no_port_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_no_port_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_revslimit50_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_revslimit50_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_revslimit50_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_revslimit50_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_default_functional_tests_revslimit50_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_functional_tests_revslimit50_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/sync_gateway_default_low_revs_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_low_revs_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_default_low_revs_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_low_revs_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_default_low_revs_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_low_revs_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/sync_gateway_default_with_importpartitions_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_with_importpartitions_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ no_conflicts }}

--- a/resources/sync_gateway_configs/sync_gateway_default_with_importpartitions_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_with_importpartitions_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/sync_gateway_default_with_importpartitions_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_default_with_importpartitions_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ no_conflicts }}

--- a/resources/sync_gateway_configs/sync_gateway_guest_enabled_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_guest_enabled_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_guest_enabled_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_guest_enabled_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_guest_enabled_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_guest_enabled_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/sync_gateway_gzip_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_gzip_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_gzip_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_gzip_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_gzip_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_gzip_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/sync_gateway_openid_connect_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_openid_connect_cc.json
@@ -2,6 +2,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
    "compressResponses": false,
    "AdminInterface":"0.0.0.0:4985",
    {{ sslcert }}

--- a/resources/sync_gateway_configs/sync_gateway_openid_connect_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_openid_connect_cc.json
@@ -4,7 +4,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
    "compressResponses": false,
    "AdminInterface":"0.0.0.0:4985",

--- a/resources/sync_gateway_configs/sync_gateway_openid_connect_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_openid_connect_cc.json
@@ -1,6 +1,7 @@
 {
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
    "compressResponses": false,
    "AdminInterface":"0.0.0.0:4985",
    {{ sslcert }}

--- a/resources/sync_gateway_configs/sync_gateway_openid_connect_unsigned_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_openid_connect_unsigned_cc.json
@@ -2,6 +2,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
    "compressResponses": false,
    "AdminInterface":"0.0.0.0:4985",
    {{ sslcert }}

--- a/resources/sync_gateway_configs/sync_gateway_openid_connect_unsigned_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_openid_connect_unsigned_cc.json
@@ -4,7 +4,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
    "compressResponses": false,
    "AdminInterface":"0.0.0.0:4985",

--- a/resources/sync_gateway_configs/sync_gateway_openid_connect_unsigned_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_openid_connect_unsigned_cc.json
@@ -1,6 +1,7 @@
 {
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
    "compressResponses": false,
    "AdminInterface":"0.0.0.0:4985",
    {{ sslcert }}

--- a/resources/sync_gateway_configs/sync_gateway_rev_cache_size5_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_rev_cache_size5_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_rev_cache_size5_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_rev_cache_size5_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_rev_cache_size5_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_rev_cache_size5_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/sync_gateway_revs_conflict_configurable_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_revs_conflict_configurable_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_revs_conflict_configurable_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_revs_conflict_configurable_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_revs_conflict_configurable_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_revs_conflict_configurable_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/sync_gateway_sg_replicate1_in_sgwconfig_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_sg_replicate1_in_sgwconfig_cc.json
@@ -7,6 +7,10 @@
   {{ logging }}
   {{ hide_product_version }}
   {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
   {{ replace_with_sg1_replications }}
   {{ sslcert }}
   {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_sg_replicate1_in_sgwconfig_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_sg_replicate1_in_sgwconfig_cc.json
@@ -9,7 +9,6 @@
   {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
   {{ replace_with_sg1_replications }}
   {{ sslcert }}

--- a/resources/sync_gateway_configs/sync_gateway_sg_replicate1_in_sgwconfig_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_sg_replicate1_in_sgwconfig_cc.json
@@ -6,6 +6,7 @@
   "compressResponses": false,
   {{ logging }}
   {{ hide_product_version }}
+  {{ disable_persistent_config }}
   {{ replace_with_sg1_replications }}
   {{ sslcert }}
   {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_sg_replicate_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_sg_replicate_cc.json
@@ -9,6 +9,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db1":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_sg_replicate_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_sg_replicate_cc.json
@@ -12,7 +12,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db1":{

--- a/resources/sync_gateway_configs/sync_gateway_sg_replicate_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_sg_replicate_cc.json
@@ -10,6 +10,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db1":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/sync_gateway_sg_replicate_continuous_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_sg_replicate_continuous_cc.json
@@ -7,6 +7,10 @@
   {{ logging }}
   {{ hide_product_version }}
   {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
   "replications": [
     {
       "replication_id": "continuous",

--- a/resources/sync_gateway_configs/sync_gateway_sg_replicate_continuous_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_sg_replicate_continuous_cc.json
@@ -6,6 +6,7 @@
   "compressResponses": false,
   {{ logging }}
   {{ hide_product_version }}
+  {{ disable_persistent_config }}
   "replications": [
     {
       "replication_id": "continuous",

--- a/resources/sync_gateway_configs/sync_gateway_sg_replicate_continuous_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_sg_replicate_continuous_cc.json
@@ -9,7 +9,6 @@
   {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
   "replications": [
     {

--- a/resources/sync_gateway_configs/sync_gateway_travel_sample_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_travel_sample_cc.json
@@ -8,6 +8,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/sync_gateway_travel_sample_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_travel_sample_cc.json
@@ -10,7 +10,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/sync_gateway_travel_sample_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_travel_sample_cc.json
@@ -7,6 +7,7 @@
     {{ prometheus }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/sync_gateway_with_shared_bucket_false_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_with_shared_bucket_false_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ no_conflicts }}

--- a/resources/sync_gateway_configs/sync_gateway_with_shared_bucket_false_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_with_shared_bucket_false_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/sync_gateway_with_shared_bucket_false_cc.json
+++ b/resources/sync_gateway_configs/sync_gateway_with_shared_bucket_false_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ no_conflicts }}

--- a/resources/sync_gateway_configs/sync_gateways_one_with_import_docs_cc.json
+++ b/resources/sync_gateway_configs/sync_gateways_one_with_import_docs_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db1":{

--- a/resources/sync_gateway_configs/sync_gateways_one_with_import_docs_cc.json
+++ b/resources/sync_gateway_configs/sync_gateways_one_with_import_docs_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db1":{
             "enable_shared_bucket_access": true,

--- a/resources/sync_gateway_configs/sync_gateways_one_with_import_docs_cc.json
+++ b/resources/sync_gateway_configs/sync_gateways_one_with_import_docs_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db1":{
             "enable_shared_bucket_access": true,

--- a/resources/sync_gateway_configs/testfest_todo_cc.json
+++ b/resources/sync_gateway_configs/testfest_todo_cc.json
@@ -5,6 +5,7 @@
   {{ sslkey }}
   {{ logging }}
   {{ hide_product_version }}
+  {{ disable_persistent_config }}
   "databases": {
     "todo": {
       {{ autoimport }}

--- a/resources/sync_gateway_configs/testfest_todo_cc.json
+++ b/resources/sync_gateway_configs/testfest_todo_cc.json
@@ -6,6 +6,10 @@
   {{ logging }}
   {{ hide_product_version }}
   {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
   "databases": {
     "todo": {
       {{ autoimport }}

--- a/resources/sync_gateway_configs/testfest_todo_cc.json
+++ b/resources/sync_gateway_configs/testfest_todo_cc.json
@@ -8,7 +8,6 @@
   {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
   "databases": {
     "todo": {

--- a/resources/sync_gateway_configs/todolite.json
+++ b/resources/sync_gateway_configs/todolite.json
@@ -1,6 +1,7 @@
 {
   {{ logging }}
   {{ hide_product_version }}
+  {{ disable_persistent_config }}
   "adminInterface": "0.0.0.0:4985",
   "facebook": { "register": true },
   {{ sslcert }}

--- a/resources/sync_gateway_configs/todolite.json
+++ b/resources/sync_gateway_configs/todolite.json
@@ -2,6 +2,10 @@
   {{ logging }}
   {{ hide_product_version }}
   {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
   "adminInterface": "0.0.0.0:4985",
   "facebook": { "register": true },
   {{ sslcert }}

--- a/resources/sync_gateway_configs/todolite.json
+++ b/resources/sync_gateway_configs/todolite.json
@@ -4,7 +4,6 @@
   {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
   "adminInterface": "0.0.0.0:4985",
   "facebook": { "register": true },

--- a/resources/sync_gateway_configs/user_views/user_views_cc.json
+++ b/resources/sync_gateway_configs/user_views/user_views_cc.json
@@ -11,7 +11,6 @@
   {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
   "databases": {
     "db": {

--- a/resources/sync_gateway_configs/user_views/user_views_cc.json
+++ b/resources/sync_gateway_configs/user_views/user_views_cc.json
@@ -8,6 +8,7 @@
   {{ sslkey }}
   {{ logging }}
   {{ hide_product_version }}
+  {{ disable_persistent_config }}
   "databases": {
     "db": {
       {{ autoimport }}

--- a/resources/sync_gateway_configs/user_views/user_views_cc.json
+++ b/resources/sync_gateway_configs/user_views/user_views_cc.json
@@ -9,6 +9,10 @@
   {{ logging }}
   {{ hide_product_version }}
   {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
   "databases": {
     "db": {
       {{ autoimport }}

--- a/resources/sync_gateway_configs/webhooks/webhook_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_cc.json
@@ -8,7 +8,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/webhooks/webhook_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_cc.json
@@ -5,6 +5,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/webhooks/webhook_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_cc.json
@@ -6,6 +6,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/webhooks/webhook_filter_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_filter_cc.json
@@ -8,7 +8,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/webhooks/webhook_filter_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_filter_cc.json
@@ -5,6 +5,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/webhooks/webhook_filter_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_filter_cc.json
@@ -6,6 +6,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/webhooks/webhook_filter_external_js_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_filter_external_js_cc.json
@@ -8,7 +8,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/webhooks/webhook_filter_external_js_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_filter_external_js_cc.json
@@ -5,6 +5,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/webhooks/webhook_filter_external_js_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_filter_external_js_cc.json
@@ -6,6 +6,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ autoimport }}

--- a/resources/sync_gateway_configs/webhooks/webhook_offline_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_offline_cc.json
@@ -6,6 +6,7 @@
     "compressResponses": false,
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/webhooks/webhook_offline_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_offline_cc.json
@@ -9,7 +9,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/webhooks/webhook_offline_cc.json
+++ b/resources/sync_gateway_configs/webhooks/webhook_offline_cc.json
@@ -7,6 +7,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/xattrs/mobile_opt_in_cc.json
+++ b/resources/sync_gateway_configs/xattrs/mobile_opt_in_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ no_conflicts }}

--- a/resources/sync_gateway_configs/xattrs/mobile_opt_in_cc.json
+++ b/resources/sync_gateway_configs/xattrs/mobile_opt_in_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/xattrs/mobile_opt_in_cc.json
+++ b/resources/sync_gateway_configs/xattrs/mobile_opt_in_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ no_conflicts }}

--- a/resources/sync_gateway_configs/xattrs/mobile_opt_in_no_import_cc.json
+++ b/resources/sync_gateway_configs/xattrs/mobile_opt_in_no_import_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ no_conflicts }}

--- a/resources/sync_gateway_configs/xattrs/mobile_opt_in_no_import_cc.json
+++ b/resources/sync_gateway_configs/xattrs/mobile_opt_in_no_import_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/xattrs/mobile_opt_in_no_import_cc.json
+++ b/resources/sync_gateway_configs/xattrs/mobile_opt_in_no_import_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ no_conflicts }}

--- a/resources/sync_gateway_configs/xattrs/no_import_cc.json
+++ b/resources/sync_gateway_configs/xattrs/no_import_cc.json
@@ -8,6 +8,7 @@
     {{ sslkey }}
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     "databases":{
         "db":{
             {{ no_conflicts }}

--- a/resources/sync_gateway_configs/xattrs/no_import_cc.json
+++ b/resources/sync_gateway_configs/xattrs/no_import_cc.json
@@ -11,7 +11,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     "databases":{
         "db":{

--- a/resources/sync_gateway_configs/xattrs/no_import_cc.json
+++ b/resources/sync_gateway_configs/xattrs/no_import_cc.json
@@ -9,6 +9,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     "databases":{
         "db":{
             {{ no_conflicts }}

--- a/resources/sync_gateway_configs/xattrs/old_doc_cc.json
+++ b/resources/sync_gateway_configs/xattrs/old_doc_cc.json
@@ -6,7 +6,6 @@
     {{ disable_persistent_config }}
     {{ server_tls_skip_verify }}
     {{ disable_tls_server }}
-    {{ disable_tls_client }}
     {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}

--- a/resources/sync_gateway_configs/xattrs/old_doc_cc.json
+++ b/resources/sync_gateway_configs/xattrs/old_doc_cc.json
@@ -3,6 +3,7 @@
     "adminInterface": "0.0.0.0:4985",
     {{ logging }}
     {{ hide_product_version }}
+    {{ disable_persistent_config }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/resources/sync_gateway_configs/xattrs/old_doc_cc.json
+++ b/resources/sync_gateway_configs/xattrs/old_doc_cc.json
@@ -4,6 +4,10 @@
     {{ logging }}
     {{ hide_product_version }}
     {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_tls_client }}
+    {{ disable_admin_auth }}
     {{ sslcert }}
     {{ sslkey }}
     "databases":{

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
@@ -83,6 +83,7 @@ def test_replication_configuration_valid_values(params_from_base_test_setup, num
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_config = temp_cluster_config
     c = cluster.Cluster(config=cluster_config)
     c.reset(sg_config_path=sg_config)
@@ -630,6 +631,7 @@ def test_CBL_tombstone_doc(params_from_base_test_setup, num_of_docs, x509_cert_a
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_config = temp_cluster_config
     c = cluster.Cluster(config=cluster_config)
     c.reset(sg_config_path=sg_config)

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
@@ -80,7 +80,10 @@ def test_replication_configuration_valid_values(params_from_base_test_setup, num
     sg_client = MobileRestClient()
 
     # Reset cluster to ensure no data in system
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
@@ -628,7 +631,10 @@ def test_CBL_tombstone_doc(params_from_base_test_setup, num_of_docs, x509_cert_a
     sg_client = MobileRestClient()
 
     # Modify sync-gateway config to use no-conflicts config
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
@@ -81,9 +81,9 @@ def test_replication_configuration_valid_values(params_from_base_test_setup, num
 
     # Reset cluster to ensure no data in system
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
@@ -632,9 +632,9 @@ def test_CBL_tombstone_doc(params_from_base_test_setup, num_of_docs, x509_cert_a
 
     # Modify sync-gateway config to use no-conflicts config
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_xattrs_grants_with_cbl.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_xattrs_grants_with_cbl.py
@@ -63,6 +63,7 @@ def test_xattrs_grant_automatic_imports(params_from_base_test_setup, x509_cert_a
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_config = temp_cluster_config
     c_cluster = cluster.Cluster(config=cluster_config)
     c_cluster.reset(sg_config_path=temp_sg_config)

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_xattrs_grants_with_cbl.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_xattrs_grants_with_cbl.py
@@ -61,9 +61,9 @@ def test_xattrs_grant_automatic_imports(params_from_base_test_setup, x509_cert_a
 
     # Reset cluster to ensure no data in system
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_xattrs_grants_with_cbl.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_xattrs_grants_with_cbl.py
@@ -60,7 +60,10 @@ def test_xattrs_grant_automatic_imports(params_from_base_test_setup, x509_cert_a
     temp_sg_config = replace_xattrs_sync_func_in_config(sg_config, user_custom_channel)
 
     # Reset cluster to ensure no data in system
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/CBLTester/CBL_Functional_tests/conftest.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/conftest.py
@@ -199,10 +199,6 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="Disable tls server")
 
-    parser.addoption("--disable-tls-client",
-                     action="store_true",
-                     help="Disable tls client")
-
     parser.addoption("--disable-admin-auth",
                      action="store_true",
                      help="Disable Admin auth")
@@ -223,6 +219,7 @@ def params_from_base_suite_setup(request):
     skip_provisioning = request.config.getoption("--skip-provisioning")
     use_local_testserver = request.config.getoption("--use-local-testserver")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
     mode = request.config.getoption("--mode")
     server_version = request.config.getoption("--server-version")
     enable_sample_bucket = request.config.getoption("--enable-sample-bucket")
@@ -256,7 +253,7 @@ def params_from_base_suite_setup(request):
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_tls_server = request.config.getoption("--disable-tls-server")
-    disable_tls_client = request.config.getoption("--disable-tls-client")
+
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     test_name = request.node.name
@@ -438,13 +435,6 @@ def params_from_base_suite_setup(request):
         log_info("Enable tls server flag")
         persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
 
-    if disable_tls_client:
-        log_info("Disabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
-    else:
-        log_info("Enabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
-
     if disable_admin_auth:
         log_info("Disabled Admin Auth")
         persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
@@ -604,6 +594,7 @@ def params_from_base_suite_setup(request):
         "sg_db": sg_db,
         "no_conflicts_enabled": no_conflicts_enabled,
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "target_admin_url": target_admin_url,
         "base_url": base_url,
         "enable_sample_bucket": enable_sample_bucket,
@@ -687,6 +678,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     sg_ip = params_from_base_suite_setup["sg_ip"]
     sg_db = params_from_base_suite_setup["sg_db"]
     sync_gateway_version = params_from_base_suite_setup["sync_gateway_version"]
+    disable_tls_server = params_from_base_suite_setup["disable_tls_server"]
     sg_config = params_from_base_suite_setup["sg_config"]
     liteserv_platform = params_from_base_suite_setup["liteserv_platform"]
     testserver = params_from_base_suite_setup["testserver"]
@@ -778,6 +770,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         "sg_db": sg_db,
         "no_conflicts_enabled": no_conflicts_enabled,
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "source_db": source_db,
         "cbl_db": cbl_db,
         "suite_source_db": suite_source_db,

--- a/testsuites/CBLTester/CBL_Functional_tests/conftest.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/conftest.py
@@ -189,8 +189,23 @@ def pytest_addoption(parser):
 
     parser.addoption("--disable-persistent-config",
                      action="store_true",
-                     help="Centralized Persistent Config",
-                     default=True)
+                     help="Disable Centralized Persistent Config")
+
+    parser.addoption("--enable-server-tls-skip-verify",
+                     action="store_true",
+                     help="Enable Server tls skip verify config")
+
+    parser.addoption("--disable-tls-server",
+                     action="store_true",
+                     help="Disable tls server")
+
+    parser.addoption("--disable-tls-client",
+                     action="store_true",
+                     help="Disable tls client")
+
+    parser.addoption("--disable-admin-auth",
+                     action="store_true",
+                     help="Disable Admin auth")
 
 
 # This will get called once before the first test that
@@ -239,6 +254,10 @@ def params_from_base_suite_setup(request):
     cbs_ssl = request.config.getoption("--server-ssl")
     magma_storage_enabled = request.config.getoption("--magma-storage")
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
+    enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
+    disable_tls_client = request.config.getoption("--disable-tls-client")
+    disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     test_name = request.node.name
 
@@ -404,6 +423,34 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without Centralized Persistent Config")
         persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
+
+    if enable_server_tls_skip_verify:
+        log_info("Enable server tls skip verify flag")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', True)
+    else:
+        log_info("Running without server_tls_skip_verify Config")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', False)
+
+    if disable_tls_server:
+        log_info("Disable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', True)
+    else:
+        log_info("Enable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
+
+    if disable_tls_client:
+        log_info("Disabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
+    else:
+        log_info("Enabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
+
+    if disable_admin_auth:
+        log_info("Disabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
+    else:
+        log_info("Enabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', False)
 
     # As cblite jobs run with on Centos platform, adding by default centos to environment config
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)

--- a/testsuites/CBLTester/CBL_Functional_tests/conftest.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/conftest.py
@@ -187,6 +187,11 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="magma-storage: Enable magma storage on couchbase server")
 
+    parser.addoption("--disable-persistent-config",
+                     action="store_true",
+                     help="Centralized Persistent Config",
+                     default=True)
+
 
 # This will get called once before the first test that
 # runs with this as input parameters in this file
@@ -233,6 +238,7 @@ def params_from_base_suite_setup(request):
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
     cbs_ssl = request.config.getoption("--server-ssl")
     magma_storage_enabled = request.config.getoption("--magma-storage")
+    disable_persistent_config = request.config.getoption("--disable-persistent-config")
 
     test_name = request.node.name
 
@@ -391,6 +397,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without magma storage")
         persist_cluster_config_environment_prop(cluster_config, 'magma_storage_enabled', False, False)
+
+    if disable_persistent_config:
+        log_info(" disable persistent config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', True)
+    else:
+        log_info("Running without Centralized Persistent Config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
 
     # As cblite jobs run with on Centos platform, adding by default centos to environment config
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)

--- a/testsuites/CBLTester/System_test_multiple_device/conftest.py
+++ b/testsuites/CBLTester/System_test_multiple_device/conftest.py
@@ -207,10 +207,6 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="Disable tls server")
 
-    parser.addoption("--disable-tls-client",
-                     action="store_true",
-                     help="Disable tls client")
-
     parser.addoption("--disable-admin-auth",
                      action="store_true",
                      help="Disable Admin auth")
@@ -237,6 +233,7 @@ def params_from_base_suite_setup(request):
         raise Exception("Provide equal no. of Parameters for host, port, version and platforms")
     skip_provisioning = request.config.getoption("--skip-provisioning")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
     mode = request.config.getoption("--mode")
 
     server_version = request.config.getoption("--server-version")
@@ -273,7 +270,7 @@ def params_from_base_suite_setup(request):
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_tls_server = request.config.getoption("--disable-tls-server")
-    disable_tls_client = request.config.getoption("--disable-tls-client")
+
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
     # Changing up_time in days
     up_time = up_time * 24 * 60
@@ -413,13 +410,6 @@ def params_from_base_suite_setup(request):
         log_info("Enable tls server flag")
         persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
 
-    if disable_tls_client:
-        log_info("Disabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
-    else:
-        log_info("Enabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
-
     if disable_admin_auth:
         log_info("Disabled Admin Auth")
         persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
@@ -518,6 +508,7 @@ def params_from_base_suite_setup(request):
         "sg_admin_url": sg_admin_url,
         "no_conflicts_enabled": no_conflicts_enabled,
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "target_admin_url": target_admin_url,
         "enable_sample_bucket": enable_sample_bucket,
         "cbl_db_list": cbl_db_list,

--- a/testsuites/CBLTester/System_test_multiple_device/conftest.py
+++ b/testsuites/CBLTester/System_test_multiple_device/conftest.py
@@ -195,6 +195,11 @@ def pytest_addoption(parser):
                      help="Enabling CBS developer preview",
                      default=False)
 
+    parser.addoption("--disable-persistent-config",
+                     action="store_true",
+                     help="Centralized Persistent Config",
+                     default=True)
+
 
 # This will get called once before the first test that
 # runs with this as input parameters in this file
@@ -250,6 +255,7 @@ def params_from_base_suite_setup(request):
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     up_time = int(request.config.getoption("--up-time"))
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
+    disable_persistent_config = request.config.getoption("--disable-persistent-config")
     # Changing up_time in days
     up_time = up_time * 24 * 60
     repl_status_check_sleep_time = int(request.config.getoption("--repl-status-check-sleep-time"))
@@ -366,6 +372,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without CBS developer preview")
         persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
+
+    if disable_persistent_config:
+        log_info(" disable persistent config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', True)
+    else:
+        log_info("Running without Centralized Persistent Config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
 
     if sync_gateway_version < "2.0":
         pytest.skip('Does not work with sg < 2.0 , so skipping the test')

--- a/testsuites/CBLTester/System_test_multiple_device/conftest.py
+++ b/testsuites/CBLTester/System_test_multiple_device/conftest.py
@@ -197,8 +197,23 @@ def pytest_addoption(parser):
 
     parser.addoption("--disable-persistent-config",
                      action="store_true",
-                     help="Centralized Persistent Config",
-                     default=True)
+                     help="Disable Centralized Persistent Config")
+
+    parser.addoption("--enable-server-tls-skip-verify",
+                     action="store_true",
+                     help="Enable Server tls skip verify config")
+
+    parser.addoption("--disable-tls-server",
+                     action="store_true",
+                     help="Disable tls server")
+
+    parser.addoption("--disable-tls-client",
+                     action="store_true",
+                     help="Disable tls client")
+
+    parser.addoption("--disable-admin-auth",
+                     action="store_true",
+                     help="Disable Admin auth")
 
 
 # This will get called once before the first test that
@@ -256,6 +271,10 @@ def params_from_base_suite_setup(request):
     up_time = int(request.config.getoption("--up-time"))
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
+    enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
+    disable_tls_client = request.config.getoption("--disable-tls-client")
+    disable_admin_auth = request.config.getoption("--disable-admin-auth")
     # Changing up_time in days
     up_time = up_time * 24 * 60
     repl_status_check_sleep_time = int(request.config.getoption("--repl-status-check-sleep-time"))
@@ -379,6 +398,34 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without Centralized Persistent Config")
         persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
+
+    if enable_server_tls_skip_verify:
+        log_info("Enable server tls skip verify flag")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', True)
+    else:
+        log_info("Running without server_tls_skip_verify Config")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', False)
+
+    if disable_tls_server:
+        log_info("Disable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', True)
+    else:
+        log_info("Enable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
+
+    if disable_tls_client:
+        log_info("Disabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
+    else:
+        log_info("Enabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
+
+    if disable_admin_auth:
+        log_info("Disabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
+    else:
+        log_info("Enabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', False)
 
     if sync_gateway_version < "2.0":
         pytest.skip('Does not work with sg < 2.0 , so skipping the test')

--- a/testsuites/CBLTester/p2p_topology_specific_tests/conftest.py
+++ b/testsuites/CBLTester/p2p_topology_specific_tests/conftest.py
@@ -145,6 +145,7 @@ def params_from_base_suite_setup(request):
     skip_provisioning = request.config.getoption("--skip-provisioning")
     use_local_testserver = request.config.getoption("--use-local-testserver")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
     mode = request.config.getoption("--mode")
 
     server_version = request.config.getoption("--server-version")
@@ -385,6 +386,7 @@ def params_from_base_suite_setup(request):
         "sg_db": sg_db,
         "no_conflicts_enabled": no_conflicts_enabled,
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "base_url": base_url,
         "base_url2": base_url2,
         "enable_sample_bucket": enable_sample_bucket,
@@ -444,6 +446,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     mode = params_from_base_suite_setup["mode"]
     target_url = params_from_base_suite_setup["target_url"]
     sync_gateway_version = params_from_base_suite_setup["sync_gateway_version"]
+    disable_tls_server = params_from_base_suite_setup["disable_tls_server"]
     sg_ip = params_from_base_suite_setup["sg_ip"]
     sg_db = params_from_base_suite_setup["sg_db"]
     sg_config = params_from_base_suite_setup["sg_config"]
@@ -530,6 +533,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         "sg_db": sg_db,
         "no_conflicts_enabled": no_conflicts_enabled,
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "source_db": source_db,
         "source_db2": source_db2,
         "cbl_db": cbl_db,

--- a/testsuites/CBLTester/system_tests/conftest.py
+++ b/testsuites/CBLTester/system_tests/conftest.py
@@ -188,8 +188,23 @@ def pytest_addoption(parser):
 
     parser.addoption("--disable-persistent-config",
                      action="store_true",
-                     help="Centralized Persistent Config",
-                     default=True)
+                     help="Disable Centralized Persistent Config")
+
+    parser.addoption("--enable-server-tls-skip-verify",
+                     action="store_true",
+                     help="Enable Server tls skip verify config")
+
+    parser.addoption("--disable-tls-server",
+                     action="store_true",
+                     help="Disable tls server")
+
+    parser.addoption("--disable-tls-client",
+                     action="store_true",
+                     help="Disable tls client")
+
+    parser.addoption("--disable-admin-auth",
+                     action="store_true",
+                     help="Disable Admin auth")
 
 
 # This will get called once before the first test that
@@ -251,6 +266,10 @@ def params_from_base_suite_setup(request):
     up_time = up_time * 24 * 60
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
+    enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
+    disable_tls_client = request.config.getoption("--disable-tls-client")
+    disable_admin_auth = request.config.getoption("--disable-admin-auth")
     repl_status_check_sleep_time = int(request.config.getoption("--repl-status-check-sleep-time"))
     test_name = request.node.name
 
@@ -380,6 +399,34 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without Centralized Persistent Config")
         persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
+
+    if enable_server_tls_skip_verify:
+        log_info("Enable server tls skip verify flag")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', True)
+    else:
+        log_info("Running without server_tls_skip_verify Config")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', False)
+
+    if disable_tls_server:
+        log_info("Disable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', True)
+    else:
+        log_info("Enable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
+
+    if disable_tls_client:
+        log_info("Disabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
+    else:
+        log_info("Enabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
+
+    if disable_admin_auth:
+        log_info("Disabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
+    else:
+        log_info("Enabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', False)
 
     if sync_gateway_version < "2.0":
         pytest.skip('Does not work with sg < 2.0 , so skipping the test')

--- a/testsuites/CBLTester/system_tests/conftest.py
+++ b/testsuites/CBLTester/system_tests/conftest.py
@@ -186,6 +186,11 @@ def pytest_addoption(parser):
                      help="Enabling CBS developer preview",
                      default=False)
 
+    parser.addoption("--disable-persistent-config",
+                     action="store_true",
+                     help="Centralized Persistent Config",
+                     default=True)
+
 
 # This will get called once before the first test that
 # runs with this as input parameters in this file
@@ -245,6 +250,7 @@ def params_from_base_suite_setup(request):
     # convert to minutes
     up_time = up_time * 24 * 60
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
+    disable_persistent_config = request.config.getoption("--disable-persistent-config")
     repl_status_check_sleep_time = int(request.config.getoption("--repl-status-check-sleep-time"))
     test_name = request.node.name
 
@@ -367,6 +373,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without CBS developer preview")
         persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
+
+    if disable_persistent_config:
+        log_info(" disable persistent config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', True)
+    else:
+        log_info("Running without Centralized Persistent Config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
 
     if sync_gateway_version < "2.0":
         pytest.skip('Does not work with sg < 2.0 , so skipping the test')

--- a/testsuites/CBLTester/system_tests/conftest.py
+++ b/testsuites/CBLTester/system_tests/conftest.py
@@ -198,10 +198,6 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="Disable tls server")
 
-    parser.addoption("--disable-tls-client",
-                     action="store_true",
-                     help="Disable tls client")
-
     parser.addoption("--disable-admin-auth",
                      action="store_true",
                      help="Disable Admin auth")
@@ -232,6 +228,7 @@ def params_from_base_suite_setup(request):
         raise Exception("Provide equal no. of Parameters for host, port, version and platforms")
     skip_provisioning = request.config.getoption("--skip-provisioning")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
     mode = request.config.getoption("--mode")
 
     server_version = request.config.getoption("--server-version")
@@ -268,7 +265,7 @@ def params_from_base_suite_setup(request):
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_tls_server = request.config.getoption("--disable-tls-server")
-    disable_tls_client = request.config.getoption("--disable-tls-client")
+
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
     repl_status_check_sleep_time = int(request.config.getoption("--repl-status-check-sleep-time"))
     test_name = request.node.name
@@ -414,13 +411,6 @@ def params_from_base_suite_setup(request):
         log_info("Enable tls server flag")
         persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
 
-    if disable_tls_client:
-        log_info("Disabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
-    else:
-        log_info("Enabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
-
     if disable_admin_auth:
         log_info("Disabled Admin Auth")
         persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
@@ -526,6 +516,7 @@ def params_from_base_suite_setup(request):
         "sg_admin_url": sg_admin_url,
         "no_conflicts_enabled": no_conflicts_enabled,
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "target_admin_url": target_admin_url,
         "enable_sample_bucket": enable_sample_bucket,
         "cbl_db_obj_list": cbl_db_obj_list,

--- a/testsuites/CBLTester/topology_specific_tests/conftest.py
+++ b/testsuites/CBLTester/topology_specific_tests/conftest.py
@@ -143,10 +143,6 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="Disable tls server")
 
-    parser.addoption("--disable-tls-client",
-                     action="store_true",
-                     help="Disable tls client")
-
     parser.addoption("--disable-admin-auth",
                      action="store_true",
                      help="Disable Admin auth")

--- a/testsuites/CBLTester/topology_specific_tests/conftest.py
+++ b/testsuites/CBLTester/topology_specific_tests/conftest.py
@@ -130,3 +130,8 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="Enabling CBS developer preview",
                      default=False)
+
+    parser.addoption("--disable-persistent-config",
+                     action="store_true",
+                     help="Centralized Persistent Config",
+                     default=True)

--- a/testsuites/CBLTester/topology_specific_tests/conftest.py
+++ b/testsuites/CBLTester/topology_specific_tests/conftest.py
@@ -133,5 +133,20 @@ def pytest_addoption(parser):
 
     parser.addoption("--disable-persistent-config",
                      action="store_true",
-                     help="Centralized Persistent Config",
-                     default=True)
+                     help="Disable Centralized Persistent Config")
+
+    parser.addoption("--enable-server-tls-skip-verify",
+                     action="store_true",
+                     help="Enable Server tls skip verify config")
+
+    parser.addoption("--disable-tls-server",
+                     action="store_true",
+                     help="Disable tls server")
+
+    parser.addoption("--disable-tls-client",
+                     action="store_true",
+                     help="Disable tls client")
+
+    parser.addoption("--disable-admin-auth",
+                     action="store_true",
+                     help="Disable Admin auth")

--- a/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -38,6 +38,7 @@ def params_from_base_suite_setup(request):
     skip_provisioning = request.config.getoption("--skip-provisioning")
     use_local_testserver = request.config.getoption("--use-local-testserver")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
     mode = request.config.getoption("--mode")
 
     server_version = request.config.getoption("--server-version")
@@ -66,7 +67,7 @@ def params_from_base_suite_setup(request):
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_tls_server = request.config.getoption("--disable-tls-server")
-    disable_tls_client = request.config.getoption("--disable-tls-client")
+
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     testserver = TestServerFactory.create(platform=liteserv_platform,
@@ -202,13 +203,6 @@ def params_from_base_suite_setup(request):
         log_info("Enable tls server flag")
         persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
 
-    if disable_tls_client:
-        log_info("Disabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
-    else:
-        log_info("Enabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
-
     if disable_admin_auth:
         log_info("Disabled Admin Auth")
         persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
@@ -336,6 +330,7 @@ def params_from_base_suite_setup(request):
         "sg_db": sg_db,
         "no_conflicts_enabled": no_conflicts_enabled,
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "base_url": base_url,
         "enable_sample_bucket": enable_sample_bucket,
         "create_db_per_test": create_db_per_test,
@@ -393,6 +388,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     mode = params_from_base_suite_setup["mode"]
     target_url = params_from_base_suite_setup["target_url"]
     sync_gateway_version = params_from_base_suite_setup["sync_gateway_version"]
+    disable_tls_server = params_from_base_suite_setup["disable_tls_server"]
     sg_ip = params_from_base_suite_setup["sg_ip"]
     sg_db = params_from_base_suite_setup["sg_db"]
     sg_config = params_from_base_suite_setup["sg_config"]
@@ -479,6 +475,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         "sg_db": sg_db,
         "no_conflicts_enabled": no_conflicts_enabled,
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "source_db": source_db,
         "cbl_db": cbl_db,
         "suite_source_db": suite_source_db,

--- a/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -63,6 +63,7 @@ def params_from_base_suite_setup(request):
     prometheus_enable = request.config.getoption("--prometheus-enable")
     hide_product_version = request.config.getoption("--hide-product-version")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
+    disable_persistent_config = request.config.getoption("--disable-persistent-config")
 
     testserver = TestServerFactory.create(platform=liteserv_platform,
                                           version_build=liteserv_version,
@@ -175,6 +176,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without CBS developer preview")
         persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
+
+    if disable_persistent_config:
+        log_info(" disable persistent config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', True)
+    else:
+        log_info("Running without Centralized Persistent Config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
 
     # As cblite jobs run with on Centos platform, adding by default centos to environment config
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)

--- a/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -64,6 +64,10 @@ def params_from_base_suite_setup(request):
     hide_product_version = request.config.getoption("--hide-product-version")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
+    enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
+    disable_tls_client = request.config.getoption("--disable-tls-client")
+    disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     testserver = TestServerFactory.create(platform=liteserv_platform,
                                           version_build=liteserv_version,
@@ -183,6 +187,34 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without Centralized Persistent Config")
         persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
+
+    if enable_server_tls_skip_verify:
+        log_info("Enable server tls skip verify flag")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', True)
+    else:
+        log_info("Running without server_tls_skip_verify Config")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', False)
+
+    if disable_tls_server:
+        log_info("Disable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', True)
+    else:
+        log_info("Enable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
+
+    if disable_tls_client:
+        log_info("Disabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
+    else:
+        log_info("Enabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
+
+    if disable_admin_auth:
+        log_info("Disabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
+    else:
+        log_info("Enabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', False)
 
     # As cblite jobs run with on Centos platform, adding by default centos to environment config
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)

--- a/testsuites/CBLTester/topology_specific_tests/sync_gateway_proxy_enabled/conftest.py
+++ b/testsuites/CBLTester/topology_specific_tests/sync_gateway_proxy_enabled/conftest.py
@@ -49,6 +49,7 @@ def params_from_base_suite_setup(request):
     skip_provisioning = request.config.getoption("--skip-provisioning")
     use_local_testserver = request.config.getoption("--use-local-testserver")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
 
     server_version = request.config.getoption("--server-version")
     enable_sample_bucket = request.config.getoption("--enable-sample-bucket")
@@ -74,7 +75,7 @@ def params_from_base_suite_setup(request):
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_tls_server = request.config.getoption("--disable-tls-server")
-    disable_tls_client = request.config.getoption("--disable-tls-client")
+
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     sg_ssl = ""
@@ -197,13 +198,6 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Enable tls server flag")
         persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
-
-    if disable_tls_client:
-        log_info("Disabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
-    else:
-        log_info("Enabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
 
     if disable_admin_auth:
         log_info("Disabled Admin Auth")
@@ -357,6 +351,7 @@ def params_from_base_suite_setup(request):
         "sg_db": sg_db,
         "no_conflicts_enabled": True,
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "target_admin_url": target_admin_url,
         "base_url": base_url,
         "enable_sample_bucket": enable_sample_bucket,
@@ -434,6 +429,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     sg_ip = params_from_base_suite_setup["sg_ip"]
     sg_db = params_from_base_suite_setup["sg_db"]
     sync_gateway_version = params_from_base_suite_setup["sync_gateway_version"]
+    disable_tls_server = params_from_base_suite_setup["disable_tls_server"]
     sg_config = params_from_base_suite_setup["sg_config"]
     liteserv_platform = params_from_base_suite_setup["liteserv_platform"]
     testserver = params_from_base_suite_setup["testserver"]
@@ -520,6 +516,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         "sg_db": sg_db,
         "no_conflicts_enabled": no_conflicts_enabled,
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "source_db": source_db,
         "cbl_db": cbl_db,
         "suite_source_db": suite_source_db,

--- a/testsuites/CBLTester/topology_specific_tests/sync_gateway_proxy_enabled/conftest.py
+++ b/testsuites/CBLTester/topology_specific_tests/sync_gateway_proxy_enabled/conftest.py
@@ -72,6 +72,11 @@ def params_from_base_suite_setup(request):
     hide_product_version = request.config.getoption("--hide-product-version")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
+    enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
+    disable_tls_client = request.config.getoption("--disable-tls-client")
+    disable_admin_auth = request.config.getoption("--disable-admin-auth")
+
     sg_ssl = ""
 
     test_name = request.node.name
@@ -178,6 +183,34 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without Centralized Persistent Config")
         persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
+
+    if enable_server_tls_skip_verify:
+        log_info("Enable server tls skip verify flag")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', True)
+    else:
+        log_info("Running without server_tls_skip_verify Config")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', False)
+
+    if disable_tls_server:
+        log_info("Disable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', True)
+    else:
+        log_info("Enable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
+
+    if disable_tls_client:
+        log_info("Disabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
+    else:
+        log_info("Enabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
+
+    if disable_admin_auth:
+        log_info("Disabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
+    else:
+        log_info("Enabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', False)
 
     # As cblite jobs run with on Centos platform, adding by default centos to environment config
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)

--- a/testsuites/CBLTester/topology_specific_tests/sync_gateway_proxy_enabled/conftest.py
+++ b/testsuites/CBLTester/topology_specific_tests/sync_gateway_proxy_enabled/conftest.py
@@ -71,6 +71,7 @@ def params_from_base_suite_setup(request):
     prometheus_enable = request.config.getoption("--prometheus-enable")
     hide_product_version = request.config.getoption("--hide-product-version")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
+    disable_persistent_config = request.config.getoption("--disable-persistent-config")
     sg_ssl = ""
 
     test_name = request.node.name
@@ -170,6 +171,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without CBS developer preview")
         persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
+
+    if disable_persistent_config:
+        log_info(" disable persistent config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', True)
+    else:
+        log_info("Running without Centralized Persistent Config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
 
     # As cblite jobs run with on Centos platform, adding by default centos to environment config
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)

--- a/testsuites/CBLTester/upgrade_tests/conftest.py
+++ b/testsuites/CBLTester/upgrade_tests/conftest.py
@@ -140,6 +140,11 @@ def pytest_addoption(parser):
                      help="Enabling CBS developer preview",
                      default=False)
 
+    parser.addoption("--disable-persistent-config",
+                     action="store_true",
+                     help="Centralized Persistent Config",
+                     default=True)
+
 
 # This will get called once before the first test that
 # runs with this as input parameters in this file
@@ -179,6 +184,7 @@ def params_from_base_suite_setup(request):
     second_liteserv_platform = request.config.getoption("--second-liteserv-platform")
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
+    disable_persistent_config = request.config.getoption("--disable-persistent-config")
 
     test_name = request.node.name
     if enable_upgrade_app:
@@ -304,6 +310,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without CBS developer preview")
         persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
+
+    if disable_persistent_config:
+        log_info(" disable persistent config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', True)
+    else:
+        log_info("Running without Centralized Persistent Config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
 
     # As cblite jobs run with on Centos platform, adding by default centos to environment config
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)

--- a/testsuites/CBLTester/upgrade_tests/conftest.py
+++ b/testsuites/CBLTester/upgrade_tests/conftest.py
@@ -152,10 +152,6 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="Disable tls server")
 
-    parser.addoption("--disable-tls-client",
-                     action="store_true",
-                     help="Disable tls client")
-
     parser.addoption("--disable-admin-auth",
                      action="store_true",
                      help="Disable Admin auth")
@@ -176,6 +172,7 @@ def params_from_base_suite_setup(request):
     liteserv_port = request.config.getoption("--liteserv-port")
     skip_provisioning = request.config.getoption("--skip-provisioning")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
     mode = request.config.getoption("--mode")
     db_password = request.config.getoption("--encrypted-db-password")
     encrypted_db = request.config.getoption("--encrypted-db")
@@ -202,7 +199,7 @@ def params_from_base_suite_setup(request):
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_tls_server = request.config.getoption("--disable-tls-server")
-    disable_tls_client = request.config.getoption("--disable-tls-client")
+
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     test_name = request.node.name
@@ -351,13 +348,6 @@ def params_from_base_suite_setup(request):
         log_info("Enable tls server flag")
         persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
 
-    if disable_tls_client:
-        log_info("Disabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
-    else:
-        log_info("Enabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
-
     if disable_admin_auth:
         log_info("Disabled Admin Auth")
         persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
@@ -444,6 +434,7 @@ def params_from_base_suite_setup(request):
         "no_conflicts_enabled": no_conflicts_enabled,
         "server_version": server_version,
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "sg_admin_url": sg_admin_url,
         "base_url": base_url,
         "suite_source_db": suite_source_db,

--- a/testsuites/CBLTester/upgrade_tests/conftest.py
+++ b/testsuites/CBLTester/upgrade_tests/conftest.py
@@ -142,8 +142,23 @@ def pytest_addoption(parser):
 
     parser.addoption("--disable-persistent-config",
                      action="store_true",
-                     help="Centralized Persistent Config",
-                     default=True)
+                     help="Disable Centralized Persistent Config")
+
+    parser.addoption("--enable-server-tls-skip-verify",
+                     action="store_true",
+                     help="Enable Server tls skip verify config")
+
+    parser.addoption("--disable-tls-server",
+                     action="store_true",
+                     help="Disable tls server")
+
+    parser.addoption("--disable-tls-client",
+                     action="store_true",
+                     help="Disable tls client")
+
+    parser.addoption("--disable-admin-auth",
+                     action="store_true",
+                     help="Disable Admin auth")
 
 
 # This will get called once before the first test that
@@ -185,6 +200,10 @@ def params_from_base_suite_setup(request):
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
+    enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
+    disable_tls_client = request.config.getoption("--disable-tls-client")
+    disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     test_name = request.node.name
     if enable_upgrade_app:
@@ -317,6 +336,34 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without Centralized Persistent Config")
         persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
+
+    if enable_server_tls_skip_verify:
+        log_info("Enable server tls skip verify flag")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', True)
+    else:
+        log_info("Running without server_tls_skip_verify Config")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', False)
+
+    if disable_tls_server:
+        log_info("Disable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', True)
+    else:
+        log_info("Enable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
+
+    if disable_tls_client:
+        log_info("Disabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
+    else:
+        log_info("Enabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
+
+    if disable_admin_auth:
+        log_info("Disabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
+    else:
+        log_info("Enabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', False)
 
     # As cblite jobs run with on Centos platform, adding by default centos to environment config
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)

--- a/testsuites/syncgateway/functional/custom_port/conftest.py
+++ b/testsuites/syncgateway/functional/custom_port/conftest.py
@@ -174,10 +174,6 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="Disable tls server")
 
-    parser.addoption("--disable-tls-client",
-                     action="store_true",
-                     help="Disable tls client")
-
     parser.addoption("--disable-admin-auth",
                      action="store_true",
                      help="Disable Admin auth")
@@ -196,6 +192,7 @@ def params_from_base_suite_setup(request):
     # pytest command line parameters
     server_version = request.config.getoption("--server-version")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
     mode = request.config.getoption("--mode")
     skip_provisioning = request.config.getoption("--skip-provisioning")
     ci = request.config.getoption("--ci")
@@ -222,7 +219,7 @@ def params_from_base_suite_setup(request):
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_tls_server = request.config.getoption("--disable-tls-server")
-    disable_tls_client = request.config.getoption("--disable-tls-client")
+
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
@@ -415,13 +412,6 @@ def params_from_base_suite_setup(request):
         log_info("Enable tls server flag")
         persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
 
-    if disable_tls_client:
-        log_info("Disabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
-    else:
-        log_info("Enabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
-
     if disable_admin_auth:
         log_info("Disabled Admin Auth")
         persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
@@ -479,6 +469,7 @@ def params_from_base_suite_setup(request):
 
     yield {
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "cluster_config": cluster_config,
         "cluster_topology": cluster_topology,
         "mode": mode,
@@ -526,6 +517,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     no_conflicts_enabled = params_from_base_suite_setup["no_conflicts_enabled"]
     cbs_ssl = params_from_base_suite_setup["ssl_enabled"]
     sync_gateway_version = params_from_base_suite_setup["sync_gateway_version"]
+    disable_tls_server = params_from_base_suite_setup["disable_tls_server"]
     sg_platform = params_from_base_suite_setup["sg_platform"]
     delta_sync_enabled = params_from_base_suite_setup["delta_sync_enabled"]
     sg_ce = params_from_base_suite_setup["sg_ce"]
@@ -578,6 +570,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         "xattrs_enabled": xattrs_enabled,
         "no_conflicts_enabled": no_conflicts_enabled,
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "sg_platform": sg_platform,
         "ssl_enabled": cbs_ssl,
         "delta_sync_enabled": delta_sync_enabled,

--- a/testsuites/syncgateway/functional/custom_port/conftest.py
+++ b/testsuites/syncgateway/functional/custom_port/conftest.py
@@ -162,6 +162,11 @@ def pytest_addoption(parser):
                      help="Hides SGW product version when you hit SGW url",
                      default=False)
 
+    parser.addoption("--disable-persistent-config",
+                     action="store_true",
+                     help="Centralized Persistent Config",
+                     default=True)
+
 # This will be called once for the at the beggining of the execution in the 'tests/' directory
 # and will be torn down, (code after the yeild) when all the test session has completed.
 # IMPORTANT: Tests in 'tests/' should be executed in their own test run and should not be
@@ -199,6 +204,7 @@ def params_from_base_suite_setup(request):
     magma_storage_enabled = request.config.getoption("--magma-storage")
     prometheus_enabled = request.config.getoption("--prometheus-enable")
     hide_product_version = request.config.getoption("--hide-product-version")
+    disable_persistent_config = request.config.getoption("--disable-persistent-config")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -227,6 +233,7 @@ def params_from_base_suite_setup(request):
     log_info("number_replicas: {}".format(number_replicas))
     log_info("delta_sync_enabled: {}".format(delta_sync_enabled))
     log_info("hide_product_version: {}".format(hide_product_version))
+    log_info("disable_persistent_config: {}".format(disable_persistent_config))
 
     # sg-ce is invalid for di mode
     if mode == "di" and sg_ce:
@@ -367,6 +374,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without suppress SGW product Version")
         persist_cluster_config_environment_prop(cluster_config, 'hide_product_version', False)
+
+    if disable_persistent_config:
+        log_info(" disable persistent config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', True)
+    else:
+        log_info("Running without Centralized Persistent Config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
 
     sg_config = sync_gateway_config_path_for_mode("sync_gateway_default_functional_tests", mode)
 

--- a/testsuites/syncgateway/functional/custom_port/conftest.py
+++ b/testsuites/syncgateway/functional/custom_port/conftest.py
@@ -164,8 +164,23 @@ def pytest_addoption(parser):
 
     parser.addoption("--disable-persistent-config",
                      action="store_true",
-                     help="Centralized Persistent Config",
-                     default=True)
+                     help="Disable Centralized Persistent Config")
+
+    parser.addoption("--enable-server-tls-skip-verify",
+                     action="store_true",
+                     help="Enable Server tls skip verify config")
+
+    parser.addoption("--disable-tls-server",
+                     action="store_true",
+                     help="Disable tls server")
+
+    parser.addoption("--disable-tls-client",
+                     action="store_true",
+                     help="Disable tls client")
+
+    parser.addoption("--disable-admin-auth",
+                     action="store_true",
+                     help="Disable Admin auth")
 
 # This will be called once for the at the beggining of the execution in the 'tests/' directory
 # and will be torn down, (code after the yeild) when all the test session has completed.
@@ -205,6 +220,10 @@ def params_from_base_suite_setup(request):
     prometheus_enabled = request.config.getoption("--prometheus-enable")
     hide_product_version = request.config.getoption("--hide-product-version")
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
+    enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
+    disable_tls_client = request.config.getoption("--disable-tls-client")
+    disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -381,6 +400,34 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without Centralized Persistent Config")
         persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
+
+    if enable_server_tls_skip_verify:
+        log_info("Enable server tls skip verify flag")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', True)
+    else:
+        log_info("Running without server_tls_skip_verify Config")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', False)
+
+    if disable_tls_server:
+        log_info("Disable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', True)
+    else:
+        log_info("Enable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
+
+    if disable_tls_client:
+        log_info("Disabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
+    else:
+        log_info("Enabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
+
+    if disable_admin_auth:
+        log_info("Disabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
+    else:
+        log_info("Enabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', False)
 
     sg_config = sync_gateway_config_path_for_mode("sync_gateway_default_functional_tests", mode)
 

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -172,8 +172,23 @@ def pytest_addoption(parser):
 
     parser.addoption("--disable-persistent-config",
                      action="store_true",
-                     help="Centralized Persistent Config",
-                     default=True)
+                     help="Disable Centralized Persistent Config")
+
+    parser.addoption("--enable-server-tls-skip-verify",
+                     action="store_true",
+                     help="Enable Server tls skip verify config")
+
+    parser.addoption("--disable-tls-server",
+                     action="store_true",
+                     help="Disable tls server")
+
+    parser.addoption("--disable-tls-client",
+                     action="store_true",
+                     help="Disable tls client")
+
+    parser.addoption("--disable-admin-auth",
+                     action="store_true",
+                     help="Disable Admin auth")
 
 
 # This will be called once for the at the beggining of the execution in the 'tests/' directory
@@ -216,6 +231,10 @@ def params_from_base_suite_setup(request):
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
+    enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
+    disable_tls_client = request.config.getoption("--disable-tls-client")
+    disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -400,6 +419,34 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without Centralized Persistent Config")
         persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
+
+    if enable_server_tls_skip_verify:
+        log_info("Enable server tls skip verify flag")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', True)
+    else:
+        log_info("Running without server_tls_skip_verify Config")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', False)
+
+    if disable_tls_server:
+        log_info("Disable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', True)
+    else:
+        log_info("Enable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
+
+    if disable_tls_client:
+        log_info("Disabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
+    else:
+        log_info("Enabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
+
+    if disable_admin_auth:
+        log_info("Disabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
+    else:
+        log_info("Enabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', False)
 
     sg_config = sync_gateway_config_path_for_mode("sync_gateway_default_functional_tests", mode)
 

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -170,6 +170,11 @@ def pytest_addoption(parser):
                      help="Enabling CBS developer preview",
                      default=False)
 
+    parser.addoption("--disable-persistent-config",
+                     action="store_true",
+                     help="Centralized Persistent Config",
+                     default=True)
+
 
 # This will be called once for the at the beggining of the execution in the 'tests/' directory
 # and will be torn down, (code after the yeild) when all the test session has completed.
@@ -210,6 +215,7 @@ def params_from_base_suite_setup(request):
     hide_product_version = request.config.getoption("--hide-product-version")
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
+    disable_persistent_config = request.config.getoption("--disable-persistent-config")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -239,6 +245,7 @@ def params_from_base_suite_setup(request):
     log_info("delta_sync_enabled: {}".format(delta_sync_enabled))
     log_info("hide_product_version: {}".format(hide_product_version))
     log_info("enable_cbs_developer_preview: {}".format(enable_cbs_developer_preview))
+    log_info("disable_persistent_config: {}".format(disable_persistent_config))
 
     # sg-ce is invalid for di mode
     if mode == "di" and sg_ce:
@@ -386,6 +393,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without CBS developer preview")
         persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
+
+    if disable_persistent_config:
+        log_info(" disable persistent config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', True)
+    else:
+        log_info("Running without Centralized Persistent Config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
 
     sg_config = sync_gateway_config_path_for_mode("sync_gateway_default_functional_tests", mode)
 

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -182,10 +182,6 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="Disable tls server")
 
-    parser.addoption("--disable-tls-client",
-                     action="store_true",
-                     help="Disable tls client")
-
     parser.addoption("--disable-admin-auth",
                      action="store_true",
                      help="Disable Admin auth")
@@ -205,6 +201,7 @@ def params_from_base_suite_setup(request):
     # pytest command line parameters
     server_version = request.config.getoption("--server-version")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
     mode = request.config.getoption("--mode")
     skip_provisioning = request.config.getoption("--skip-provisioning")
     ci = request.config.getoption("--ci")
@@ -232,8 +229,7 @@ def params_from_base_suite_setup(request):
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
-    disable_tls_server = request.config.getoption("--disable-tls-server")
-    disable_tls_client = request.config.getoption("--disable-tls-client")
+
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
@@ -434,13 +430,6 @@ def params_from_base_suite_setup(request):
         log_info("Enable tls server flag")
         persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
 
-    if disable_tls_client:
-        log_info("Disabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
-    else:
-        log_info("Enabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
-
     if disable_admin_auth:
         log_info("Disabled Admin Auth")
         persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
@@ -499,6 +488,7 @@ def params_from_base_suite_setup(request):
 
     yield {
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "cluster_config": cluster_config,
         "cluster_topology": cluster_topology,
         "mode": mode,
@@ -546,6 +536,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     no_conflicts_enabled = params_from_base_suite_setup["no_conflicts_enabled"]
     cbs_ssl = params_from_base_suite_setup["ssl_enabled"]
     sync_gateway_version = params_from_base_suite_setup["sync_gateway_version"]
+    disable_tls_server = params_from_base_suite_setup["disable_tls_server"]
     sg_platform = params_from_base_suite_setup["sg_platform"]
     delta_sync_enabled = params_from_base_suite_setup["delta_sync_enabled"]
     sg_ce = params_from_base_suite_setup["sg_ce"]
@@ -603,6 +594,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         "xattrs_enabled": xattrs_enabled,
         "no_conflicts_enabled": no_conflicts_enabled,
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "sg_platform": sg_platform,
         "ssl_enabled": cbs_ssl,
         "delta_sync_enabled": delta_sync_enabled,

--- a/testsuites/syncgateway/functional/tests/test_attachments.py
+++ b/testsuites/syncgateway/functional/tests/test_attachments.py
@@ -45,7 +45,7 @@ def test_attachment_revpos_when_ancestor_unavailable(params_from_base_test_setup
     no_conflicts_enabled = params_from_base_test_setup["no_conflicts_enabled"]
 
     if no_conflicts_enabled:
-        pytest.skip('--no-conflicts is not enabled, so skipping the test')
+        pytest.skip('--no-conflicts is enabled, so skipping the test')
 
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
 

--- a/testsuites/syncgateway/functional/tests/test_bulk_get_compression.py
+++ b/testsuites/syncgateway/functional/tests/test_bulk_get_compression.py
@@ -186,6 +186,7 @@ def test_bulk_get_compression(params_from_base_test_setup, sg_conf_name, num_doc
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_config = temp_cluster_config
     cluster = Cluster(config=cluster_config)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_bulk_get_compression.py
+++ b/testsuites/syncgateway/functional/tests/test_bulk_get_compression.py
@@ -184,9 +184,9 @@ def test_bulk_get_compression(params_from_base_test_setup, sg_conf_name, num_doc
     log_info("Using x_accept_part_encoding: {}".format(x_accept_part_encoding))
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_bulk_get_compression.py
+++ b/testsuites/syncgateway/functional/tests/test_bulk_get_compression.py
@@ -183,7 +183,10 @@ def test_bulk_get_compression(params_from_base_test_setup, sg_conf_name, num_doc
     log_info("Using accept_encoding: {}".format(accept_encoding))
     log_info("Using x_accept_part_encoding: {}".format(x_accept_part_encoding))
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_changes.py
+++ b/testsuites/syncgateway/functional/tests/test_changes.py
@@ -35,9 +35,9 @@ def test_deleted_docs_from_changes_active_only(params_from_base_test_setup, sg_c
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_changes.py
+++ b/testsuites/syncgateway/functional/tests/test_changes.py
@@ -37,6 +37,7 @@ def test_deleted_docs_from_changes_active_only(params_from_base_test_setup, sg_c
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_config = temp_cluster_config
 
     cluster = Cluster(cluster_config)

--- a/testsuites/syncgateway/functional/tests/test_changes.py
+++ b/testsuites/syncgateway/functional/tests/test_changes.py
@@ -34,7 +34,10 @@ def test_deleted_docs_from_changes_active_only(params_from_base_test_setup, sg_c
     mode = params_from_base_test_setup["mode"]
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_changes_backfill.py
+++ b/testsuites/syncgateway/functional/tests/test_changes_backfill.py
@@ -52,9 +52,9 @@ def test_backfill_channels_oneshot_changes(params_from_base_test_setup, sg_conf_
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_changes_backfill.py
+++ b/testsuites/syncgateway/functional/tests/test_changes_backfill.py
@@ -51,7 +51,10 @@ def test_backfill_channels_oneshot_changes(params_from_base_test_setup, sg_conf_
 
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_changes_backfill.py
+++ b/testsuites/syncgateway/functional/tests/test_changes_backfill.py
@@ -54,6 +54,7 @@ def test_backfill_channels_oneshot_changes(params_from_base_test_setup, sg_conf_
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_config = temp_cluster_config
 
     cluster = Cluster(cluster_config)

--- a/testsuites/syncgateway/functional/tests/test_channels.py
+++ b/testsuites/syncgateway/functional/tests/test_channels.py
@@ -131,7 +131,10 @@ def test_remove_add_channels_to_doc(params_from_base_test_setup, sg_conf_name, x
 
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_channels.py
+++ b/testsuites/syncgateway/functional/tests/test_channels.py
@@ -132,9 +132,9 @@ def test_remove_add_channels_to_doc(params_from_base_test_setup, sg_conf_name, x
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_channels.py
+++ b/testsuites/syncgateway/functional/tests/test_channels.py
@@ -134,6 +134,7 @@ def test_remove_add_channels_to_doc(params_from_base_test_setup, sg_conf_name, x
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_config = temp_cluster_config
 
     cluster = Cluster(cluster_config)

--- a/testsuites/syncgateway/functional/tests/test_conflicts.py
+++ b/testsuites/syncgateway/functional/tests/test_conflicts.py
@@ -214,9 +214,9 @@ def test_winning_conflict_branch_revisions(params_from_base_test_setup, sg_conf_
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth and not cbs_ce_version:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_conflicts.py
+++ b/testsuites/syncgateway/functional/tests/test_conflicts.py
@@ -216,6 +216,7 @@ def test_winning_conflict_branch_revisions(params_from_base_test_setup, sg_conf_
     if x509_cert_auth and not cbs_ce_version:
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_config = temp_cluster_config
 
     c = cluster.Cluster(cluster_config)

--- a/testsuites/syncgateway/functional/tests/test_conflicts.py
+++ b/testsuites/syncgateway/functional/tests/test_conflicts.py
@@ -213,7 +213,10 @@ def test_winning_conflict_branch_revisions(params_from_base_test_setup, sg_conf_
 
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth and not cbs_ce_version:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_continuous.py
+++ b/testsuites/syncgateway/functional/tests/test_continuous.py
@@ -123,6 +123,7 @@ def test_continuous_changes_sanity(params_from_base_test_setup, sg_conf_name, nu
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)

--- a/testsuites/syncgateway/functional/tests/test_continuous.py
+++ b/testsuites/syncgateway/functional/tests/test_continuous.py
@@ -121,9 +121,9 @@ def test_continuous_changes_sanity(params_from_base_test_setup, sg_conf_name, nu
     log_info("num_revisions: {}".format(num_revisions))
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_continuous.py
+++ b/testsuites/syncgateway/functional/tests/test_continuous.py
@@ -120,7 +120,10 @@ def test_continuous_changes_sanity(params_from_base_test_setup, sg_conf_name, nu
     log_info("num_docs: {}".format(num_docs))
     log_info("num_revisions: {}".format(num_revisions))
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_crud.py
+++ b/testsuites/syncgateway/functional/tests/test_crud.py
@@ -99,6 +99,7 @@ def test_document_resurrection(params_from_base_test_setup, sg_conf_name, deleti
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
 
     # Reset cluster

--- a/testsuites/syncgateway/functional/tests/test_crud.py
+++ b/testsuites/syncgateway/functional/tests/test_crud.py
@@ -97,9 +97,9 @@ def test_document_resurrection(params_from_base_test_setup, sg_conf_name, deleti
 
     num_docs_per_client = 10
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_crud.py
+++ b/testsuites/syncgateway/functional/tests/test_crud.py
@@ -96,7 +96,10 @@ def test_document_resurrection(params_from_base_test_setup, sg_conf_name, deleti
     cbs_host = host_for_url(cbs_url)
 
     num_docs_per_client = 10
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline.py
@@ -45,9 +45,9 @@ def test_online_default_rest(params_from_base_test_setup, sg_conf_name, num_docs
     log_info("Using num_docs: {}".format(num_docs))
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline.py
@@ -47,6 +47,7 @@ def test_online_default_rest(params_from_base_test_setup, sg_conf_name, num_docs
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline.py
@@ -44,7 +44,10 @@ def test_online_default_rest(params_from_base_test_setup, sg_conf_name, num_docs
     log_info("Using sg_conf: {}".format(sg_conf))
     log_info("Using num_docs: {}".format(num_docs))
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline_resync.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline_resync.py
@@ -44,9 +44,9 @@ def test_bucket_online_offline_resync_sanity(params_from_base_test_setup, sg_con
     start = time.time()
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, test_mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline_resync.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline_resync.py
@@ -46,6 +46,7 @@ def test_bucket_online_offline_resync_sanity(params_from_base_test_setup, sg_con
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, test_mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline_resync.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline_resync.py
@@ -43,7 +43,10 @@ def test_bucket_online_offline_resync_sanity(params_from_base_test_setup, sg_con
 
     start = time.time()
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, test_mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline_webhooks.py
@@ -43,6 +43,7 @@ def test_db_online_offline_webhooks_offline(params_from_base_test_setup, sg_conf
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline_webhooks.py
@@ -41,9 +41,9 @@ def test_db_online_offline_webhooks_offline(params_from_base_test_setup, sg_conf
     log_info("Using num_revisions: {}".format(num_revisions))
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_db_online_offline_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_db_online_offline_webhooks.py
@@ -40,7 +40,10 @@ def test_db_online_offline_webhooks_offline(params_from_base_test_setup, sg_conf
     log_info("Using num_docs: {}".format(num_docs))
     log_info("Using num_revisions: {}".format(num_revisions))
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_log_redaction.py
+++ b/testsuites/syncgateway/functional/tests/test_log_redaction.py
@@ -65,9 +65,9 @@ def test_log_redaction_config(params_from_base_test_setup, remove_tmp_sg_redacti
                                             property_name_check=False)
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth and not cbs_ce_version:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
 
@@ -133,9 +133,9 @@ def test_sgCollect1(params_from_base_test_setup, remove_tmp_sg_redaction_logs, s
     cbs_ce_version = params_from_base_test_setup["cbs_ce"]
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth and not cbs_ce_version:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
 
@@ -206,9 +206,9 @@ def test_sgCollect_restApi(params_from_base_test_setup, remove_tmp_sg_redaction_
     persist_cluster_config_environment_prop(temp_cluster_config, 'redactlevel', "partial", property_name_check=False)
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth and not cbs_ce_version:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
 
@@ -329,9 +329,9 @@ def test_sgCollectRestApi_errorMessages(params_from_base_test_setup, remove_tmp_
     persist_cluster_config_environment_prop(temp_cluster_config, 'redactlevel', "partial", property_name_check=False)
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth and not cbs_ce_version:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
 

--- a/testsuites/syncgateway/functional/tests/test_log_redaction.py
+++ b/testsuites/syncgateway/functional/tests/test_log_redaction.py
@@ -66,6 +66,7 @@ def test_log_redaction_config(params_from_base_test_setup, remove_tmp_sg_redacti
 
     if x509_cert_auth and not cbs_ce_version:
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
 
     cluster = Cluster(config=temp_cluster_config)
     cluster.reset(sg_config_path=sg_conf)
@@ -130,6 +131,7 @@ def test_sgCollect1(params_from_base_test_setup, remove_tmp_sg_redaction_logs, s
 
     if x509_cert_auth and not cbs_ce_version:
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
 
     cluster = Cluster(config=temp_cluster_config)
     cluster.reset(sg_config_path=sg_conf)
@@ -199,6 +201,7 @@ def test_sgCollect_restApi(params_from_base_test_setup, remove_tmp_sg_redaction_
 
     if x509_cert_auth and not cbs_ce_version:
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
 
     cluster = Cluster(config=temp_cluster_config)
     cluster.reset(sg_config_path=sg_conf)
@@ -318,6 +321,7 @@ def test_sgCollectRestApi_errorMessages(params_from_base_test_setup, remove_tmp_
 
     if x509_cert_auth and not cbs_ce_version:
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
 
     cluster = Cluster(config=temp_cluster_config)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_log_redaction.py
+++ b/testsuites/syncgateway/functional/tests/test_log_redaction.py
@@ -64,7 +64,10 @@ def test_log_redaction_config(params_from_base_test_setup, remove_tmp_sg_redacti
     persist_cluster_config_environment_prop(temp_cluster_config, 'redactlevel', redaction_level,
                                             property_name_check=False)
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth and not cbs_ce_version:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
 
@@ -129,7 +132,10 @@ def test_sgCollect1(params_from_base_test_setup, remove_tmp_sg_redaction_logs, s
     persist_cluster_config_environment_prop(temp_cluster_config, 'redactlevel', "partial", property_name_check=False)
     cbs_ce_version = params_from_base_test_setup["cbs_ce"]
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth and not cbs_ce_version:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
 
@@ -199,7 +205,10 @@ def test_sgCollect_restApi(params_from_base_test_setup, remove_tmp_sg_redaction_
     temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
     persist_cluster_config_environment_prop(temp_cluster_config, 'redactlevel', "partial", property_name_check=False)
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth and not cbs_ce_version:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
 
@@ -319,7 +328,10 @@ def test_sgCollectRestApi_errorMessages(params_from_base_test_setup, remove_tmp_
     temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
     persist_cluster_config_environment_prop(temp_cluster_config, 'redactlevel', "partial", property_name_check=False)
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth and not cbs_ce_version:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
 

--- a/testsuites/syncgateway/functional/tests/test_log_rotation.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation.py
@@ -95,9 +95,9 @@ def test_log_rotation_default_values(params_from_base_test_setup, sg_conf_name, 
     log_info("Using sg_conf: {}".format(sg_conf))
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth and not cbs_ce_version:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_log_rotation.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation.py
@@ -94,7 +94,10 @@ def test_log_rotation_default_values(params_from_base_test_setup, sg_conf_name, 
     log_info("Using cluster_conf: {}".format(cluster_conf))
     log_info("Using sg_conf: {}".format(sg_conf))
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth and not cbs_ce_version:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_log_rotation.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation.py
@@ -97,6 +97,7 @@ def test_log_rotation_default_values(params_from_base_test_setup, sg_conf_name, 
     if x509_cert_auth and not cbs_ce_version:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)

--- a/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
@@ -45,6 +45,7 @@ def test_log_rotation_default_values(params_from_base_test_setup, sg_conf_name, 
     if x509_cert_auth and not cbs_ce_version:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)

--- a/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
@@ -43,9 +43,9 @@ def test_log_rotation_default_values(params_from_base_test_setup, sg_conf_name, 
         pytest.skip("Continuous logging Test NA for SG < 2.1")
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth and not cbs_ce_version:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
+++ b/testsuites/syncgateway/functional/tests/test_log_rotation_new.py
@@ -42,7 +42,10 @@ def test_log_rotation_default_values(params_from_base_test_setup, sg_conf_name, 
     if get_sync_gateway_version(sg_ip)[0] < "2.1":
         pytest.skip("Continuous logging Test NA for SG < 2.1")
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth and not cbs_ce_version:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_longpoll.py
+++ b/testsuites/syncgateway/functional/tests/test_longpoll.py
@@ -125,7 +125,10 @@ def test_longpoll_changes_sanity(params_from_base_test_setup, sg_conf_name, num_
     log_info("num_docs: {}".format(num_docs))
     log_info("num_revisions: {}".format(num_revisions))
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth and not cbs_ce_version:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_longpoll.py
+++ b/testsuites/syncgateway/functional/tests/test_longpoll.py
@@ -128,6 +128,7 @@ def test_longpoll_changes_sanity(params_from_base_test_setup, sg_conf_name, num_
     if x509_cert_auth and not cbs_ce_version:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)

--- a/testsuites/syncgateway/functional/tests/test_longpoll.py
+++ b/testsuites/syncgateway/functional/tests/test_longpoll.py
@@ -126,9 +126,9 @@ def test_longpoll_changes_sanity(params_from_base_test_setup, sg_conf_name, num_
     log_info("num_revisions: {}".format(num_revisions))
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth and not cbs_ce_version:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_multiple_dbs.py
+++ b/testsuites/syncgateway/functional/tests/test_multiple_dbs.py
@@ -94,6 +94,7 @@ def test_multiple_db_single_data_bucket_single_index_bucket(params_from_base_tes
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
 
     # 2 dbs share the same data and index bucket

--- a/testsuites/syncgateway/functional/tests/test_multiple_dbs.py
+++ b/testsuites/syncgateway/functional/tests/test_multiple_dbs.py
@@ -92,9 +92,9 @@ def test_multiple_db_single_data_bucket_single_index_bucket(params_from_base_tes
     log_info("Using num_docs_per_user: {}".format(num_docs_per_user))
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_multiple_dbs.py
+++ b/testsuites/syncgateway/functional/tests/test_multiple_dbs.py
@@ -91,7 +91,10 @@ def test_multiple_db_single_data_bucket_single_index_bucket(params_from_base_tes
     log_info("Using num_users: {}".format(num_users))
     log_info("Using num_docs_per_user: {}".format(num_docs_per_user))
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_multiple_users_multiple_channels_multiple_revisions.py
+++ b/testsuites/syncgateway/functional/tests/test_multiple_users_multiple_channels_multiple_revisions.py
@@ -55,7 +55,10 @@ def test_mulitple_users_mulitiple_channels_mulitple_revisions(params_from_base_t
 
     start = time.time()
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_multiple_users_multiple_channels_multiple_revisions.py
+++ b/testsuites/syncgateway/functional/tests/test_multiple_users_multiple_channels_multiple_revisions.py
@@ -58,6 +58,7 @@ def test_mulitple_users_mulitiple_channels_mulitple_revisions(params_from_base_t
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)

--- a/testsuites/syncgateway/functional/tests/test_multiple_users_multiple_channels_multiple_revisions.py
+++ b/testsuites/syncgateway/functional/tests/test_multiple_users_multiple_channels_multiple_revisions.py
@@ -56,9 +56,9 @@ def test_mulitple_users_mulitiple_channels_mulitple_revisions(params_from_base_t
     start = time.time()
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
+++ b/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
@@ -61,9 +61,9 @@ def test_overloaded_channel_cache(params_from_base_test_setup, sg_conf_name, num
     log_info("Using limit: {}".format(limit))
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth and not cbs_ce_version:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
+++ b/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
@@ -60,7 +60,10 @@ def test_overloaded_channel_cache(params_from_base_test_setup, sg_conf_name, num
     log_info("Using filter: {}".format(filter))
     log_info("Using limit: {}".format(limit))
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth and not cbs_ce_version:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
+++ b/testsuites/syncgateway/functional/tests/test_overloaded_channel_cache.py
@@ -63,6 +63,7 @@ def test_overloaded_channel_cache(params_from_base_test_setup, sg_conf_name, num
     if x509_cert_auth and not cbs_ce_version:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)

--- a/testsuites/syncgateway/functional/tests/test_resync.py
+++ b/testsuites/syncgateway/functional/tests/test_resync.py
@@ -43,9 +43,9 @@ def test_resync(params_from_base_test_setup, sg_conf_name, x509_cert_auth):
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_resync.py
+++ b/testsuites/syncgateway/functional/tests/test_resync.py
@@ -42,7 +42,10 @@ def test_resync(params_from_base_test_setup, sg_conf_name, x509_cert_auth):
     mode = params_from_base_test_setup["mode"]
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_resync.py
+++ b/testsuites/syncgateway/functional/tests/test_resync.py
@@ -45,6 +45,7 @@ def test_resync(params_from_base_test_setup, sg_conf_name, x509_cert_auth):
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_config = temp_cluster_config
 
     cluster = Cluster(cluster_config)

--- a/testsuites/syncgateway/functional/tests/test_roles.py
+++ b/testsuites/syncgateway/functional/tests/test_roles.py
@@ -43,9 +43,9 @@ def test_roles_sanity(params_from_base_test_setup, sg_conf_name, x509_cert_auth)
     log_info("sg_conf: {}".format(sg_conf))
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_roles.py
+++ b/testsuites/syncgateway/functional/tests/test_roles.py
@@ -42,7 +42,10 @@ def test_roles_sanity(params_from_base_test_setup, sg_conf_name, x509_cert_auth)
     log_info("cluster_conf: {}".format(cluster_conf))
     log_info("sg_conf: {}".format(sg_conf))
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_roles.py
+++ b/testsuites/syncgateway/functional/tests/test_roles.py
@@ -45,6 +45,7 @@ def test_roles_sanity(params_from_base_test_setup, sg_conf_name, x509_cert_auth)
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)

--- a/testsuites/syncgateway/functional/tests/test_rollback.py
+++ b/testsuites/syncgateway/functional/tests/test_rollback.py
@@ -58,7 +58,10 @@ def test_rollback_server_reset(params_from_base_test_setup, sg_conf_name, x509_c
         pytest.skip("Rollback not supported in channel cache mode")
 
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_rollback.py
+++ b/testsuites/syncgateway/functional/tests/test_rollback.py
@@ -61,6 +61,7 @@ def test_rollback_server_reset(params_from_base_test_setup, sg_conf_name, x509_c
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_config = temp_cluster_config
     cluster = Cluster(cluster_config)
     cluster.reset(sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_rollback.py
+++ b/testsuites/syncgateway/functional/tests/test_rollback.py
@@ -59,9 +59,9 @@ def test_rollback_server_reset(params_from_base_test_setup, sg_conf_name, x509_c
 
     sg_conf = sync_gateway_config_path_for_mode(sg_conf_name, mode)
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_seq.py
+++ b/testsuites/syncgateway/functional/tests/test_seq.py
@@ -49,6 +49,7 @@ def test_seq(params_from_base_test_setup, sg_conf_name, num_users, num_docs, num
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
 
     cluster = Cluster(config=cluster_conf)

--- a/testsuites/syncgateway/functional/tests/test_seq.py
+++ b/testsuites/syncgateway/functional/tests/test_seq.py
@@ -47,9 +47,9 @@ def test_seq(params_from_base_test_setup, sg_conf_name, num_users, num_docs, num
     log_info("num_revisions: {}".format(num_revisions))
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_seq.py
+++ b/testsuites/syncgateway/functional/tests/test_seq.py
@@ -46,7 +46,10 @@ def test_seq(params_from_base_test_setup, sg_conf_name, num_users, num_docs, num
     log_info("num_docs: {}".format(num_docs))
     log_info("num_revisions: {}".format(num_revisions))
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_single_user_single_channel_doc_updates.py
+++ b/testsuites/syncgateway/functional/tests/test_single_user_single_channel_doc_updates.py
@@ -53,7 +53,10 @@ def test_single_user_single_channel_doc_updates(params_from_base_test_setup, sg_
     log.info("num_revisions: {}".format(num_revisions))
 
     start = time.time()
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_single_user_single_channel_doc_updates.py
+++ b/testsuites/syncgateway/functional/tests/test_single_user_single_channel_doc_updates.py
@@ -54,9 +54,9 @@ def test_single_user_single_channel_doc_updates(params_from_base_test_setup, sg_
 
     start = time.time()
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_single_user_single_channel_doc_updates.py
+++ b/testsuites/syncgateway/functional/tests/test_single_user_single_channel_doc_updates.py
@@ -56,6 +56,7 @@ def test_single_user_single_channel_doc_updates(params_from_base_test_setup, sg_
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_sync.py
+++ b/testsuites/syncgateway/functional/tests/test_sync.py
@@ -121,9 +121,9 @@ def test_sync_access_sanity(params_from_base_test_setup, sg_conf_name, x509_cert
     log_info("Using cluster_conf: {}".format(cluster_conf))
     log_info("Using sg_conf: {}".format(sg_conf))
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth and not cbs_ce_version:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_sync.py
+++ b/testsuites/syncgateway/functional/tests/test_sync.py
@@ -123,6 +123,7 @@ def test_sync_access_sanity(params_from_base_test_setup, sg_conf_name, x509_cert
     if x509_cert_auth and not cbs_ce_version:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_sync.py
+++ b/testsuites/syncgateway/functional/tests/test_sync.py
@@ -120,7 +120,10 @@ def test_sync_access_sanity(params_from_base_test_setup, sg_conf_name, x509_cert
     log_info("Running 'sync_access_sanity'")
     log_info("Using cluster_conf: {}".format(cluster_conf))
     log_info("Using sg_conf: {}".format(sg_conf))
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth and not cbs_ce_version:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_user_views.py
+++ b/testsuites/syncgateway/functional/tests/test_user_views.py
@@ -34,9 +34,9 @@ def test_user_views_sanity(params_from_base_test_setup, sg_conf_name, x509_cert_
     log_info("cluster_conf: {}".format(cluster_conf))
     log_info("conf: {}".format(sg_conf))
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_user_views.py
+++ b/testsuites/syncgateway/functional/tests/test_user_views.py
@@ -33,7 +33,10 @@ def test_user_views_sanity(params_from_base_test_setup, sg_conf_name, x509_cert_
     log_info("Running 'single_user_multiple_channels'")
     log_info("cluster_conf: {}".format(cluster_conf))
     log_info("conf: {}".format(sg_conf))
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_user_views.py
+++ b/testsuites/syncgateway/functional/tests/test_user_views.py
@@ -36,6 +36,7 @@ def test_user_views_sanity(params_from_base_test_setup, sg_conf_name, x509_cert_
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_users_channels.py
+++ b/testsuites/syncgateway/functional/tests/test_users_channels.py
@@ -47,6 +47,7 @@ def test_multiple_users_multiple_channels(params_from_base_test_setup, sg_conf_n
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_users_channels.py
+++ b/testsuites/syncgateway/functional/tests/test_users_channels.py
@@ -44,7 +44,10 @@ def test_multiple_users_multiple_channels(params_from_base_test_setup, sg_conf_n
     log_info("Running 'multiple_users_multiple_channels'")
     log_info("cluster_conf: {}".format(cluster_conf))
     log_info("conf: {}".format(sg_conf))
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_users_channels.py
+++ b/testsuites/syncgateway/functional/tests/test_users_channels.py
@@ -45,9 +45,9 @@ def test_multiple_users_multiple_channels(params_from_base_test_setup, sg_conf_n
     log_info("cluster_conf: {}".format(cluster_conf))
     log_info("conf: {}".format(sg_conf))
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_views.py
+++ b/testsuites/syncgateway/functional/tests/test_views.py
@@ -57,9 +57,9 @@ def test_view_backfill_for_deletes(params_from_base_test_setup, sg_conf_name,
     log_info('cbs_url: {}'.format(cbs_url))
     log_info('validate_changes_before_restart: {}'.format(validate_changes_before_restart))
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_views.py
+++ b/testsuites/syncgateway/functional/tests/test_views.py
@@ -59,6 +59,7 @@ def test_view_backfill_for_deletes(params_from_base_test_setup, sg_conf_name,
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_views.py
+++ b/testsuites/syncgateway/functional/tests/test_views.py
@@ -56,7 +56,10 @@ def test_view_backfill_for_deletes(params_from_base_test_setup, sg_conf_name,
     log_info('sg_url: {}'.format(sg_url))
     log_info('cbs_url: {}'.format(cbs_url))
     log_info('validate_changes_before_restart: {}'.format(validate_changes_before_restart))
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_webhooks.py
@@ -51,9 +51,9 @@ def test_webhooks(params_from_base_test_setup, sg_conf_name, num_users, num_chan
     log_info("Using num_docs: {}".format(num_docs))
     log_info("Using num_revisions: {}".format(num_revisions))
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth and not cbs_ce_version:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_webhooks.py
@@ -53,6 +53,7 @@ def test_webhooks(params_from_base_test_setup, sg_conf_name, num_users, num_chan
     if x509_cert_auth and not cbs_ce_version:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_webhooks.py
+++ b/testsuites/syncgateway/functional/tests/test_webhooks.py
@@ -50,7 +50,10 @@ def test_webhooks(params_from_base_test_setup, sg_conf_name, num_users, num_chan
     log_info("Using num_channels: {}".format(num_channels))
     log_info("Using num_docs: {}".format(num_docs))
     log_info("Using num_revisions: {}".format(num_revisions))
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth and not cbs_ce_version:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_xattrs.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs.py
@@ -355,6 +355,7 @@ def test_on_demand_import_of_external_updates(params_from_base_test_setup, sg_co
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)
@@ -753,6 +754,7 @@ def test_purge(params_from_base_test_setup, sg_conf_name, use_multiple_channels,
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_xattrs.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs.py
@@ -352,7 +352,10 @@ def test_on_demand_import_of_external_updates(params_from_base_test_setup, sg_co
     log_info('sg_admin_url: {}'.format(sg_admin_url))
     log_info('sg_url: {}'.format(sg_url))
     log_info('cbs_url: {}'.format(cbs_url))
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
@@ -752,7 +755,10 @@ def test_purge(params_from_base_test_setup, sg_conf_name, use_multiple_channels,
     log_info('sg_conf: {}'.format(sg_conf))
     log_info('sg_admin_url: {}'.format(sg_admin_url))
     log_info('sg_url: {}'.format(sg_url))
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_xattrs.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs.py
@@ -478,7 +478,10 @@ def test_offline_processing_of_external_updates(params_from_base_test_setup, sg_
     log_info('sg_admin_url: {}'.format(sg_admin_url))
     log_info('sg_url: {}'.format(sg_url))
     log_info('cbs_url: {}'.format(cbs_url))
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth and not cbs_ce_version:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_xattrs.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs.py
@@ -478,6 +478,7 @@ def test_offline_processing_of_external_updates(params_from_base_test_setup, sg_
     if x509_cert_auth and not cbs_ce_version:
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_conf = temp_cluster_config
     cluster = Cluster(config=cluster_conf)
     cluster.reset(sg_config_path=sg_conf)

--- a/testsuites/syncgateway/functional/tests/test_xattrs.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs.py
@@ -353,9 +353,9 @@ def test_on_demand_import_of_external_updates(params_from_base_test_setup, sg_co
     log_info('sg_url: {}'.format(sg_url))
     log_info('cbs_url: {}'.format(cbs_url))
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
@@ -479,9 +479,9 @@ def test_offline_processing_of_external_updates(params_from_base_test_setup, sg_
     log_info('sg_url: {}'.format(sg_url))
     log_info('cbs_url: {}'.format(cbs_url))
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth and not cbs_ce_version:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
@@ -759,9 +759,9 @@ def test_purge(params_from_base_test_setup, sg_conf_name, use_multiple_channels,
     log_info('sg_admin_url: {}'.format(sg_admin_url))
     log_info('sg_url: {}'.format(sg_url))
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_conf, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_xattrs_grants.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs_grants.py
@@ -57,7 +57,10 @@ def test_automatic_and_ondemand_imports(params_from_base_test_setup, x509_cert_a
 
     sg_client = MobileRestClient()
 
+    disable_tls_server = params_from_base_test_setup["disable_tls_server"]
     if x509_cert_auth:
+        if disable_tls_server:
+            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_xattrs_grants.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs_grants.py
@@ -58,9 +58,9 @@ def test_automatic_and_ondemand_imports(params_from_base_test_setup, x509_cert_a
     sg_client = MobileRestClient()
 
     disable_tls_server = params_from_base_test_setup["disable_tls_server"]
+    if x509_cert_auth and disable_tls_server:
+        pytest.skip("x509 test cannot run tls server disabled")
     if x509_cert_auth:
-        if disable_tls_server:
-            pytest.skip("x509 test cannot run tls server disabled")
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
         persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)

--- a/testsuites/syncgateway/functional/tests/test_xattrs_grants.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs_grants.py
@@ -60,6 +60,7 @@ def test_automatic_and_ondemand_imports(params_from_base_test_setup, x509_cert_a
     if x509_cert_auth:
         temp_cluster_config = copy_to_temp_conf(cluster_config, mode)
         persist_cluster_config_environment_prop(temp_cluster_config, 'x509_certs', True)
+        persist_cluster_config_environment_prop(temp_cluster_config, 'server_tls_skip_verify', False)
         cluster_config = temp_cluster_config
 
     # 1. Set xattr key in config

--- a/testsuites/syncgateway/functional/topology_specific_tests/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/conftest.py
@@ -123,10 +123,6 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="Disable tls server")
 
-    parser.addoption("--disable-tls-client",
-                     action="store_true",
-                     help="Disable tls client")
-
     parser.addoption("--disable-admin-auth",
                      action="store_true",
                      help="Disable Admin auth")

--- a/testsuites/syncgateway/functional/topology_specific_tests/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/conftest.py
@@ -113,5 +113,20 @@ def pytest_addoption(parser):
 
     parser.addoption("--disable-persistent-config",
                      action="store_true",
-                     help="Centralized Persistent Config",
-                     default=True)
+                     help="Disable Centralized Persistent Config")
+
+    parser.addoption("--enable-server-tls-skip-verify",
+                     action="store_true",
+                     help="Enable Server tls skip verify config")
+
+    parser.addoption("--disable-tls-server",
+                     action="store_true",
+                     help="Disable tls server")
+
+    parser.addoption("--disable-tls-client",
+                     action="store_true",
+                     help="Disable tls client")
+
+    parser.addoption("--disable-admin-auth",
+                     action="store_true",
+                     help="Disable Admin auth")

--- a/testsuites/syncgateway/functional/topology_specific_tests/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/conftest.py
@@ -110,3 +110,8 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="Enabling CBS developer preview",
                      default=False)
+
+    parser.addoption("--disable-persistent-config",
+                     action="store_true",
+                     help="Centralized Persistent Config",
+                     default=True)

--- a/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
@@ -22,6 +22,7 @@ def params_from_base_suite_setup(request):
     # pytest command line parameters
     server_version = request.config.getoption("--server-version")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
     mode = request.config.getoption("--mode")
     skip_provisioning = request.config.getoption("--skip-provisioning")
     race_enabled = request.config.getoption("--race")
@@ -50,7 +51,7 @@ def params_from_base_suite_setup(request):
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_tls_server = request.config.getoption("--disable-tls-server")
-    disable_tls_client = request.config.getoption("--disable-tls-client")
+
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
@@ -239,13 +240,6 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Enable tls server flag")
         persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
-
-    if disable_tls_client:
-        log_info("Disabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
-    else:
-        log_info("Enabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
 
     if disable_admin_auth:
         log_info("Disabled Admin Auth")

--- a/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
@@ -47,6 +47,7 @@ def params_from_base_suite_setup(request):
     prometheus_enabled = request.config.getoption("--prometheus-enable")
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
+    disable_persistent_config = request.config.getoption("--disable-persistent-config")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -75,6 +76,7 @@ def params_from_base_suite_setup(request):
     log_info("Delta_sync: {}".format(delta_sync_enabled))
     log_info("prometheus_enabled: {}".format(prometheus_enabled))
     log_info("enable_cbs_developer_preview: {}".format(enable_cbs_developer_preview))
+    log_info("disable_persistent_config: {}".format(disable_persistent_config))
 
     # sg-ce is invalid for di mode
     if mode == "di" and sg_ce:
@@ -212,6 +214,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without CBS developer preview")
         persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
+
+    if disable_persistent_config:
+        log_info(" disable persistent config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', True)
+    else:
+        log_info("Running without Centralized Persistent Config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
 
     if sync_gateway_version < "2.0.0" and no_conflicts_enabled:
         pytest.skip("Test cannot run with no-conflicts with sg version < 2.0.0")

--- a/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
@@ -48,6 +48,10 @@ def params_from_base_suite_setup(request):
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
+    enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
+    disable_tls_client = request.config.getoption("--disable-tls-client")
+    disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -221,6 +225,34 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without Centralized Persistent Config")
         persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
+
+    if enable_server_tls_skip_verify:
+        log_info("Enable server tls skip verify flag")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', True)
+    else:
+        log_info("Running without server_tls_skip_verify Config")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', False)
+
+    if disable_tls_server:
+        log_info("Disable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', True)
+    else:
+        log_info("Enable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
+
+    if disable_tls_client:
+        log_info("Disabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
+    else:
+        log_info("Enabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
+
+    if disable_admin_auth:
+        log_info("Disabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
+    else:
+        log_info("Enabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', False)
 
     if sync_gateway_version < "2.0.0" and no_conflicts_enabled:
         pytest.skip("Test cannot run with no-conflicts with sg version < 2.0.0")

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
@@ -25,6 +25,7 @@ def params_from_base_suite_setup(request):
     # pytest command line parameters
     server_version = request.config.getoption("--server-version")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
     mode = request.config.getoption("--mode")
     skip_provisioning = request.config.getoption("--skip-provisioning")
     race_enabled = request.config.getoption("--race")
@@ -53,7 +54,7 @@ def params_from_base_suite_setup(request):
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_tls_server = request.config.getoption("--disable-tls-server")
-    disable_tls_client = request.config.getoption("--disable-tls-client")
+
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
@@ -233,13 +234,6 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Enable tls server flag")
         persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
-
-    if disable_tls_client:
-        log_info("Disabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
-    else:
-        log_info("Enabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
 
     if disable_admin_auth:
         log_info("Disabled Admin Auth")

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
@@ -50,6 +50,7 @@ def params_from_base_suite_setup(request):
     prometheus_enabled = request.config.getoption("--prometheus-enable")
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
+    disable_persistent_config = request.config.getoption("--disable-persistent-config")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -79,6 +80,7 @@ def params_from_base_suite_setup(request):
     log_info("hide_product_version: {}".format(hide_product_version))
     log_info("prometheus_enabled: {}".format(prometheus_enabled))
     log_info("enable_cbs_developer_preview: {}".format(enable_cbs_developer_preview))
+    log_info("disable_persistent_config: {}".format(disable_persistent_config))
 
     # sg-ce is invalid for di mode
     if mode == "di" and sg_ce:
@@ -206,6 +208,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without CBS developer preview")
         persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
+
+    if disable_persistent_config:
+        log_info(" disable persistent config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', True)
+    else:
+        log_info("Running without Centralized Persistent Config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
 
     if sync_gateway_version < "2.0.0" and no_conflicts_enabled:
         pytest.skip("Test cannot run with no-conflicts with sg version < 2.0.0")

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
@@ -51,6 +51,10 @@ def params_from_base_suite_setup(request):
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
+    enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
+    disable_tls_client = request.config.getoption("--disable-tls-client")
+    disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -215,6 +219,34 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without Centralized Persistent Config")
         persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
+
+    if enable_server_tls_skip_verify:
+        log_info("Enable server tls skip verify flag")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', True)
+    else:
+        log_info("Running without server_tls_skip_verify Config")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', False)
+
+    if disable_tls_server:
+        log_info("Disable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', True)
+    else:
+        log_info("Enable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
+
+    if disable_tls_client:
+        log_info("Disabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
+    else:
+        log_info("Enabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
+
+    if disable_admin_auth:
+        log_info("Disabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
+    else:
+        log_info("Enabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', False)
 
     if sync_gateway_version < "2.0.0" and no_conflicts_enabled:
         pytest.skip("Test cannot run with no-conflicts with sg version < 2.0.0")

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -48,6 +48,7 @@ def params_from_base_suite_setup(request):
     hide_product_version = request.config.getoption("--hide-product-version")
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
+    disable_persistent_config = request.config.getoption("--disable-persistent-config")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -75,6 +76,7 @@ def params_from_base_suite_setup(request):
     log_info("prometheus_enabled: {}".format(prometheus_enabled))
     log_info("hide_product_version: {}".format(hide_product_version))
     log_info("enable_cbs_developer_preview: {}".format(enable_cbs_developer_preview))
+    log_info("disable_persistent_config: {}".format(disable_persistent_config))
 
     # sg-ce is invalid for di mode
     if mode == "di" and sg_ce:
@@ -203,6 +205,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without CBS developer preview")
         persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
+
+    if disable_persistent_config:
+        log_info(" disable persistent config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', True)
+    else:
+        log_info("Running without Centralized Persistent Config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
 
     if sync_gateway_version < "2.0.0" and no_conflicts_enabled:
         pytest.skip("Test cannot run with no-conflicts with sg version < 2.0.0")

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -49,6 +49,10 @@ def params_from_base_suite_setup(request):
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
+    enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
+    disable_tls_client = request.config.getoption("--disable-tls-client")
+    disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -212,6 +216,34 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without Centralized Persistent Config")
         persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
+
+    if enable_server_tls_skip_verify:
+        log_info("Enable server tls skip verify flag")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', True)
+    else:
+        log_info("Running without server_tls_skip_verify Config")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', False)
+
+    if disable_tls_server:
+        log_info("Disable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', True)
+    else:
+        log_info("Enable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
+
+    if disable_tls_client:
+        log_info("Disabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
+    else:
+        log_info("Enabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
+
+    if disable_admin_auth:
+        log_info("Disabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
+    else:
+        log_info("Enabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', False)
 
     if sync_gateway_version < "2.0.0" and no_conflicts_enabled:
         pytest.skip("Test cannot run with no-conflicts with sg version < 2.0.0")

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -25,6 +25,7 @@ def params_from_base_suite_setup(request):
     # pytest command line parameters
     server_version = request.config.getoption("--server-version")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
     mode = request.config.getoption("--mode")
     skip_provisioning = request.config.getoption("--skip-provisioning")
     race_enabled = request.config.getoption("--race")
@@ -51,7 +52,7 @@ def params_from_base_suite_setup(request):
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_tls_server = request.config.getoption("--disable-tls-server")
-    disable_tls_client = request.config.getoption("--disable-tls-client")
+
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
@@ -231,13 +232,6 @@ def params_from_base_suite_setup(request):
         log_info("Enable tls server flag")
         persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
 
-    if disable_tls_client:
-        log_info("Disabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
-    else:
-        log_info("Enabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
-
     if disable_admin_auth:
         log_info("Disabled Admin Auth")
         persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
@@ -295,6 +289,7 @@ def params_from_base_suite_setup(request):
            "xattrs_enabled": xattrs_enabled,
            "sg_platform": sg_platform,
            "sync_gateway_version": sync_gateway_version,
+           "disable_tls_server": disable_tls_server,
            "sg_ce": sg_ce,
            "prometheus_enabled": prometheus_enabled,
            "sg_ssl": sg_ssl
@@ -326,6 +321,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     xattrs_enabled = params_from_base_suite_setup["xattrs_enabled"]
     sg_platform = params_from_base_suite_setup["sg_platform"]
     sync_gateway_version = params_from_base_suite_setup["sync_gateway_version"]
+    disable_tls_server = params_from_base_suite_setup["disable_tls_server"]
     sg_ce = params_from_base_suite_setup["sg_ce"]
     prometheus_enabled = params_from_base_suite_setup["prometheus_enabled"]
     sg_ssl = params_from_base_suite_setup["sg_ssl"]
@@ -339,6 +335,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
            "xattrs_enabled": xattrs_enabled,
            "sg_platform": sg_platform,
            "sync_gateway_version": sync_gateway_version,
+           "disable_tls_server": disable_tls_server,
            "sg_ce": sg_ce,
            "prometheus_enabled": prometheus_enabled,
            "sg_ssl": sg_ssl

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_sg_replicate.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_sg_replicate.py
@@ -45,6 +45,8 @@ def test_sg_replicate_basic_test(params_from_base_test_setup):
     sg_ssl = params_from_base_test_setup["sg_ssl"]
     sg_platform = params_from_base_test_setup["sg_platform"]
 
+    if sync_gateway_version >= "3.0.0":
+        pytest.skip('sg-replicate 1  does not support 3.0.0 and above')
     log_info("Running 'test_sg_replicate_basic_test'")
     log_info("Using cluster_config: {}".format(cluster_config))
 
@@ -191,7 +193,11 @@ def test_sg_replicate_basic_test(params_from_base_test_setup):
 def test_sg_replicate_basic_test_channels(params_from_base_test_setup):
 
     cluster_config = params_from_base_test_setup["cluster_config"]
+    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
     mode = params_from_base_test_setup["mode"]
+
+    if sync_gateway_version >= "3.0.0":
+        pytest.skip('sg-replicate 1  does not support 3.0.0 and above')
 
     log_info("Running 'test_sg_replicate_basic_test_channels'")
     log_info("Using cluster_config: {}".format(cluster_config))
@@ -247,6 +253,10 @@ def test_sg_replicate_continuous_replication(params_from_base_test_setup):
 
     cluster_config = params_from_base_test_setup["cluster_config"]
     mode = params_from_base_test_setup["mode"]
+    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
+
+    if sync_gateway_version >= "3.0.0":
+        pytest.skip('sg-replicate 1  does not support 3.0.0 and above')
 
     log_info("Running 'test_sg_replicate_continuous_replication'")
     log_info("Using cluster_config: {}".format(cluster_config))
@@ -358,6 +368,10 @@ def test_sg_replicate_non_existent_db(params_from_base_test_setup):
 
     cluster_config = params_from_base_test_setup["cluster_config"]
     mode = params_from_base_test_setup["mode"]
+    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
+
+    if sync_gateway_version >= "3.0.0":
+        pytest.skip('sg-replicate 1  does not support 3.0.0 and above')
 
     log_info("Running 'test_sg_replicate_non_existent_db'")
     log_info("Using cluster_config: {}".format(cluster_config))
@@ -410,6 +424,10 @@ def test_sg_replicate_push_async(params_from_base_test_setup, num_docs):
 
     cluster_config = params_from_base_test_setup["cluster_config"]
     mode = params_from_base_test_setup["mode"]
+    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
+
+    if sync_gateway_version >= "3.0.0":
+        pytest.skip('sg-replicate 1  does not support 3.0.0 and above')
 
     log_info("Running 'test_sg_replicate_push_async'")
     log_info("Using cluster_config: {}".format(cluster_config))
@@ -466,6 +484,10 @@ def test_stop_replication_via_replication_id(params_from_base_test_setup):
 
     cluster_config = params_from_base_test_setup["cluster_config"]
     mode = params_from_base_test_setup["mode"]
+    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
+
+    if sync_gateway_version >= "3.0.0":
+        pytest.skip('sg-replicate 1  does not support 3.0.0 and above')
 
     log_info("Running 'test_stop_replication_via_replication_id'")
     log_info("Using cluster_config: {}".format(cluster_config))
@@ -513,6 +535,10 @@ def test_replication_config(params_from_base_test_setup):
 
     cluster_config = params_from_base_test_setup["cluster_config"]
     mode = params_from_base_test_setup["mode"]
+    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
+
+    if sync_gateway_version >= "3.0.0":
+        pytest.skip('sg-replicate 1  does not support 3.0.0 and above')
 
     log_info("Running 'test_replication_config'")
     log_info("Using cluster_config: {}".format(cluster_config))
@@ -549,6 +575,10 @@ def test_sdk_update_with_changes_request(params_from_base_test_setup):
     cluster_config = params_from_base_test_setup["cluster_config"]
     mode = params_from_base_test_setup["mode"]
     xattrs_enabled = params_from_base_test_setup["xattrs_enabled"]
+    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
+
+    if sync_gateway_version >= "3.0.0":
+        pytest.skip('sg-replicate 1  does not support 3.0.0 and above')
 
     channel = ['ABC']
     bucket_name = 'data-bucket-1'

--- a/testsuites/syncgateway/system/conftest.py
+++ b/testsuites/syncgateway/system/conftest.py
@@ -126,8 +126,23 @@ def pytest_addoption(parser):
 
     parser.addoption("--disable-persistent-config",
                      action="store_true",
-                     help="Centralized Persistent Config",
-                     default=True)
+                     help="Disable Centralized Persistent Config")
+
+    parser.addoption("--enable-server-tls-skip-verify",
+                     action="store_true",
+                     help="Enable Server tls skip verify config")
+
+    parser.addoption("--disable-tls-server",
+                     action="store_true",
+                     help="Disable tls server")
+
+    parser.addoption("--disable-tls-client",
+                     action="store_true",
+                     help="Disable tls client")
+
+    parser.addoption("--disable-admin-auth",
+                     action="store_true",
+                     help="Disable Admin auth")
 
 
 # This will be called once for the at the beggining of the execution in the 'tests/' directory
@@ -167,6 +182,10 @@ def params_from_base_suite_setup(request):
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
+    enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
+    disable_tls_client = request.config.getoption("--disable-tls-client")
+    disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -267,6 +286,34 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without Centralized Persistent Config")
         persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
+
+    if enable_server_tls_skip_verify:
+        log_info("Enable server tls skip verify flag")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', True)
+    else:
+        log_info("Running without server_tls_skip_verify Config")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', False)
+
+    if disable_tls_server:
+        log_info("Disable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', True)
+    else:
+        log_info("Enable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
+
+    if disable_tls_client:
+        log_info("Disabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
+    else:
+        log_info("Enabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
+
+    if disable_admin_auth:
+        log_info("Disabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
+    else:
+        log_info("Enabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', False)
 
     sg_config = sync_gateway_config_path_for_mode("sync_gateway_default_functional_tests", mode)
 

--- a/testsuites/syncgateway/system/conftest.py
+++ b/testsuites/syncgateway/system/conftest.py
@@ -136,10 +136,6 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="Disable tls server")
 
-    parser.addoption("--disable-tls-client",
-                     action="store_true",
-                     help="Disable tls client")
-
     parser.addoption("--disable-admin-auth",
                      action="store_true",
                      help="Disable Admin auth")
@@ -159,6 +155,7 @@ def params_from_base_suite_setup(request):
     # pytest command line parameters
     server_version = request.config.getoption("--server-version")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
     mode = request.config.getoption("--mode")
     use_sequoia = request.config.getoption("--sequoia")
     skip_provisioning = request.config.getoption("--skip-provisioning")
@@ -184,7 +181,7 @@ def params_from_base_suite_setup(request):
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_tls_server = request.config.getoption("--disable-tls-server")
-    disable_tls_client = request.config.getoption("--disable-tls-client")
+
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
@@ -300,13 +297,6 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Enable tls server flag")
         persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
-
-    if disable_tls_client:
-        log_info("Disabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
-    else:
-        log_info("Enabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
 
     if disable_admin_auth:
         log_info("Disabled Admin Auth")

--- a/testsuites/syncgateway/system/conftest.py
+++ b/testsuites/syncgateway/system/conftest.py
@@ -124,6 +124,11 @@ def pytest_addoption(parser):
                      help="Enabling CBS developer preview",
                      default=False)
 
+    parser.addoption("--disable-persistent-config",
+                     action="store_true",
+                     help="Centralized Persistent Config",
+                     default=True)
+
 
 # This will be called once for the at the beggining of the execution in the 'tests/' directory
 # and will be torn down, (code after the yeild) when all the test session has completed.
@@ -161,6 +166,7 @@ def params_from_base_suite_setup(request):
     hide_product_version = request.config.getoption("--hide-product-version")
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
+    disable_persistent_config = request.config.getoption("--disable-persistent-config")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)
@@ -176,6 +182,7 @@ def params_from_base_suite_setup(request):
     log_info("number_replicas: {}".format(number_replicas))
     log_info("hide_product_version: {}".format(hide_product_version))
     log_info("enable_cbs_developer_preview: {}".format(enable_cbs_developer_preview))
+    log_info("disable_persistent_config: {}".format(disable_persistent_config))
 
     # Make sure mode for sync_gateway is supported ('cc' or 'di')
     validate_sync_gateway_mode(mode)
@@ -253,6 +260,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without CBS developer preview")
         persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
+
+    if disable_persistent_config:
+        log_info(" disable persistent config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', True)
+    else:
+        log_info("Running without Centralized Persistent Config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
 
     sg_config = sync_gateway_config_path_for_mode("sync_gateway_default_functional_tests", mode)
 

--- a/testsuites/syncgateway/upgrade/liteserv/conftest.py
+++ b/testsuites/syncgateway/upgrade/liteserv/conftest.py
@@ -153,8 +153,23 @@ def pytest_addoption(parser):
 
     parser.addoption("--disable-persistent-config",
                      action="store_true",
-                     help="Centralized Persistent Config",
-                     default=True)
+                     help="Disable Centralized Persistent Config")
+
+    parser.addoption("--enable-server-tls-skip-verify",
+                     action="store_true",
+                     help="Enable Server tls skip verify config")
+
+    parser.addoption("--disable-tls-server",
+                     action="store_true",
+                     help="Disable tls server")
+
+    parser.addoption("--disable-tls-client",
+                     action="store_true",
+                     help="Disable tls client")
+
+    parser.addoption("--disable-admin-auth",
+                     action="store_true",
+                     help="Disable Admin auth")
 
 
 # This will be called once for the at the beggining of the execution in the 'tests/' directory
@@ -196,6 +211,10 @@ def params_from_base_suite_setup(request):
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
+    enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
+    disable_tls_client = request.config.getoption("--disable-tls-client")
+    disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_upgraded_version, sync_gateway_upgraded_version)
@@ -315,6 +334,34 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without Centralized Persistent Config")
         persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
+
+    if enable_server_tls_skip_verify:
+        log_info("Enable server tls skip verify flag")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', True)
+    else:
+        log_info("Running without server_tls_skip_verify Config")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', False)
+
+    if disable_tls_server:
+        log_info("Disable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', True)
+    else:
+        log_info("Enable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
+
+    if disable_tls_client:
+        log_info("Disabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
+    else:
+        log_info("Enabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
+
+    if disable_admin_auth:
+        log_info("Disabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
+    else:
+        log_info("Enabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', False)
 
     # SGW upgrade job run with on Centos platform, adding by default centos to environment config
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)

--- a/testsuites/syncgateway/upgrade/liteserv/conftest.py
+++ b/testsuites/syncgateway/upgrade/liteserv/conftest.py
@@ -163,10 +163,6 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="Disable tls server")
 
-    parser.addoption("--disable-tls-client",
-                     action="store_true",
-                     help="Disable tls client")
-
     parser.addoption("--disable-admin-auth",
                      action="store_true",
                      help="Disable Admin auth")
@@ -186,6 +182,7 @@ def params_from_base_suite_setup(request):
     # pytest command line parameters
     server_version = request.config.getoption("--server-version")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
     server_upgraded_version = request.config.getoption("--server-upgraded-version")
     sync_gateway_upgraded_version = request.config.getoption("--sync-gateway-upgraded-version")
     mode = request.config.getoption("--mode")
@@ -213,7 +210,7 @@ def params_from_base_suite_setup(request):
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_tls_server = request.config.getoption("--disable-tls-server")
-    disable_tls_client = request.config.getoption("--disable-tls-client")
+
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
@@ -349,13 +346,6 @@ def params_from_base_suite_setup(request):
         log_info("Enable tls server flag")
         persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
 
-    if disable_tls_client:
-        log_info("Disabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
-    else:
-        log_info("Enabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
-
     if disable_admin_auth:
         log_info("Disabled Admin Auth")
         persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
@@ -419,6 +409,7 @@ def params_from_base_suite_setup(request):
         "xattrs_enabled": xattrs_enabled,
         "server_version": server_version,
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "server_upgraded_version": server_upgraded_version,
         "sync_gateway_upgraded_version": sync_gateway_upgraded_version,
         "liteserv_host": liteserv_host,
@@ -450,6 +441,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     xattrs_enabled = params_from_base_suite_setup["xattrs_enabled"]
     server_version = params_from_base_suite_setup["server_version"]
     sync_gateway_version = params_from_base_suite_setup["sync_gateway_version"]
+    disable_tls_server = params_from_base_suite_setup["disable_tls_server"]
     server_upgraded_version = params_from_base_suite_setup["server_upgraded_version"]
     sync_gateway_upgraded_version = params_from_base_suite_setup["sync_gateway_upgraded_version"]
     liteserv_host = params_from_base_suite_setup["liteserv_host"]
@@ -495,6 +487,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         "xattrs_enabled": xattrs_enabled,
         "server_version": server_version,
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "server_upgraded_version": server_upgraded_version,
         "sync_gateway_upgraded_version": sync_gateway_upgraded_version,
         "liteserv_host": liteserv_host,

--- a/testsuites/syncgateway/upgrade/liteserv/conftest.py
+++ b/testsuites/syncgateway/upgrade/liteserv/conftest.py
@@ -151,6 +151,11 @@ def pytest_addoption(parser):
                      help="Enabling CBS developer preview",
                      default=False)
 
+    parser.addoption("--disable-persistent-config",
+                     action="store_true",
+                     help="Centralized Persistent Config",
+                     default=True)
+
 
 # This will be called once for the at the beggining of the execution in the 'tests/' directory
 # and will be torn down, (code after the yeild) when all the test session has completed.
@@ -190,6 +195,7 @@ def params_from_base_suite_setup(request):
     hide_product_version = request.config.getoption("--hide-product-version")
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
+    disable_persistent_config = request.config.getoption("--disable-persistent-config")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_upgraded_version, sync_gateway_upgraded_version)
@@ -216,6 +222,7 @@ def params_from_base_suite_setup(request):
     log_info("delta_sync_enabled: {}".format(delta_sync_enabled))
     log_info("hide_product_version: {}".format(hide_product_version))
     log_info("enable_cbs_developer_preview: {}".format(enable_cbs_developer_preview))
+    log_info("disable_persistent_config: {}".format(disable_persistent_config))
 
     # Make sure mode for sync_gateway is supported ('cc' or 'di')
     validate_sync_gateway_mode(mode)
@@ -301,6 +308,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without CBS developer preview")
         persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
+
+    if disable_persistent_config:
+        log_info(" disable persistent config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', True)
+    else:
+        log_info("Running without Centralized Persistent Config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
 
     # SGW upgrade job run with on Centos platform, adding by default centos to environment config
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)

--- a/testsuites/syncgateway/upgrade/testserver/sg_replicate/conftest.py
+++ b/testsuites/syncgateway/upgrade/testserver/sg_replicate/conftest.py
@@ -187,10 +187,6 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="Disable tls server")
 
-    parser.addoption("--disable-tls-client",
-                     action="store_true",
-                     help="Disable tls client")
-
     parser.addoption("--disable-admin-auth",
                      action="store_true",
                      help="Disable Admin auth")
@@ -214,6 +210,7 @@ def params_from_base_suite_setup(request):
 
     server_version = request.config.getoption("--server-version")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
 
     cbs_ssl = request.config.getoption("--server-ssl")
     sg_ssl = request.config.getoption("--sg-ssl")
@@ -248,7 +245,7 @@ def params_from_base_suite_setup(request):
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_tls_server = request.config.getoption("--disable-tls-server")
-    disable_tls_client = request.config.getoption("--disable-tls-client")
+
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
     test_name = request.node.name
 
@@ -449,13 +446,6 @@ def params_from_base_suite_setup(request):
         log_info("Enable tls server flag")
         persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
 
-    if disable_tls_client:
-        log_info("Disabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
-    else:
-        log_info("Enabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
-
     if disable_admin_auth:
         log_info("Disabled Admin Auth")
         persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
@@ -534,6 +524,7 @@ def params_from_base_suite_setup(request):
         "cbs_platform": cbs_platform,
         "server_version": server_version,
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "server_upgraded_version": server_upgraded_version,
         "sync_gateway_upgraded_version": sync_gateway_upgraded_version,
         "cbs_ssl": cbs_ssl,
@@ -591,6 +582,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     mode = params_from_base_suite_setup["mode"]
     server_version = params_from_base_suite_setup["server_version"]
     sync_gateway_version = params_from_base_suite_setup["sync_gateway_version"]
+    disable_tls_server = params_from_base_suite_setup["disable_tls_server"]
     server_upgraded_version = params_from_base_suite_setup["server_upgraded_version"]
     sync_gateway_upgraded_version = params_from_base_suite_setup["sync_gateway_upgraded_version"]
     cbs_ssl = params_from_base_suite_setup["cbs_ssl"],
@@ -699,6 +691,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         "mode": mode,
         "server_version": server_version,
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "server_upgraded_version": server_upgraded_version,
         "sync_gateway_upgraded_version": sync_gateway_upgraded_version,
         "cbs_ssl": cbs_ssl,

--- a/testsuites/syncgateway/upgrade/testserver/sg_replicate/conftest.py
+++ b/testsuites/syncgateway/upgrade/testserver/sg_replicate/conftest.py
@@ -177,8 +177,23 @@ def pytest_addoption(parser):
 
     parser.addoption("--disable-persistent-config",
                      action="store_true",
-                     help="Centralized Persistent Config",
-                     default=True)
+                     help="Disable Centralized Persistent Config")
+
+    parser.addoption("--enable-server-tls-skip-verify",
+                     action="store_true",
+                     help="Enable Server tls skip verify config")
+
+    parser.addoption("--disable-tls-server",
+                     action="store_true",
+                     help="Disable tls server")
+
+    parser.addoption("--disable-tls-client",
+                     action="store_true",
+                     help="Disable tls client")
+
+    parser.addoption("--disable-admin-auth",
+                     action="store_true",
+                     help="Disable Admin auth")
 
 
 # This will get called once before the first test that
@@ -231,6 +246,10 @@ def params_from_base_suite_setup(request):
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
+    enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
+    disable_tls_client = request.config.getoption("--disable-tls-client")
+    disable_admin_auth = request.config.getoption("--disable-admin-auth")
     test_name = request.node.name
 
     log_info("mode: {}".format(mode))
@@ -415,6 +434,34 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without Centralized Persistent Config")
         persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
+
+    if enable_server_tls_skip_verify:
+        log_info("Enable server tls skip verify flag")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', True)
+    else:
+        log_info("Running without server_tls_skip_verify Config")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', False)
+
+    if disable_tls_server:
+        log_info("Disable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', True)
+    else:
+        log_info("Enable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
+
+    if disable_tls_client:
+        log_info("Disabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
+    else:
+        log_info("Enabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
+
+    if disable_admin_auth:
+        log_info("Disabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
+    else:
+        log_info("Enabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', False)
 
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)
 

--- a/testsuites/syncgateway/upgrade/testserver/sg_replicate/conftest.py
+++ b/testsuites/syncgateway/upgrade/testserver/sg_replicate/conftest.py
@@ -175,6 +175,11 @@ def pytest_addoption(parser):
                      help="Enabling CBS developer preview",
                      default=False)
 
+    parser.addoption("--disable-persistent-config",
+                     action="store_true",
+                     help="Centralized Persistent Config",
+                     default=True)
+
 
 # This will get called once before the first test that
 # runs with this as input parameters in this file
@@ -225,6 +230,7 @@ def params_from_base_suite_setup(request):
     hide_product_version = request.config.getoption("--hide-product-version")
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
+    disable_persistent_config = request.config.getoption("--disable-persistent-config")
     test_name = request.node.name
 
     log_info("mode: {}".format(mode))
@@ -261,6 +267,7 @@ def params_from_base_suite_setup(request):
     log_info("upgraded_no_conflicts_enabled: {}".format(upgraded_no_conflicts_enabled))
     log_info("hide_product_version: {}".format(hide_product_version))
     log_info("enable_cbs_developer_preview: {}".format(enable_cbs_developer_preview))
+    log_info("disable_persistent_config: {}".format(disable_persistent_config))
 
     # if xattrs is specified but the post upgrade SG version doesn't support, don't continue
     if upgraded_xattrs_enabled and version_is_binary(sync_gateway_upgraded_version):
@@ -401,6 +408,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without CBS developer preview")
         persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
+
+    if disable_persistent_config:
+        log_info(" disable persistent config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', True)
+    else:
+        log_info("Running without Centralized Persistent Config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
 
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)
 

--- a/testsuites/syncgateway/upgrade/testserver/sg_replicate/test_upgrade_with_sgreplicate.py
+++ b/testsuites/syncgateway/upgrade/testserver/sg_replicate/test_upgrade_with_sgreplicate.py
@@ -257,7 +257,7 @@ def test_upgrade(params_from_base_test_setup, setup_customized_teardown_test):
         replications_key = "replications"
         sgr2_replace_string = "\"{}\": {}{}{},".format(replications_key, "{", replications_ids, "}")
         temp_sg_config_copy, _ = copy_sgconf_to_temp(sg_config, mode)
-        if stop_replication_before_upgrade:
+        if stop_replication_before_upgrade and sync_gateway_version >= "3.0.0":
             sg1.stop_replication_by_id(sgw_repl1_id1, use_admin_url=True)
             sg1.stop_replication_by_id(sgw_repl1_id2, use_admin_url=True)
             temp_sg_config = replace_string_on_sgw_config(temp_sg_config_copy, "{{ replace_with_sg1_replications }}", "")

--- a/testsuites/syncgateway/upgrade/testserver/sg_single_sgw/conftest.py
+++ b/testsuites/syncgateway/upgrade/testserver/sg_single_sgw/conftest.py
@@ -169,10 +169,6 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="Disable tls server")
 
-    parser.addoption("--disable-tls-client",
-                     action="store_true",
-                     help="Disable tls client")
-
     parser.addoption("--disable-admin-auth",
                      action="store_true",
                      help="Disable Admin auth")
@@ -196,6 +192,7 @@ def params_from_base_suite_setup(request):
 
     server_version = request.config.getoption("--server-version")
     sync_gateway_version = request.config.getoption("--sync-gateway-version")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
 
     cbs_ssl = request.config.getoption("--server-ssl")
     sg_ssl = request.config.getoption("--sg-ssl")
@@ -228,7 +225,7 @@ def params_from_base_suite_setup(request):
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_tls_server = request.config.getoption("--disable-tls-server")
-    disable_tls_client = request.config.getoption("--disable-tls-client")
+
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     test_name = request.node.name
@@ -417,13 +414,6 @@ def params_from_base_suite_setup(request):
         log_info("Enable tls server flag")
         persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
 
-    if disable_tls_client:
-        log_info("Disabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
-    else:
-        log_info("Enabled tls client flag")
-        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
-
     if disable_admin_auth:
         log_info("Disabled Admin Auth")
         persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
@@ -503,6 +493,7 @@ def params_from_base_suite_setup(request):
         "cbs_platform": cbs_platform,
         "server_version": server_version,
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "server_upgraded_version": server_upgraded_version,
         "sync_gateway_upgraded_version": sync_gateway_upgraded_version,
         "cbs_ssl": cbs_ssl,
@@ -553,6 +544,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     mode = params_from_base_suite_setup["mode"]
     server_version = params_from_base_suite_setup["server_version"]
     sync_gateway_version = params_from_base_suite_setup["sync_gateway_version"]
+    disable_tls_server = params_from_base_suite_setup["disable_tls_server"]
     server_upgraded_version = params_from_base_suite_setup["server_upgraded_version"]
     sync_gateway_upgraded_version = params_from_base_suite_setup["sync_gateway_upgraded_version"]
     cbs_ssl = params_from_base_suite_setup["cbs_ssl"],
@@ -653,6 +645,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         "mode": mode,
         "server_version": server_version,
         "sync_gateway_version": sync_gateway_version,
+        "disable_tls_server": disable_tls_server,
         "server_upgraded_version": server_upgraded_version,
         "sync_gateway_upgraded_version": sync_gateway_upgraded_version,
         "cbs_ssl": cbs_ssl,

--- a/testsuites/syncgateway/upgrade/testserver/sg_single_sgw/conftest.py
+++ b/testsuites/syncgateway/upgrade/testserver/sg_single_sgw/conftest.py
@@ -159,8 +159,23 @@ def pytest_addoption(parser):
 
     parser.addoption("--disable-persistent-config",
                      action="store_true",
-                     help="Centralized Persistent Config",
-                     default=True)
+                     help="Disable Centralized Persistent Config")
+
+    parser.addoption("--enable-server-tls-skip-verify",
+                     action="store_true",
+                     help="Enable Server tls skip verify config")
+
+    parser.addoption("--disable-tls-server",
+                     action="store_true",
+                     help="Disable tls server")
+
+    parser.addoption("--disable-tls-client",
+                     action="store_true",
+                     help="Disable tls client")
+
+    parser.addoption("--disable-admin-auth",
+                     action="store_true",
+                     help="Disable Admin auth")
 
 
 # This will get called once before the first test that
@@ -211,6 +226,10 @@ def params_from_base_suite_setup(request):
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
+    enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
+    disable_tls_server = request.config.getoption("--disable-tls-server")
+    disable_tls_client = request.config.getoption("--disable-tls-client")
+    disable_admin_auth = request.config.getoption("--disable-admin-auth")
 
     test_name = request.node.name
 
@@ -383,6 +402,34 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without Centralized Persistent Config")
         persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
+
+    if enable_server_tls_skip_verify:
+        log_info("Enable server tls skip verify flag")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', True)
+    else:
+        log_info("Running without server_tls_skip_verify Config")
+        persist_cluster_config_environment_prop(cluster_config, 'server_tls_skip_verify', False)
+
+    if disable_tls_server:
+        log_info("Disable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', True)
+    else:
+        log_info("Enable tls server flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_server', False)
+
+    if disable_tls_client:
+        log_info("Disabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', True)
+    else:
+        log_info("Enabled tls client flag")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_tls_client', False)
+
+    if disable_admin_auth:
+        log_info("Disabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', True)
+    else:
+        log_info("Enabled Admin Auth")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', False)
 
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)
 

--- a/testsuites/syncgateway/upgrade/testserver/sg_single_sgw/conftest.py
+++ b/testsuites/syncgateway/upgrade/testserver/sg_single_sgw/conftest.py
@@ -157,6 +157,11 @@ def pytest_addoption(parser):
                      help="Enabling CBS developer preview",
                      default=False)
 
+    parser.addoption("--disable-persistent-config",
+                     action="store_true",
+                     help="Centralized Persistent Config",
+                     default=True)
+
 
 # This will get called once before the first test that
 # runs with this as input parameters in this file
@@ -205,6 +210,7 @@ def params_from_base_suite_setup(request):
     hide_product_version = request.config.getoption("--hide-product-version")
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
+    disable_persistent_config = request.config.getoption("--disable-persistent-config")
 
     test_name = request.node.name
 
@@ -237,6 +243,7 @@ def params_from_base_suite_setup(request):
     log_info("cbs_toy_build: {}".format(cbs_toy_build))
     log_info("hide_product_version: {}".format(hide_product_version))
     log_info("enable_cbs_developer_preview: {}".format(enable_cbs_developer_preview))
+    log_info("disable_persistent_config: {}".format(disable_persistent_config))
 
     # if xattrs is specified but the post upgrade SG version doesn't support, don't continue
     if upgraded_xattrs_enabled and version_is_binary(sync_gateway_upgraded_version):
@@ -369,6 +376,13 @@ def params_from_base_suite_setup(request):
     else:
         log_info("Running without CBS developer preview")
         persist_cluster_config_environment_prop(cluster_config, 'cbs_developer_preview', False)
+
+    if disable_persistent_config:
+        log_info(" disable persistent config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', True)
+    else:
+        log_info("Running without Centralized Persistent Config")
+        persist_cluster_config_environment_prop(cluster_config, 'disable_persistent_config', False)
 
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)
 

--- a/utilities/cluster_config_utils.py
+++ b/utilities/cluster_config_utils.py
@@ -366,7 +366,7 @@ def is_tls_client_disabled(cluster_config):
 
     cluster = load_cluster_config_json(cluster_config)
     try:
-        return cluster["environment"]["tls_client"]
+        return cluster["environment"]["disable_tls_client"]
     except KeyError:
         return False
 

--- a/utilities/cluster_config_utils.py
+++ b/utilities/cluster_config_utils.py
@@ -60,7 +60,7 @@ def persist_cluster_config_environment_prop(cluster_config, property_name, value
     if property_name_check is True:
         valid_props = ["cbs_ssl_enabled", "xattrs_enabled", "sg_lb_enabled", "sync_gateway_version", "server_version",
                        "no_conflicts_enabled", "sync_gateway_ssl", "sg_use_views", "number_replicas",
-                       "delta_sync_enabled", "x509_certs", "hide_product_version", "cbs_developer_preview"]
+                       "delta_sync_enabled", "x509_certs", "hide_product_version", "cbs_developer_preview", "disable_persistent_config"]
         if property_name not in valid_props:
             raise ProvisioningError("Make sure the property you are trying to change is one of: {}".format(valid_props))
 
@@ -326,5 +326,15 @@ def is_hide_prod_version_enabled(cluster_config):
     cluster = load_cluster_config_json(cluster_config)
     try:
         return cluster["environment"]["hide_product_version"]
+    except KeyError:
+        return False
+
+
+def is_centralized_persistent_config_disabled(cluster_config):
+    """ verify centralized persistent config enabled/disabled"""
+
+    cluster = load_cluster_config_json(cluster_config)
+    try:
+        return cluster["environment"]["disable_persistent_config"]
     except KeyError:
         return False

--- a/utilities/cluster_config_utils.py
+++ b/utilities/cluster_config_utils.py
@@ -338,3 +338,43 @@ def is_centralized_persistent_config_disabled(cluster_config):
         return cluster["environment"]["disable_persistent_config"]
     except KeyError:
         return False
+
+
+def is_server_tls_skip_verify_enabled(cluster_config):
+    """ verify server tls skip verify config enabled/disabled"""
+
+    cluster = load_cluster_config_json(cluster_config)
+    try:
+        return cluster["environment"]["server_tls_skip_verify"]
+    except KeyError:
+        return False
+
+
+def is_tls_server_disabled(cluster_config):
+    """ verify tls server enabled/disabled"""
+
+    cluster = load_cluster_config_json(cluster_config)
+    try:
+        return cluster["environment"]["disable_tls_server"]
+    except KeyError:
+        return False
+
+
+def is_tls_client_disabled(cluster_config):
+    """ verify tls client enabled/disabled"""
+
+    cluster = load_cluster_config_json(cluster_config)
+    try:
+        return cluster["environment"]["tls_client"]
+    except KeyError:
+        return False
+
+
+def is_admin_auth_disabled(cluster_config):
+    """ verify admin auth enabled/disabled"""
+
+    cluster = load_cluster_config_json(cluster_config)
+    try:
+        return cluster["environment"]["disable_admin_auth"]
+    except KeyError:
+        return False

--- a/utilities/cluster_config_utils.py
+++ b/utilities/cluster_config_utils.py
@@ -61,7 +61,7 @@ def persist_cluster_config_environment_prop(cluster_config, property_name, value
         valid_props = ["cbs_ssl_enabled", "xattrs_enabled", "sg_lb_enabled", "sync_gateway_version", "server_version",
                        "no_conflicts_enabled", "sync_gateway_ssl", "sg_use_views", "number_replicas",
                        "delta_sync_enabled", "x509_certs", "hide_product_version", "cbs_developer_preview", "disable_persistent_config",
-                       "server_tls_skip_verify", "disable_tls_server", "disable_tls_client", "disable_admin_auth"]
+                       "server_tls_skip_verify", "disable_tls_server", "disable_admin_auth"]
         if property_name not in valid_props:
             raise ProvisioningError("Make sure the property you are trying to change is one of: {}".format(valid_props))
 
@@ -357,16 +357,6 @@ def is_tls_server_disabled(cluster_config):
     cluster = load_cluster_config_json(cluster_config)
     try:
         return cluster["environment"]["disable_tls_server"]
-    except KeyError:
-        return False
-
-
-def is_tls_client_disabled(cluster_config):
-    """ verify tls client enabled/disabled"""
-
-    cluster = load_cluster_config_json(cluster_config)
-    try:
-        return cluster["environment"]["disable_tls_client"]
     except KeyError:
         return False
 

--- a/utilities/cluster_config_utils.py
+++ b/utilities/cluster_config_utils.py
@@ -60,7 +60,8 @@ def persist_cluster_config_environment_prop(cluster_config, property_name, value
     if property_name_check is True:
         valid_props = ["cbs_ssl_enabled", "xattrs_enabled", "sg_lb_enabled", "sync_gateway_version", "server_version",
                        "no_conflicts_enabled", "sync_gateway_ssl", "sg_use_views", "number_replicas",
-                       "delta_sync_enabled", "x509_certs", "hide_product_version", "cbs_developer_preview", "disable_persistent_config"]
+                       "delta_sync_enabled", "x509_certs", "hide_product_version", "cbs_developer_preview", "disable_persistent_config",
+                       "server_tls_skip_verify", "disable_tls_server", "disable_tls_client", "disable_admin_auth"]
         if property_name not in valid_props:
             raise ProvisioningError("Make sure the property you are trying to change is one of: {}".format(valid_props))
 


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Added support for 5 flags : disable persistent config, 2 TLS flags and 2 Authenticated admin api flag
- Tested and verified on latest build . Greenboard : http://centos-0037.corp.couchbase.com/#/sync_gateway/3.0.0/3.0.0-0350
- Failures are due to latest feature changes which will get fixed in next PR. All fixes related to flags and TLS changes are fixed with multiple iterations : 

