### PR TITLE
adding checkup condition for xattrs

### DIFF
--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_sg_attachments.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_sg_attachments.py
@@ -461,6 +461,9 @@ def test_attachment_expire_purged_doc(params_from_base_test_setup, delete_doc_ty
     if sync_gateway_version < "3.0.0":
         pytest.skip('This test cannot run with sg version below 3.0.0')
 
+    if not xattrs_enabled:
+        pytest.skip('--xattrs is not enabled, so skipping the test')
+
     channels = ["Replication"]
     sg_client = MobileRestClient()
 
@@ -544,7 +547,6 @@ def test_attachment_expire_purged_doc(params_from_base_test_setup, delete_doc_ty
     with pytest.raises(DocumentNotFoundException) as nfe:
         sdk_client.get(doc_id)
     log_info(nfe)
-    if xattrs_enabled:
-        with pytest.raises(DocumentNotFoundException) as nfe:
-            sdk_client.get(attachment_ids[0])
-        log_info(nfe)
+    with pytest.raises(DocumentNotFoundException) as nfe:
+        sdk_client.get(attachment_ids[0])
+    log_info(nfe)

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_sg_attachments.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_sg_attachments.py
@@ -454,6 +454,7 @@ def test_attachment_expire_purged_doc(params_from_base_test_setup, delete_doc_ty
     sg_config = params_from_base_test_setup["sg_config"]
     db = params_from_base_test_setup["db"]
     cbl_db = params_from_base_test_setup["source_db"]
+    xattrs_enabled = params_from_base_test_setup["xattrs_enabled"]
     num_of_docs = 10
     sg_conf_name = "listener_tests/listener_tests_no_conflicts"
 
@@ -543,6 +544,7 @@ def test_attachment_expire_purged_doc(params_from_base_test_setup, delete_doc_ty
     with pytest.raises(DocumentNotFoundException) as nfe:
         sdk_client.get(doc_id)
     log_info(nfe)
-    with pytest.raises(DocumentNotFoundException) as nfe:
-        sdk_client.get(attachment_ids[0])
-    log_info(nfe)
+    if xattrs_enabled:
+        with pytest.raises(DocumentNotFoundException) as nfe:
+            sdk_client.get(attachment_ids[0])
+        log_info(nfe)


### PR DESCRIPTION
#### Fixes #. deal w/o xattrs for expired documents

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- added xattrs_enabled if condition to the test case.

