### PR TITLE
Test/restricted_collection

### DIFF
--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -1182,8 +1182,8 @@ class CouchbaseServer:
 
         self._wait_for_rebalance_complete()
         return True
-    
-    def add_simple_document(self, bucket, scope, collection, doc_id, ipv6 = False):
+
+    def add_simple_document(self, bucket, scope, collection, doc_id, ipv6=False):
         """Add a simple document to a collection"""
         connection_url = choose_connection_url(self.cbs_ssl, ipv6, self.host)
         sdk_client = get_cluster(connection_url, bucket, get_bucket=True)
@@ -1197,7 +1197,7 @@ class CouchbaseServer:
             raise Exception("Tried to insert document that already exists: " + str(e)) from e
         return result
 
-    def get_document(self, bucket, scope, collection, doc_id, ipv6 = False):
+    def get_document(self, bucket, scope, collection, doc_id, ipv6=False):
         """Retrieve a document from a collection"""
         connection_url = choose_connection_url(self.cbs_ssl, ipv6, self.host)
         sdk_client = get_cluster(connection_url, bucket, get_bucket=True)

--- a/libraries/testkit/admin.py
+++ b/libraries/testkit/admin.py
@@ -531,6 +531,18 @@ class Admin:
         resp.raise_for_status()
         return resp.status_code
 
+    # GET /{db}/_config/import_filter
+    def get_db_import_filter(self, db):
+        if not is_admin_auth_disabled(self.cluster_config):
+            self.auth = HTTPBasicAuth(RBAC_FULL_ADMIN['user'], RBAC_FULL_ADMIN['pwd'])
+        if self.auth:
+            resp = requests.get("{0}/{1}/_config/import_filter".format(self.admin_url, db), headers=self._headers, timeout=settings.HTTP_REQ_TIMEOUT, verify=False, auth=self.auth)
+        else:
+            resp = requests.get("{0}/{1}/_config/import_filter".format(self.admin_url, db), headers=self._headers, timeout=settings.HTTP_REQ_TIMEOUT, verify=False)
+        log.info("GET {}".format(resp.url))
+        resp.raise_for_status()
+        return resp.json()
+
     # PUT /_config
     def put_config(self, config):
         if not is_admin_auth_disabled(self.cluster_config):

--- a/testsuites/syncgateway/functional/tests/test_cbs_collections.py
+++ b/testsuites/syncgateway/functional/tests/test_cbs_collections.py
@@ -293,11 +293,11 @@ def test_restricted_collection(scopes_collections_tests_fixture):
 
     # 3. Sync one collection to SGW
     db_config = {"bucket": bucket, "scopes": {scope: {"collections": {collection: {}}}}, "num_index_replicas": 0,
-                "import_docs": True, "enable_shared_bucket_access": True}
+                 "import_docs": True, "enable_shared_bucket_access": True}
     admin_client.post_db_config(db, db_config)
     admin_client.wait_for_db_online(db, 60)
 
-    #4. Check that documents in the server restricted collection are not accesible via SGW
+    # 4. Check that documents in the server restricted collection are not accesible via SGW
     all_docs = sg_client.get_all_docs(sg_admin_url, db)
     assert(all_docs["total_rows"] == 1)
     assert(all_docs["rows"][0]["id"] == doc_1_key)

--- a/testsuites/syncgateway/functional/tests/test_cbs_collections.py
+++ b/testsuites/syncgateway/functional/tests/test_cbs_collections.py
@@ -285,11 +285,11 @@ def test_restricted_collection(scopes_collections_tests_fixture):
     doc_2_key = "doc_2" + random_suffix
 
     # 2. Add a document to each collection
-    cb_server.add_simple_document(bucket, scope, collection, doc_1_key)
-    cb_server.add_simple_document(bucket, scope, second_collection, doc_2_key)
+    cb_server.add_simple_document(doc_1_key, bucket, scope, collection)
+    cb_server.add_simple_document(doc_2_key, bucket, scope, second_collection)
 
-    assert(cb_server.get_document(bucket, scope, collection, doc_1_key)["id"] == doc_1_key)
-    assert(cb_server.get_document(bucket, scope, second_collection, doc_2_key)["id"] == doc_2_key)
+    assert(cb_server.get_document(doc_1_key, bucket, scope, collection)["id"] == doc_1_key), "Error in test setup: failed to add document to server under " + bucket + "." + scope + "." + collection
+    assert(cb_server.get_document(doc_2_key, bucket, scope, second_collection)["id"] == doc_2_key), "Error in test setup: failed to add document to server under " + bucket + "." + scope + "." + second_collection
 
     # 3. Sync one collection to SGW
     db_config = {"bucket": bucket, "scopes": {scope: {"collections": {collection: {}}}}, "num_index_replicas": 0,
@@ -299,8 +299,8 @@ def test_restricted_collection(scopes_collections_tests_fixture):
 
     # 4. Check that documents in the server restricted collection are not accesible via SGW
     all_docs = sg_client.get_all_docs(sg_admin_url, db)
-    assert(all_docs["total_rows"] == 1)
-    assert(all_docs["rows"][0]["id"] == doc_1_key)
+    assert(all_docs["total_rows"] == 1), "Number of expected documents in Sync Gateway database does not match expected. Expected 1; Found " + str(all_docs["total_rows"])
+    assert(all_docs["rows"][0]["id"] == doc_1_key), "Sync Gateway database document has wrong ID, possibly due to accessing document under server restricted collection"
 
 
 def rename_a_single_scope_or_collection(db, scope, new_name):

--- a/utilities/cluster_config_utils.py
+++ b/utilities/cluster_config_utils.py
@@ -38,14 +38,12 @@ class CustomConfigParser(configparser.RawConfigParser):
             fp.write("\n")
 
 
-def get_cluster(url, bucket_name, get_bucket=False):
+def get_cluster(url, bucket_name):
     timeout_options = ClusterTimeoutOptions(kv_timeout=timedelta(seconds=180), query_timeout=timedelta(seconds=300),
                                             config_total_timeout=timedelta(seconds=600))
     options = ClusterOptions(PasswordAuthenticator("Administrator", "password"), timeout_options=timeout_options)
     cluster = Cluster(url, options)
     cluster = cluster.bucket(bucket_name)
-    if get_bucket:
-        return cluster
     return cluster.default_collection()
 
 

--- a/utilities/cluster_config_utils.py
+++ b/utilities/cluster_config_utils.py
@@ -38,7 +38,7 @@ class CustomConfigParser(configparser.RawConfigParser):
             fp.write("\n")
 
 
-def get_cluster(url, bucket_name, get_bucket = False):
+def get_cluster(url, bucket_name, get_bucket=False):
     timeout_options = ClusterTimeoutOptions(kv_timeout=timedelta(seconds=180), query_timeout=timedelta(seconds=300),
                                             config_total_timeout=timedelta(seconds=600))
     options = ClusterOptions(PasswordAuthenticator("Administrator", "password"), timeout_options=timeout_options)

--- a/utilities/cluster_config_utils.py
+++ b/utilities/cluster_config_utils.py
@@ -38,12 +38,14 @@ class CustomConfigParser(configparser.RawConfigParser):
             fp.write("\n")
 
 
-def get_cluster(url, bucket_name):
+def get_cluster(url, bucket_name, get_bucket = False):
     timeout_options = ClusterTimeoutOptions(kv_timeout=timedelta(seconds=180), query_timeout=timedelta(seconds=300),
                                             config_total_timeout=timedelta(seconds=600))
     options = ClusterOptions(PasswordAuthenticator("Administrator", "password"), timeout_options=timeout_options)
     cluster = Cluster(url, options)
     cluster = cluster.bucket(bucket_name)
+    if get_bucket:
+        return cluster
     return cluster.default_collection()
 
 


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:
Sync Gateway scopes and collections test for verifying documents in a server only collection are not pulled by Sync Gateway.

