### PR TITLE
Update troposhere version to 4.0.2 for new mac mini to run.  Do not merge to master

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ rsa==3.3
 s3transfer==0.0.1
 six==1.15.0
 termcolor==1.1.0
-troposphere==1.5.0
+troposphere==4.0.2
 websocket-client==0.40.0
 wrapt==1.12.1
 xmltodict==0.10.2


### PR DESCRIPTION
#### Fixes #.

- [ ] Ran `flake8`
- [ ] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- 
-

