### PR TITLE
Update cluster.py

### DIFF
--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -269,7 +269,7 @@ class Cluster:
                 playbook_vars["server_scheme"] = "couchbases"
                 playbook_vars["server_port"] = 11207
                 block_http_vars = {}
-                port_list = [8091, 8092, 8093, 8094, 8095, 8096, 11210, 11211]
+                port_list = ["8091:8096,11210:11211"]
                 for port in port_list:
                     block_http_vars["port"] = port
                     status = ansible_runner.run_ansible_playbook(
@@ -493,7 +493,7 @@ class Cluster:
             server_scheme_var = "couchbases"
             server_port_var = "11207"
             block_http_vars = {}
-            port_list = [8091, 8092, 8093, 8094, 8095, 8096, 11210, 11211]
+            port_list = ["8091:8096,11210:11211"]
             for port in port_list:
                 block_http_vars["port"] = port
                 status = ansible_runner.run_ansible_playbook(


### PR DESCRIPTION
put all ports to single run

#### Fixes #.

- [ ] Ran `flake8`
- [ ] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- 
-

