### PR TITLE
Use '-' instead of '_' in the trace_logs flag, for consistency

### DIFF
--- a/testsuites/conftest.py
+++ b/testsuites/conftest.py
@@ -7,7 +7,7 @@ def pytest_addoption(parser):
                      help="Value can be 'failed' (or) 'passed' (or) 'failed=<junit_xml_path (or) "
                      "jenkins_build_url>' (or) 'passed=<junit_xml_path or "
                      "jenkins_build_url>' (or) 'file=<filename>'")
-    parser.addoption("--trace_logs", action="store_true",
+    parser.addoption("--trace-logs", action="store_true",
                      help="Enable trace level logs for Sync Gateway, accessed via SSHing into machine running SGW "
                      "and navigating to /tmp/sg_logs/")
 

--- a/testsuites/syncgateway/functional/custom_port/conftest.py
+++ b/testsuites/syncgateway/functional/custom_port/conftest.py
@@ -183,6 +183,10 @@ def pytest_addoption(parser):
                      help="Enabling CBS developer preview",
                      default=False)
 
+    parser.addoption("--trace-logs", action="store_true",
+                     help="Enable trace level logs for Sync Gateway, accessed via SSHing into machine running SGW "
+                     "and navigating to /tmp/sg_logs/")
+
 # This will be called once for the at the beggining of the execution in the 'tests/' directory
 # and will be torn down, (code after the yeild) when all the test session has completed.
 # IMPORTANT: Tests in 'tests/' should be executed in their own test run and should not be
@@ -226,7 +230,7 @@ def params_from_base_suite_setup(request):
     disable_tls_server = request.config.getoption("--disable-tls-server")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
-    trace_logs = request.config.getoption("--trace_logs")
+    trace_logs = request.config.getoption("--trace-logs")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)

--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -191,6 +191,10 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="Disable Admin auth")
 
+    parser.addoption("--disable-admin-auth",
+                     action="store_true",
+                     help="Disable Admin auth")
+
 
 # This will be called once for the at the beggining of the execution in the 'tests/' directory
 # and will be torn down, (code after the yeild) when all the test session has completed.
@@ -236,7 +240,7 @@ def params_from_base_suite_setup(request):
     sync_gateway_previous_version = request.config.getoption("--sync-gateway-previous-version")
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
-    trace_logs = request.config.getoption("--trace_logs")
+    trace_logs = request.config.getoption("--trace-logs")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)

--- a/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/load_balancer/conftest.py
@@ -52,7 +52,7 @@ def params_from_base_suite_setup(request):
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_tls_server = request.config.getoption("--disable-tls-server")
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
-    trace_logs = request.config.getoption("--trace_logs")
+    trace_logs = request.config.getoption("--trace-logs")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_accels/conftest.py
@@ -46,7 +46,7 @@ def params_from_base_suite_setup(request):
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
-    trace_logs = request.config.getoption("--trace_logs")
+    trace_logs = request.config.getoption("--trace-logs")
 
     log_info("server_version: {}".format(server_version))
     log_info("sync_gateway_version: {}".format(sync_gateway_version))

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/conftest.py
@@ -54,7 +54,7 @@ def params_from_base_suite_setup(request):
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_tls_server = request.config.getoption("--disable-tls-server")
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
-    trace_logs = request.config.getoption("--trace_logs")
+    trace_logs = request.config.getoption("--trace-logs")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -54,7 +54,7 @@ def params_from_base_suite_setup(request):
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_tls_server = request.config.getoption("--disable-tls-server")
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
-    trace_logs = request.config.getoption("--trace_logs")
+    trace_logs = request.config.getoption("--trace-logs")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)

--- a/testsuites/syncgateway/system/conftest.py
+++ b/testsuites/syncgateway/system/conftest.py
@@ -183,7 +183,7 @@ def params_from_base_suite_setup(request):
     disable_tls_server = request.config.getoption("--disable-tls-server")
 
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
-    trace_logs = request.config.getoption("--trace_logs")
+    trace_logs = request.config.getoption("--trace-logs")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)

--- a/testsuites/syncgateway/upgrade/automatic_migration/conftest.py
+++ b/testsuites/syncgateway/upgrade/automatic_migration/conftest.py
@@ -216,7 +216,7 @@ def params_from_base_suite_setup(request):
     skip_couchbase_provision = request.config.getoption("--skip-couchbase-provision")
     enable_cbs_developer_preview = request.config.getoption("--enable-cbs-developer-preview")
     disable_persistent_config = request.config.getoption("--disable-persistent-config")
-    trace_logs = request.config.getoption("--trace_logs")
+    trace_logs = request.config.getoption("--trace-logs")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_version, sync_gateway_version)

--- a/testsuites/syncgateway/upgrade/liteserv/conftest.py
+++ b/testsuites/syncgateway/upgrade/liteserv/conftest.py
@@ -211,7 +211,7 @@ def params_from_base_suite_setup(request):
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_tls_server = request.config.getoption("--disable-tls-server")
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
-    trace_logs = request.config.getoption("--trace_logs")
+    trace_logs = request.config.getoption("--trace-logs")
 
     if xattrs_enabled and version_is_binary(sync_gateway_version):
         check_xattr_support(server_upgraded_version, sync_gateway_upgraded_version)

--- a/testsuites/syncgateway/upgrade/testserver/sg_replicate/conftest.py
+++ b/testsuites/syncgateway/upgrade/testserver/sg_replicate/conftest.py
@@ -252,7 +252,7 @@ def params_from_base_suite_setup(request):
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
     disable_load_balancer = request.config.getoption("--disable-load-balancer")
 
-    trace_logs = request.config.getoption("--trace_logs")
+    trace_logs = request.config.getoption("--trace-logs")
 
     test_name = request.node.name
 

--- a/testsuites/syncgateway/upgrade/testserver/sg_single_sgw/conftest.py
+++ b/testsuites/syncgateway/upgrade/testserver/sg_single_sgw/conftest.py
@@ -226,7 +226,7 @@ def params_from_base_suite_setup(request):
     enable_server_tls_skip_verify = request.config.getoption("--enable-server-tls-skip-verify")
     disable_tls_server = request.config.getoption("--disable-tls-server")
     disable_admin_auth = request.config.getoption("--disable-admin-auth")
-    trace_logs = request.config.getoption("--trace_logs")
+    trace_logs = request.config.getoption("--trace-logs")
 
     test_name = request.node.name
 


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- 
-

