### PR TITLE
add upgrade job server ssl support

### DIFF
--- a/testsuites/CBLTester/upgrade_tests/conftest.py
+++ b/testsuites/CBLTester/upgrade_tests/conftest.py
@@ -156,6 +156,9 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="Disable Admin auth")
 
+    parser.addoption("--server-ssl",
+                     action="store_true",
+                     help="If set, will enable SSL communication between server and Sync Gateway")
 
 # This will get called once before the first test that
 # runs with this as input parameters in this file
@@ -180,6 +183,7 @@ def params_from_base_suite_setup(request):
     xattrs_enabled = request.config.getoption("--xattrs")
     device_enabled = request.config.getoption("--device")
     community_enabled = request.config.getoption("--community")
+    cbs_ssl = request.config.getoption("--server-ssl")
     sg_ssl = request.config.getoption("--sg-ssl")
     sg_lb = request.config.getoption("--sg-lb")
     ci = request.config.getoption("--ci")
@@ -355,6 +359,15 @@ def params_from_base_suite_setup(request):
         log_info("Enabled Admin Auth")
         persist_cluster_config_environment_prop(cluster_config, 'disable_admin_auth', False)
 
+    if cbs_ssl:
+        log_info("Running tests with cbs <-> sg ssl enabled")
+        # Enable ssl in cluster configs
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_ssl_enabled', True)
+    else:
+        log_info("Running tests with cbs <-> sg ssl disabled")
+        # Disable ssl in cluster configs
+        persist_cluster_config_environment_prop(cluster_config, 'cbs_ssl_enabled', False)
+
     # As cblite jobs run with on Centos platform, adding by default centos to environment config
     persist_cluster_config_environment_prop(cluster_config, 'sg_platform', "centos", False)
 
@@ -454,7 +467,8 @@ def params_from_base_suite_setup(request):
         "sg_url": sg_url,
         "second_liteserv_host": second_liteserv_host,
         "second_liteserv_version": second_liteserv_version,
-        "second_liteserv_platform": second_liteserv_platform
+        "second_liteserv_platform": second_liteserv_platform,
+        "cbs_ssl": cbs_ssl
     }
 
     # Flush all the memory contents on the server app

--- a/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
+++ b/testsuites/CBLTester/upgrade_tests/test_cbl_upgrade.py
@@ -49,6 +49,7 @@ def test_upgrade_cbl(params_from_base_suite_setup):
     sg_config = params_from_base_suite_setup["sg_config"]
     cbs_ip = params_from_base_suite_setup["cbs_ip"]
     server_url = params_from_base_suite_setup["server_url"]
+    cbs_ssl = params_from_base_suite_setup["cbs_ssl"]
     db = Database(base_url)
 
     cbl_db, upgrade_cbl_db_name = _upgrade_db(params_from_base_suite_setup)
@@ -86,7 +87,11 @@ def test_upgrade_cbl(params_from_base_suite_setup):
     server = CouchbaseServer(server_url)
     server._create_internal_rbac_bucket_user(cbs_bucket, cluster_config=cluster_config)
     log_info("Connecting to {}/{} with password {}".format(cbs_ip, cbs_bucket, password))
-    sdk_client = get_cluster('couchbase://{}'.format(cbs_ip), cbs_bucket)
+    if cbs_ssl:
+        connection_url = "couchbases://{}?ssl=no_verify".format(cbs_ip)
+    else:
+        connection_url = "couchbase://{}".format(cbs_ip)
+    sdk_client = get_cluster(connection_url, cbs_bucket)
     log_info("Creating primary index for {}".format(cbs_bucket))
     n1ql_query = "create primary index index1 on `{}`".format(cbs_bucket)
     sdk_client.query(n1ql_query).execute()


### PR DESCRIPTION
#### Fixes #. upgrade job currently missing server-ssl option, added

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- added --server-ssl option to upgrade job,
- tested w/o --server-ssl flag for 2.8 and 3.x sync gateway

Run with 3.0 SGW: http://uberjenkins.sc.couchbase.com:8080/job/CBLITE_Android-Listener-Upgrade-base-2.1.5-tests/103/
Run with 2.8 SGW: http://uberjenkins.sc.couchbase.com:8080/job/CBLITE_Android-Listener-Upgrade-base-2.1.5-tests/104/

