### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ docker-pycreds==0.2.1
 docutils==0.12
 ecdsa==0.13
 enum34==1.1.6
-flake8==3.3.0
+flake8==3.9.2
 futures==3.1.1
 idna==2.5
 ipaddress==1.0.18
@@ -34,10 +34,10 @@ paramiko==2.5.0
 Pillow==9.2.0
 py==1.5.1
 pyasn1==0.2.3
-pycodestyle==2.3.1
+pycodestyle==2.7.0
 pycparser==2.17
 pycrypto==2.6.1
-pyflakes==1.5.0
+pyflakes==2.3.0
 PyJWT==1.4.0
 pylint==1.6.4
 pyparsing==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ paramiko==2.5.0
 Pillow==9.2.0
 py==1.5.1
 pyasn1==0.2.3
-pycodestyle==2.7.0
+pycodestyle==2.3.1
 pycparser==2.17
 pycrypto==2.6.1
 pyflakes==1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ pyasn1==0.2.3
 pycodestyle==2.7.0
 pycparser==2.17
 pycrypto==2.6.1
-pyflakes==2.3.0
+pyflakes==1.5.0
 PyJWT==1.4.0
 pylint==1.6.4
 pyparsing==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ docker-pycreds==0.2.1
 docutils==0.12
 ecdsa==0.13
 enum34==1.1.6
-flake8==3.9.2
+flake8==3.8
 futures==3.1.1
 idna==2.5
 ipaddress==1.0.18
@@ -34,10 +34,10 @@ paramiko==2.5.0
 Pillow==9.2.0
 py==1.5.1
 pyasn1==0.2.3
-pycodestyle==2.7.0
+pycodestyle==2.6.0
 pycparser==2.17
 pycrypto==2.6.1
-pyflakes==2.3.0
+pyflakes==2.2.0
 PyJWT==1.4.0
 pylint==1.6.4
 pyparsing==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ docker-pycreds==0.2.1
 docutils==0.12
 ecdsa==0.13
 enum34==1.1.6
-flake8==3.8
+flake8==3.3
 futures==3.1.1
 idna==2.5
 ipaddress==1.0.18
@@ -34,10 +34,10 @@ paramiko==2.5.0
 Pillow==9.2.0
 py==1.5.1
 pyasn1==0.2.3
-pycodestyle==2.6.0
+pycodestyle==2.3.1
 pycparser==2.17
 pycrypto==2.6.1
-pyflakes==2.2.0
+pyflakes==1.5.0
 PyJWT==1.4.0
 pylint==1.6.4
 pyparsing==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,14 +10,14 @@ botocore==1.4.5
 cffi==1.15.1
 colorama==0.3.3
 configparser==3.5.0
-couchbase==3.2.7
+#couchbase==3.2.7
 cryptography==37.0.4
 docker==2.2.1
 docker-pycreds==0.2.1
 docutils==0.12
 ecdsa==0.13
 enum34==1.1.6
-flake8==3.9.2
+flake8==3.3.0
 futures==3.1.1
 idna==2.5
 ipaddress==1.0.18

--- a/setup.sh
+++ b/setup.sh
@@ -52,3 +52,4 @@ export ANSIBLE_CONFIG=$currentdir/ansible.cfg
 
 pip install --upgrade pip==20.1.1
 pip install couchbase==3.2.7
+pip install importlib-metadata==4.3.0

--- a/setup.sh
+++ b/setup.sh
@@ -49,3 +49,6 @@ $PIP install -r requirements.txt
 export PYTHONPATH=$PYTHONPATH:$currentdir/
 
 export ANSIBLE_CONFIG=$currentdir/ansible.cfg
+
+pip install --upgrade pip==20.1.1
+pip install couchbase==3.2.7


### PR DESCRIPTION
We will not install couchbase==3.2.7 in requirement.  In stead, we install it in setup.sh because pip version 20.1.1 will install couchbase 3.2.7 ok on python 3.7.x Downgrade flake8 to 3.3.0 because 3.9.x break android api tests

#### Fixes #.

- [ ] Ran `flake8`
- [ ] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- 
-

