### PR TITLE
Skip the collections tests in versions prior to 3.1.0

### DIFF
--- a/testsuites/syncgateway/functional/tests/test_cbs_collections.py
+++ b/testsuites/syncgateway/functional/tests/test_cbs_collections.py
@@ -40,6 +40,9 @@ def scopes_collections_tests_fixture(params_from_base_test_setup, params_from_ba
     global is_using_views
     is_using_views = params_from_base_suite_setup["use_views"]
 
+    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
+    if sync_gateway_version < "3.1.0":
+        pytest.skip('scopes and collection tests cannot be run in versions prior to 3.1.0')
     try:  # To be able to teardon in case of a setup error
         pre_test_db_exists = pre_test_user_exists = sg_client = sg_url = sg_admin_url = None
         random_suffix = str(uuid.uuid4())[:8]


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- 
-

