### PR TITLE
Fix/skip collections users view

### DIFF
--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -524,7 +524,8 @@ def params_from_base_suite_setup(request):
         "prometheus_enabled": prometheus_enabled,
         "disable_persistent_config": disable_persistent_config,
         "need_sgw_admin_auth": need_sgw_admin_auth,
-        "sync_gateway_previous_version": sync_gateway_previous_version
+        "sync_gateway_previous_version": sync_gateway_previous_version,
+        "use_views": use_views
     }
 
     log_info("Tearing down 'params_from_base_suite_setup' ...")
@@ -571,6 +572,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     need_sgw_admin_auth = params_from_base_suite_setup["need_sgw_admin_auth"]
     prometheus_enabled = request.config.getoption("--prometheus-enable")
     sync_gateway_previous_version = params_from_base_suite_setup["sync_gateway_previous_version"]
+    use_views = params_from_base_suite_setup["use_views"]
 
     test_name = request.node.name
     c = cluster.Cluster(cluster_config)
@@ -634,7 +636,8 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
         "disable_persistent_config": disable_persistent_config,
         "prometheus_enabled": prometheus_enabled,
         "need_sgw_admin_auth": need_sgw_admin_auth,
-        "sync_gateway_previous_version": sync_gateway_previous_version
+        "sync_gateway_previous_version": sync_gateway_previous_version,
+        "use_views": use_views
     }
 
     # Code after the yield will execute when each test finishes

--- a/testsuites/syncgateway/functional/tests/test_cbs_collections.py
+++ b/testsuites/syncgateway/functional/tests/test_cbs_collections.py
@@ -26,6 +26,9 @@ def teardown_doc_fixture():
 
 @pytest.fixture
 def scopes_collections_tests_fixture(params_from_base_test_setup):
+    if params_from_base_test_setup["use_views"]:
+        pytest.skip("""It is not necessary to run scopes and collections tests with views.
+                    When it is enabled, there is a problem that affects the rest of the tests suite.""")
     try:  # To be able to teardon in case of a setup error
         # get/set the parameters
         global admin_client

--- a/testsuites/syncgateway/functional/tests/test_cbs_collections.py
+++ b/testsuites/syncgateway/functional/tests/test_cbs_collections.py
@@ -26,9 +26,10 @@ def teardown_doc_fixture():
 
 @pytest.fixture
 def scopes_collections_tests_fixture(params_from_base_test_setup):
-    if params_from_base_test_setup["use_views"]:
-        pytest.skip("""It is not necessary to run scopes and collections tests with views.
-                    When it is enabled, there is a problem that affects the rest of the tests suite.""")
+    if "use_views" in params_from_base_test_setup:
+        if params_from_base_test_setup["use_views"]:
+            pytest.skip("""It is not necessary to run scopes and collections tests with views.
+                        When it is enabled, there is a problem that affects the rest of the tests suite.""")
     try:  # To be able to teardon in case of a setup error
         # get/set the parameters
         global admin_client

--- a/testsuites/syncgateway/functional/tests/test_cbs_collections.py
+++ b/testsuites/syncgateway/functional/tests/test_cbs_collections.py
@@ -8,13 +8,13 @@ from keywords.constants import RBAC_FULL_ADMIN
 from libraries.testkit.admin import Admin
 from keywords.exceptions import RestError
 from requests.auth import HTTPBasicAuth
-from utilities.cluster_config_utils import get_sg_use_views
 
 # test file shared variables
 bucket = "data-bucket"
 sg_password = "password"
 admin_client = cb_server = sg_username = channels = client_auth = sg_url = None
 admin_auth = [RBAC_FULL_ADMIN['user'], RBAC_FULL_ADMIN['pwd']]
+is_using_views = False
 
 
 @pytest.fixture
@@ -26,7 +26,7 @@ def teardown_doc_fixture():
 
 
 @pytest.fixture
-def scopes_collections_tests_fixture(params_from_base_test_setup):
+def scopes_collections_tests_fixture(params_from_base_test_setup, params_from_base_suite_setup):
     # get/set the parameters
     global admin_client
     global cb_server
@@ -34,6 +34,8 @@ def scopes_collections_tests_fixture(params_from_base_test_setup):
     global channels
     global client_auth
     global sg_url
+    global is_using_views
+    is_using_views = params_from_base_suite_setup["use_views"]
 
     try:  # To be able to teardon in case of a setup error
         pre_test_db_exists = pre_test_user_exists = sg_client = sg_url = sg_admin_url = None
@@ -95,7 +97,7 @@ def scopes_collections_tests_fixture(params_from_base_test_setup):
 @pytest.mark.syncgateway
 @pytest.mark.collections
 def test_document_only_under_named_scope(scopes_collections_tests_fixture, teardown_doc_fixture):
-    if is_use_views_enabled:
+    if is_using_views:
         pytest.skip("""It is not necessary to run scopes and collections tests with views.
                 When it is enabled, there is a problem that affects the rest of the tests suite.""")
 
@@ -135,7 +137,7 @@ def test_change_collection_name(scopes_collections_tests_fixture):
     4. Rename the collection to the original collection
     5. Verify that the document is accessible again
     """
-    if is_use_views_enabled:
+    if is_using_views:
         pytest.skip("""It is not necessary to run scopes and collections tests with views.
                 When it is enabled, there is a problem that affects the rest of the tests suite.""")
 
@@ -181,7 +183,7 @@ def test_collection_channels(scopes_collections_tests_fixture):
     7. Check that _bulk_get can get documents that are in the user's channel
     8. Check that _bulk_get cannot get a document from the "right" channel but the wrong collection
     """
-    if is_use_views_enabled:
+    if is_using_views:
         pytest.skip("""It is not necessary to run scopes and collections tests with views.
                 When it is enabled, there is a problem that affects the rest of the tests suite.""")
 
@@ -258,8 +260,3 @@ def rename_a_single_collection(db, scope, new_name):
     data = {"bucket": bucket, "scopes": {scope: {"collections": {new_name: {}}}}, "num_index_replicas": 0}
     admin_client.post_db_config(db, data)
     admin_client.wait_for_db_online(db, 60)
-
-
-def is_use_views_enabled(params_from_base_test_setup):
-    cluster_config = params_from_base_test_setup["cluster_config"]
-    return get_sg_use_views(cluster_config)


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

Skipping the scopes  and. collections tests when user views is enabled because it's causing all the tests in the run to fail.

I'm not sure how relevant it is to test scopes and collections with views enabled anyway (I'll check if this needs to be undone).

