### PR TITLE
Empty DB name API test for ios

### DIFF
--- a/testsuites/CBLTester/CBL_Functional_tests/APITests/test_database.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/APITests/test_database.py
@@ -21,7 +21,7 @@ class TestDatabase(object):
 
         log_info("check for error message: {}".format(err_msg))
 
-        if "android" in self.liteserv_platform and db_name == "":
+        if "android" or "ios" in self.liteserv_platform and db_name == "":
             pytest.skip("Test not applicable for ios")
 
         if len(db_name) >= 128 and (self.liteserv_platform != "ios" or self.liteserv_platform != "android"):


### PR DESCRIPTION
test fix

#### Fixes #.

- [x] Ran `flake8`
- [ ] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Api test used to skipped, now it is running due to c changes
-

