### PR TITLE
Adjust the ud tags check to ignore binary files

### DIFF
--- a/testsuites/syncgateway/functional/tests/test_log_redaction.py
+++ b/testsuites/syncgateway/functional/tests/test_log_redaction.py
@@ -597,6 +597,8 @@ def verify_udTags_in_zippedFile(zip_file_name):
             if redact_match:
                 redact_content = redact_match.group(0)
             else:
+                if "Binary file" in str(key):
+                    continue
                 assert False, "Line: " + key + "Value: " + value + " did not match <ud>.+</ud> regex"
             if re.search("[a-f0-9]{40}", redact_content):
                 continue


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- 
-

