### PR TITLE
Fix/scoeps and collections test

### DIFF
--- a/libraries/provision/clean_cluster.py
+++ b/libraries/provision/clean_cluster.py
@@ -3,7 +3,6 @@ import os
 from libraries.provision.ansible_runner import AnsibleRunner
 from keywords.exceptions import ProvisioningError
 from keywords.utils import log_info
-import libraries.provision.provision_cluster
 
 
 def clean_cluster(cluster_config, skip_couchbase_provision=False, server_platform="centos"):

--- a/libraries/testkit/admin.py
+++ b/libraries/testkit/admin.py
@@ -574,3 +574,13 @@ class Admin:
                 return False
             else:
                 raise Exception("Could not determine if the user exists due to the following error: " + str(e)) from e
+
+    def get_bucket_db(self, bucket):
+        dbs = self.get_dbs()
+        if not dbs:
+            return None
+        for db in dbs:
+            dbconfig = self.get_db_config(db)
+            if dbconfig["bucket"] == bucket:
+                return db
+        return None

--- a/testsuites/syncgateway/functional/tests/test_cbs_collections.py
+++ b/testsuites/syncgateway/functional/tests/test_cbs_collections.py
@@ -60,6 +60,9 @@ def scopes_collections_tests_fixture(params_from_base_test_setup):
 
         # SGW database creation
         pre_test_db_exists = admin_client.does_db_exist(db)
+        test_bucket_db = admin_client.get_bucket_db(bucket)
+        if test_bucket_db is not None:
+            admin_client.delete(test_bucket_db)
         if pre_test_db_exists is False:
             admin_client.create_db(db, data)
 


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

The scopes and collections setup did not check if there was a a db associated with a bucket. This should fix it.
The unused import is already in master, so the change to clean_cluster.py can be ignored
