### PR TITLE
Remove an option that was added by mistake

### DIFF
--- a/testsuites/syncgateway/functional/tests/conftest.py
+++ b/testsuites/syncgateway/functional/tests/conftest.py
@@ -191,10 +191,6 @@ def pytest_addoption(parser):
                      action="store_true",
                      help="Disable Admin auth")
 
-    parser.addoption("--disable-admin-auth",
-                     action="store_true",
-                     help="Disable Admin auth")
-
 
 # This will be called once for the at the beggining of the execution in the 'tests/' directory
 # and will be torn down, (code after the yeild) when all the test session has completed.


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- 
-

