### PR TITLE
Update test_restricted_collection to work with multi collections

### DIFF
--- a/testsuites/syncgateway/functional/tests/test_cbs_collections.py
+++ b/testsuites/syncgateway/functional/tests/test_cbs_collections.py
@@ -305,7 +305,7 @@ def test_restricted_collection(scopes_collections_tests_fixture):
 
     # 4. Check that documents in the server restricted collection are not accesible via SGW
     all_docs_ids = []
-    
+
     for row in (sg_client.get_all_docs(sg_admin_url, db, scope=scope, collection=collection)["rows"]):
         all_docs_ids.append(row["id"])
     for row in (sg_client.get_all_docs(sg_admin_url, db, scope=scope, collection=second_collection)["rows"]):


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

Update test to use multiple collections on CBServer and SGW.
Change get_all_docs API call to work for non-default scope.