### PR TITLE
Fix/server addnode https

### DIFF
--- a/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
+++ b/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
@@ -18,6 +18,7 @@
     couchbase_server_cluster_ram: "{{((ansible_memtotal_mb|int)*0.8)|int - 512 }}"
     couchbase_server_admin_port: "{{ couchbase_server_admin_port }}"
     protocol: http://
+    addnode_protocol: http://
     couchbase_server_home_path: /opt/couchbase
 
     # Primary node
@@ -96,18 +97,19 @@
   
     - set_fact:
         protocol: ""
+        addnode_protocol: ""
       when: "( {{ cb_major_version['stdout'] | search('\\b[1-4]\\b') }} ) or ( '5.0.0' in cb_full_version.stdout )"
 
     - set_fact:
-        protocol: "https"
+        addnode_protocol: https://
       when: "( {{ cb_major_version['stdout'] | search('\\b[7]\\b') }} ) or ( '7.1.0' in cb_full_version.stdout )"
 
     - name: COUCHBASE SERVER | Join additional cluster nodes | configure IPv4
-      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ protocol }}{{ couchbase_server_primary_node }}:{{ couchbase_server_admin_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ protocol }}{{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }}"
+      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ addnode_protocol }}{{ couchbase_server_primary_node }}:{{ couchbase_server_admin_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ addnode_protocol }}{{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }}"
       when: "not (couchbase_server_node == couchbase_server_primary_node ) and not ipv6_enabled"
 
     - name: COUCHBASE SERVER | Join additional cluster nodes | configure IPv6
-      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ protocol }}[{{ couchbase_server_primary_node }}]:{{ couchbase_server_admin_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ protocol }}{{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }}"
+      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ addnode_protocol }}[{{ couchbase_server_primary_node }}]:{{ couchbase_server_admin_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ addnode_protocol }}{{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }}"
       when: "not (couchbase_server_node == couchbase_server_primary_node ) and ipv6_enabled"
 
     - name: COUCHBASE SERVER | Rebalance cluster (6.X and up) | configure IPv4

--- a/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
+++ b/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
@@ -98,6 +98,10 @@
         protocol: ""
       when: "( {{ cb_major_version['stdout'] | search('\\b[1-4]\\b') }} ) or ( '5.0.0' in cb_full_version.stdout )"
 
+    - set_fact:
+        protocol: "https"
+      when: "( {{ cb_major_version['stdout'] | search('\\b[7]\\b') }} ) or ( '7.1.0' in cb_full_version.stdout )"
+
     - name: COUCHBASE SERVER | Join additional cluster nodes | configure IPv4
       shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ protocol }}{{ couchbase_server_primary_node }}:{{ couchbase_server_admin_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ protocol }}{{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }}"
       when: "not (couchbase_server_node == couchbase_server_primary_node ) and not ipv6_enabled"

--- a/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
+++ b/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
@@ -19,6 +19,8 @@
     couchbase_server_admin_port: "{{ couchbase_server_admin_port }}"
     protocol: http://
     addnode_protocol: http://
+    addnode_port: 18091
+    ssl_verify:
     couchbase_server_home_path: /opt/couchbase
 
     # Primary node
@@ -102,14 +104,16 @@
 
     - set_fact:
         addnode_protocol: https://
+        addnode_port: 18091
+        ssl_verify: --no-ssl-verify
       when: "( {{ cb_major_version['stdout'] | search('\\b[7]\\b') }} ) or ( '7.1.0' in cb_full_version.stdout )"
 
     - name: COUCHBASE SERVER | Join additional cluster nodes | configure IPv4
-      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ addnode_protocol }}{{ couchbase_server_primary_node }}:{{ couchbase_server_admin_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ addnode_protocol }}{{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }}"
+      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ addnode_protocol }}{{ couchbase_server_primary_node }}:{{ addnode_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ addnode_protocol }}{{ couchbase_server_node }}:{{ addnode_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }} {{ ssl_verify }}"
       when: "not (couchbase_server_node == couchbase_server_primary_node ) and not ipv6_enabled"
 
     - name: COUCHBASE SERVER | Join additional cluster nodes | configure IPv6
-      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ addnode_protocol }}[{{ couchbase_server_primary_node }}]:{{ couchbase_server_admin_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ addnode_protocol }}{{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }}"
+      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ addnode_protocol }}[{{ couchbase_server_primary_node }}]:{{ addnode_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ addnode_protocol }}{{ couchbase_server_node }}:{{ addnode_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }} {{ ssl_verify }}"
       when: "not (couchbase_server_node == couchbase_server_primary_node ) and ipv6_enabled"
 
     - name: COUCHBASE SERVER | Rebalance cluster (6.X and up) | configure IPv4

--- a/libraries/provision/ansible/playbooks/install-couchbase-server-package.yml
+++ b/libraries/provision/ansible/playbooks/install-couchbase-server-package.yml
@@ -19,6 +19,7 @@
     couchbase_server_cluster_ram: "{{((ansible_memtotal_mb|int)*0.8)|int - 512 }}"
     couchbase_server_admin_port: 8091
     protocol: http://
+    addnode_protocol: http://
     couchbase_server_home_path: /opt/couchbase
 
     # Primary node
@@ -164,22 +165,23 @@
 
     - set_fact:
         protocol: ""
+        addnode_protocol: ""
       when: "( {{ cb_major_version['stdout'] | search('\\b[1-4]\\b') }} ) or ( '5.0.0' in cb_full_version.stdout )"
 
     - set_fact:
-        protocol: "https"
+        addnode_protocol: https://
       when: "( {{ cb_major_version['stdout'] | search('\\b[7]\\b') }} ) or ( '7.1.0' in cb_full_version.stdout )"
 
     - name: COUCHBASE SERVER | Join additional cluster nodes | configure IPv6
-      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ protocol }}://[{{ couchbase_server_primary_node }}]:{{ couchbase_server_admin_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ protocol }}://[{{ couchbase_server_node }}]:{{ couchbase_server_admin_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }}"
+      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ addnode_protocol }}://[{{ couchbase_server_primary_node }}]:{{ couchbase_server_admin_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ addnode_protocol }}://[{{ couchbase_server_node }}]:{{ couchbase_server_admin_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }}"
       when: "not (couchbase_server_node == couchbase_server_primary_node ) and (not {{ cb_major_version['stdout'] | search('\\b[1-5]\\b') }}) and ipv6_enabled"
 
     - name: COUCHBASE SERVER | Join additional cluster nodes | configure IPv4
-      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ protocol }}{{ couchbase_server_primary_node }}:{{ couchbase_server_admin_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ protocol }}{{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }}"
+      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ addnode_protocol }}{{ couchbase_server_primary_node }}:{{ couchbase_server_admin_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ addnode_protocol }}{{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }}"
       when: "not (couchbase_server_node == couchbase_server_primary_node ) and not ipv6_enabled"
 
     - name: COUCHBASE SERVER | Join additional cluster nodes | configure IPv6
-      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ protocol }}[{{ couchbase_server_primary_node }}]:{{ couchbase_server_admin_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ protocol }}{{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }}"
+      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ addnode_protocol }}[{{ couchbase_server_primary_node }}]:{{ couchbase_server_admin_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ addnode_protocol }}{{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }}"
       when: "not (couchbase_server_node == couchbase_server_primary_node ) and ipv6_enabled"
 
     - name: COUCHBASE SERVER | Rebalance cluster (6.X and up) | configure IPv4

--- a/libraries/provision/ansible/playbooks/install-couchbase-server-package.yml
+++ b/libraries/provision/ansible/playbooks/install-couchbase-server-package.yml
@@ -20,6 +20,8 @@
     couchbase_server_admin_port: 8091
     protocol: http://
     addnode_protocol: http://
+    addnode_port: 18091
+    ssl_verify:
     couchbase_server_home_path: /opt/couchbase
 
     # Primary node
@@ -170,18 +172,20 @@
 
     - set_fact:
         addnode_protocol: https://
+        addnode_port: 18091
+        ssl_verify: --no-ssl-verify
       when: "( {{ cb_major_version['stdout'] | search('\\b[7]\\b') }} ) or ( '7.1.0' in cb_full_version.stdout )"
 
     - name: COUCHBASE SERVER | Join additional cluster nodes | configure IPv6
-      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ addnode_protocol }}://[{{ couchbase_server_primary_node }}]:{{ couchbase_server_admin_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ addnode_protocol }}://[{{ couchbase_server_node }}]:{{ couchbase_server_admin_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }}"
+      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ addnode_protocol }}://[{{ couchbase_server_primary_node }}]:{{ addnode_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ addnode_protocol }}://[{{ couchbase_server_node }}]:{{ addnode_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }} {{ ssl_verify }}"
       when: "not (couchbase_server_node == couchbase_server_primary_node ) and (not {{ cb_major_version['stdout'] | search('\\b[1-5]\\b') }}) and ipv6_enabled"
 
     - name: COUCHBASE SERVER | Join additional cluster nodes | configure IPv4
-      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ addnode_protocol }}{{ couchbase_server_primary_node }}:{{ couchbase_server_admin_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ addnode_protocol }}{{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }}"
+      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ addnode_protocol }}{{ couchbase_server_primary_node }}:{{ addnode_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ addnode_protocol }}{{ couchbase_server_node }}:{{ addnode_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }} {{ ssl_verify }}"
       when: "not (couchbase_server_node == couchbase_server_primary_node ) and not ipv6_enabled"
 
     - name: COUCHBASE SERVER | Join additional cluster nodes | configure IPv6
-      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ addnode_protocol }}[{{ couchbase_server_primary_node }}]:{{ couchbase_server_admin_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ addnode_protocol }}{{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }}"
+      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ addnode_protocol }}[{{ couchbase_server_primary_node }}]:{{ addnode_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ addnode_protocol }}{{ couchbase_server_node }}:{{ addnode_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }} {{ ssl_verify }}"
       when: "not (couchbase_server_node == couchbase_server_primary_node ) and ipv6_enabled"
 
     - name: COUCHBASE SERVER | Rebalance cluster (6.X and up) | configure IPv4

--- a/libraries/provision/ansible/playbooks/install-couchbase-server-package.yml
+++ b/libraries/provision/ansible/playbooks/install-couchbase-server-package.yml
@@ -166,6 +166,10 @@
         protocol: ""
       when: "( {{ cb_major_version['stdout'] | search('\\b[1-4]\\b') }} ) or ( '5.0.0' in cb_full_version.stdout )"
 
+    - set_fact:
+        protocol: "https"
+      when: "( {{ cb_major_version['stdout'] | search('\\b[7]\\b') }} ) or ( '7.1.0' in cb_full_version.stdout )"
+
     - name: COUCHBASE SERVER | Join additional cluster nodes | configure IPv6
       shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ protocol }}://[{{ couchbase_server_primary_node }}]:{{ couchbase_server_admin_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ protocol }}://[{{ couchbase_server_node }}]:{{ couchbase_server_admin_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }}"
       when: "not (couchbase_server_node == couchbase_server_primary_node ) and (not {{ cb_major_version['stdout'] | search('\\b[1-5]\\b') }}) and ipv6_enabled"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ botocore==1.4.5
 cffi==1.10.0
 colorama==0.3.3
 configparser==3.5.0
-couchbase==3.0.10
+couchbase==3.2.3
 cryptography==2.8
 docker==2.2.1
 docker-pycreds==0.2.1
@@ -53,7 +53,7 @@ requests==2.19.0
 requests-ntlm==0.3.0
 rsa==3.3
 s3transfer==0.0.1
-six==1.10.0
+six==1.15.0
 termcolor==1.1.0
 troposphere==1.5.0
 websocket-client==0.40.0


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Fixed server-add cli commands to work with 7.1.0
7.1.0 runs : 
http://uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-functional-tests-xattrs-userViews-ServerSsl/476/testReport/
http://uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-functional-tests-base-cc/3207/testReport/
http://uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-functional-tests-topology-cc/516/testReport/
http://uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-functional-tests-topology-xattrs-userView-ServerSsl/2386/testReport/

http://uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-functional-tests-xattrs-userViews-ServerSsl/479/testReport/ -> ran on 7.0.0 to make sure existing behavior is not broken