### PR TITLE
fix clean_cluster.py - restore firewall flushing

### DIFF
--- a/libraries/provision/clean_cluster.py
+++ b/libraries/provision/clean_cluster.py
@@ -17,6 +17,17 @@ def clean_cluster(cluster_config, skip_couchbase_provision=False, server_platfor
     if status != 0:
         raise ProvisioningError("Failed to removed previous installs")
 
+    # Clear firewall rules
+    if not skip_couchbase_provision:
+        status = ansible_runner.run_ansible_playbook("flush-cb-firewall.yml")
+        if status != 0:
+            raise ProvisioningError("Failed to flush firewall")
+
+    # Clear firewall rules
+    status = ansible_runner.run_ansible_playbook("flush-firewall.yml")
+    if status != 0:
+        raise ProvisioningError("Failed to flush firewall")
+
     # Reset to ntp time . Required for x509 tests to clock sync for couchbase server and sync gateway
     status = ansible_runner.run_ansible_playbook("reset-hosts.yml")
     if status != 0:


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

Restore lines to run flush-firewall.yml and flush-cb-firewall.yml, removed previously (https://github.com/couchbaselabs/mobile-testkit/commit/48562790f3fc1fca4326c3dd5915a5a772e7661e#diff-05c39c5bdeaa6e287d99f54b3b62232a1305e488e1bc77cbe026ad326e8ac657)

Fixes error when provisioning resulting in failure:
Oct 20 02:21:33 localhost.localdomain systemd[1]: sync_gateway.service: main process exited, code=exited, status=130/n/a
