### PR TITLE
Revs test change

### DIFF
--- a/resources/sync_gateway_configs/listener_tests/multiple_sync_gateways_rev_cc.json
+++ b/resources/sync_gateway_configs/listener_tests/multiple_sync_gateways_rev_cc.json
@@ -1,0 +1,48 @@
+{
+    "interface":":4984",
+    "adminInterface": "0.0.0.0:4985",
+    {{ sslcert }}
+    {{ sslkey }}
+    {{ logging }}
+    {{ hide_product_version }}
+    {{ disable_persistent_config }}
+    {{ server_tls_skip_verify }}
+    {{ disable_tls_server }}
+    {{ disable_admin_auth }}
+    "databases":{
+        "sg_db1":{
+            {{ autoimport }}
+            {{ xattrs }}
+            {{ no_conflicts }}
+            "revs_limit": 23,
+            {{ sg_use_views }}
+            {{ num_index_replicas }}
+            {{ delta_sync }}
+            {{ cacertpath }}
+            {{ certpath }}
+            {{ keypath }}
+            "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
+            "bucket":"data-bucket-1",
+            "username":"data-bucket-1",
+            "password": "password",
+            "revs_limit": 23
+        },
+        "sg_db2":{
+            {{ autoimport }}
+            {{ xattrs }}
+            {{ no_conflicts }}
+            "revs_limit": 23,
+            {{ sg_use_views }}
+            {{ num_index_replicas }}
+            {{ delta_sync }}
+            {{ cacertpath }}
+            {{ certpath }}
+            {{ keypath }}
+            "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}",
+            "bucket":"data-bucket-2",
+            "username":"data-bucket-2",
+            "password": "password",
+            "revs_limit": 23
+        }
+    }
+}

--- a/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/test_replication_multiple_sgs.py
+++ b/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/test_replication_multiple_sgs.py
@@ -16,9 +16,9 @@ from keywords.constants import RBAC_FULL_ADMIN
 @pytest.mark.listener
 @pytest.mark.replication
 @pytest.mark.parametrize("sg_conf_name, num_of_docs", [
-    pytest.param('listener_tests/multiple_sync_gateways', 10, marks=pytest.mark.sanity),
-    ('listener_tests/multiple_sync_gateways', 100),
-    ('listener_tests/multiple_sync_gateways', 1000)
+    pytest.param('listener_tests/multiple_sync_gateways_rev', 10, marks=pytest.mark.sanity),
+    ('listener_tests/multiple_sync_gateways_rev', 100),
+    ('listener_tests/multiple_sync_gateways_rev', 1000)
 ])
 def test_multiple_sgs_with_differrent_revs_limit(params_from_base_test_setup, setup_customized_teardown_test, sg_conf_name, num_of_docs):
     """

--- a/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/test_replication_multiple_sgs.py
+++ b/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/test_replication_multiple_sgs.py
@@ -61,8 +61,8 @@ def test_multiple_sgs_with_differrent_revs_limit(params_from_base_test_setup, se
     sg2 = c.sync_gateways[1]
 
     # Setting revs_limit to sg1 and sg2
-    revs_limit1 = 25
-    revs_limit2 = 25
+    revs_limit1 = 23
+    revs_limit2 = 23
 
     admin = Admin(sg1)
     admin.admin_url = sg1.url

--- a/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/test_replication_multiple_sgs.py
+++ b/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/test_replication_multiple_sgs.py
@@ -10,7 +10,6 @@ from libraries.testkit.cluster import Cluster
 from libraries.testkit import cluster
 from libraries.testkit.admin import Admin
 from keywords.constants import CLUSTER_CONFIGS_DIR
-from utilities.cluster_config_utils import persist_cluster_config_environment_prop, copy_to_temp_conf
 from keywords.constants import RBAC_FULL_ADMIN
 
 
@@ -61,19 +60,9 @@ def test_multiple_sgs_with_differrent_revs_limit(params_from_base_test_setup, se
     sg1 = c.sync_gateways[0]
     sg2 = c.sync_gateways[1]
 
-    # Setting revs_limit to sg1
-    revs_limit1 = 23
-    temp_cluster_config = copy_to_temp_conf(cluster_config, sg_mode)
-    persist_cluster_config_environment_prop(temp_cluster_config, 'revs_limit', revs_limit1, property_name_check=False)
-    status = sg1.restart(config=sg_config, cluster_config=temp_cluster_config)
-    assert status == 0, "Syncgateway did not start after changing the revs_limit on sg1"
-
-    # Setting revs_limit to sg2
-    revs_limit2 = 23
-    temp_cluster_config = copy_to_temp_conf(cluster_config, sg_mode)
-    persist_cluster_config_environment_prop(temp_cluster_config, 'revs_limit', revs_limit2, property_name_check=False)
-    status = sg2.restart(config=sg_config, cluster_config=temp_cluster_config)
-    assert status == 0, "Syncgateway did not start after changing the revs_limit on sg2"
+    # Setting revs_limit to sg1 and sg2
+    revs_limit1 = 25
+    revs_limit2 = 25
 
     admin = Admin(sg1)
     admin.admin_url = sg1.url


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Change the revs test using multiple sync gateway to remove dependencies such as restart and --disable-persistent-config
- The changes make the particular test execution faster.

