### PR TITLE
Fix/sgw server710 x509

### DIFF
--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_xattrs_grants_with_cbl.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_xattrs_grants_with_cbl.py
@@ -38,9 +38,11 @@ def test_xattrs_grant_automatic_imports(params_from_base_test_setup, x509_cert_a
     mode = params_from_base_test_setup["mode"]
     ssl_enabled = params_from_base_test_setup["ssl_enabled"]
     sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
+    xattrs_enabled = params_from_base_test_setup["xattrs_enabled"]
 
-    if sync_gateway_version < "3.0.0":
-        pytest.skip('This test cannot run with sg version below 3.0.0')
+    if not xattrs_enabled or sync_gateway_version < "3.0.0":
+        pytest.skip('Test did not enable xattrs or sgw version is not 3.0 and above')
+
     sg_channel1_value = "abc"
     sg_channels1 = [sg_channel1_value]
     username = "autotest"
@@ -137,9 +139,11 @@ def test_reassigning_channels_using_user_xattrs(params_from_base_test_setup, set
     cbl_db1 = setup_customized_teardown_test["cbl_db1"]
     cbl_db2 = setup_customized_teardown_test["cbl_db2"]
     delta_sync_enabled = params_from_base_test_setup["delta_sync_enabled"]
+    xattrs_enabled = params_from_base_test_setup["xattrs_enabled"]
 
-    if sync_gateway_version < "3.0.0":
-        pytest.skip('This test cannot run with sg version below 3.0.0')
+    if not xattrs_enabled or sync_gateway_version < "3.0.0":
+        pytest.skip('Test did not enable xattrs or sgw version is not 3.0 and above')
+
     sg_channel1_value1 = "xattrs_channel_one"
     sg_channel1_value2 = "xattrs_channel_two"
     sg_channels_1 = [sg_channel1_value1]
@@ -240,9 +244,11 @@ def test_tombstone_docs_via_sdk(params_from_base_test_setup, tombstone_type):
     mode = params_from_base_test_setup["mode"]
     ssl_enabled = params_from_base_test_setup["ssl_enabled"]
     sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
+    xattrs_enabled = params_from_base_test_setup["xattrs_enabled"]
 
-    if sync_gateway_version < "3.0.0":
-        pytest.skip('This test cannot run with sg version below 3.0.0')
+    if not xattrs_enabled or sync_gateway_version < "3.0.0":
+        pytest.skip('Test did not enable xattrs or sgw version is not 3.0 and above')
+
     sg_channel1_value1 = "xattrs_channel_one"
     sg_channels_1 = [sg_channel1_value1]
     username = "autotest_1"

--- a/testsuites/syncgateway/functional/tests/test_xattrs_grants.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs_grants.py
@@ -819,7 +819,7 @@ def test_rev_with_docupdates_docxattrsupdate(params_from_base_test_setup, update
         sdk_bucket.upsert(sg_doc_xattrs_id, doc_body)
     else:
         sg_docs = sg_client.get_all_docs(url=sg_url, db=sg_db, auth=auto_user)["rows"]
-        with ThreadPoolExecutor(max_workers=2) as tpe:
+        with ThreadPoolExecutor(max_workers=1) as tpe:
             sdk_mutate = tpe.submit(sdk_bucket.mutate_in, sg_doc_xattrs_id, [SD.upsert(user_custom_channel, sg_channel1_value1, xattr=True, create_parents=True)])
             sg_client.update_doc(url=sg_url, db=sg_db, doc_id=sg_doc_xattrs_id, number_updates=1, auth=auto_user)
             sdk_mutate.result()

--- a/testsuites/syncgateway/functional/tests/test_xattrs_grants.py
+++ b/testsuites/syncgateway/functional/tests/test_xattrs_grants.py
@@ -764,7 +764,7 @@ def test_rev_with_docupdates_docxattrsupdate(params_from_base_test_setup, update
             channel1 : ""abc1"",
             channel2 : ""abc2""
         }
-        5. Also  update doc via sdk/SGW in parallel
+        5. Also  update doc via sdk and then via SGW
         6. Wait until docs imported and docs processed via sync function and verify the revision generated and incremented by 1
     """
     sg_db = "db"
@@ -819,10 +819,8 @@ def test_rev_with_docupdates_docxattrsupdate(params_from_base_test_setup, update
         sdk_bucket.upsert(sg_doc_xattrs_id, doc_body)
     else:
         sg_docs = sg_client.get_all_docs(url=sg_url, db=sg_db, auth=auto_user)["rows"]
-        with ThreadPoolExecutor(max_workers=1) as tpe:
-            sdk_mutate = tpe.submit(sdk_bucket.mutate_in, sg_doc_xattrs_id, [SD.upsert(user_custom_channel, sg_channel1_value1, xattr=True, create_parents=True)])
-            sg_client.update_doc(url=sg_url, db=sg_db, doc_id=sg_doc_xattrs_id, number_updates=1, auth=auto_user)
-            sdk_mutate.result()
+        sdk_bucket.mutate_in(sg_doc_xattrs_id, [SD.upsert(user_custom_channel, sg_channel1_value1, xattr=True, create_parents=True)])
+        sg_client.update_doc(url=sg_url, db=sg_db, doc_id=sg_doc_xattrs_id, number_updates=1, auth=auto_user)
     sg_docs = sg_client.get_all_docs(url=sg_url, db=sg_db, auth=auto_user)["rows"]
     assert len(sg_docs) == 1, "docs still exist in old channel even after replacing the user xattrs"
 

--- a/utilities/cluster_config_utils.py
+++ b/utilities/cluster_config_utils.py
@@ -85,6 +85,7 @@ def persist_cluster_config_environment_prop(cluster_config, property_name, value
 
 def generate_x509_certs(cluster_config, bucket_name, sg_platform):
     ''' Generate and insert x509 certs for CBS and SG TLS Handshake'''
+    cbs_version = get_cbs_version(cluster_config)
     cluster = load_cluster_config_json(cluster_config)
     if sg_platform.lower() != "windows" and sg_platform.lower() != "macos":
         for line in open("ansible.cfg"):
@@ -112,7 +113,7 @@ def generate_x509_certs(cluster_config, bucket_name, sg_platform):
             else:
                 f.write("DNS.{} = {}\n".format(item + 1, cbs_nodes[item]))
 
-    cmd = ["./gen_keystore.sh", cbs_nodes[0], bucket_name[0]]
+    cmd = ["./gen_keystore.sh", cbs_nodes[0], bucket_name[0], cbs_version]
     print(" ".join(cmd))
     proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
     stdout, stderr = proc.communicate()


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- x509 fix to work with 7.1.0 and below
- skipping xattrs access grant tests when xattrs not enabled

http://uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-functional-tests-xattrs-deltaSync-ServerSsl_MAGMA/434/testReport/