### PR TITLE
Adjust the CBL Java code to old releases and latest Python

### DIFF
--- a/keywords/TestServerJavaWS.py
+++ b/keywords/TestServerJavaWS.py
@@ -25,21 +25,21 @@ class TestServerJavaWS(TestServerBase):
         else:
             self.build_type = "enterprise"
         if self.build is None:
-            self.package_name = "CBLTestServer-Java-WS-{}-{}".format(self.build_type, self.version)
+            self.package_name = "CBLTestServer-Java-WS-{}-{}".format(self.version, self.build_type)
             self.download_url = "{}/couchbase-lite-java/{}/{}.war".format(RELEASED_BUILDS, self.version, self.package_name)
             if community_enabled:
                 self.cbl_core_lib_name = "couchbase-lite-java-{}".format(self.version)
             else:
                 self.cbl_core_lib_name = "couchbase-lite-java-ee-{}".format(self.version)
 
-            self.download_corelib_url = "{}/couchbase-lite-java/{}/{}/{}.zip".format(RELEASED_BUILDS, self.version, self.build, self.cbl_core_lib_name)
+            self.download_corelib_url = "{}/couchbase-lite-java/{}/{}.zip".format(RELEASED_BUILDS, self.version, self.cbl_core_lib_name)
         else:
             self.package_name = "CBLTestServer-Java-WS-{}-{}".format(self.version_build, self.build_type)
             self.download_url = "{}/couchbase-lite-java/{}/{}/{}.war".format(LATEST_BUILDS, self.version, self.build, self.package_name)
             if community_enabled:
                 self.cbl_core_lib_name = "couchbase-lite-java-{}-{}".format(self.version, self.build)
             else:
-                self.cbl_core_lib_name = "couchbase-lite-java-ee-{}-{}".format(self.version, self.build)
+                self.cbl_core_lib_name = "couchbase-lite-java-enterprise-{}-{}".format(self.version, self.build)
             self.download_corelib_url = "{}/couchbase-lite-java/{}/{}/{}.zip".format(LATEST_BUILDS, self.version, self.build, self.cbl_core_lib_name)
 
         self.build_name = "TestServer-java-WS-{}-{}".format(self.build_type, self.version_build)
@@ -117,7 +117,7 @@ class TestServerJavaWS(TestServerBase):
             # download war file to a remote Windows server machine
             status = self.ansible_runner.run_ansible_playbook("download-testserver-java-ws-msft.yml", extra_vars={
                 "testserver_download_url": self.download_url,
-                "cblite_download_url": self.download_corelib_url.replace("-ee-","-enterprise-"),
+                "cblite_download_url": self.download_corelib_url,
                 "war_package_name": self.package_name,
                 "core_package_name": self.cbl_core_lib_name,
                 "build_name": self.build_name
@@ -126,7 +126,7 @@ class TestServerJavaWS(TestServerBase):
             # download war file to a remote non-Windows machine
             status = self.ansible_runner.run_ansible_playbook("download-testserver-java-ws.yml", extra_vars={
                 "testserver_download_url": self.download_url,
-                "cblite_download_url": self.download_corelib_url.replace("-ee-","-enterprise-"),
+                "cblite_download_url": self.download_corelib_url,
                 "war_package_name": self.package_name,
                 "core_package_name": self.cbl_core_lib_name
             })

--- a/libraries/provision/ansible/playbooks/install-testserver-java-ws-msft.yml
+++ b/libraries/provision/ansible/playbooks/install-testserver-java-ws-msft.yml
@@ -63,4 +63,4 @@
   - win_shell: copy C:\Users\{{ ansible_user }}\Desktop\TestServer\{{ build_name }}\{{ war_package_name }}.war "{{ ansible_env.CATALINA_BASE }}\\webapps\\ROOT.war"
 
   - debug: msg="Copy CouchbaseLite supporting jar files"
-  - win_shell: copy C:\Users\{{ ansible_user }}\Desktop\TestServer\{{ build_name }}\{{ core_package_name }}\lib\*.jar "{{ ansible_env.CATALINA_BASE }}\\lib"
+  - win_shell: copy C:\Users\{{ ansible_user }}\Desktop\TestServer\{{ build_name }}*\{{ core_package_name }}\lib\*.jar "{{ ansible_env.CATALINA_BASE }}\\lib"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ backports.functools-lru-cache==1.3
 backports.ssl-match-hostname==3.5.0.1
 boto3==1.3
 botocore==1.4.5
-cffi==1.10.0
+cffi==1.15.1
 colorama==0.3.3
 configparser==3.5.0
 couchbase==3.2.7
@@ -32,7 +32,7 @@ netifaces==0.10.4
 olefile==0.44
 packaging==16.8
 paramiko==2.1.5
-Pillow==6.2.0
+Pillow==9.3.0
 py==1.5.1
 pyasn1==0.2.3
 pycodestyle==2.3.1


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Upgrade dependencies to support Python 3.8 that's on the Java tests slaves
- Adjust the binaries that are being pulled to support older releases.


