### PR TITLE
Increase the number of nodes from 2 to 3 in the topology tests. 

### DIFF
--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -97,7 +97,7 @@ def params_from_base_suite_setup(request):
 
     # use base_cc cluster config if mode is "cc" or base_di cluster config if more is "di"
     # cluster_config = "{}/{}{}".format(CLUSTER_CONFIGS_DIR, cluster_config, mode)
-    cluster_config = "{}/multiple_sync_gateways_{}".format(CLUSTER_CONFIGS_DIR, mode)
+    cluster_config = "{}/three_sync_gateways_{}".format(CLUSTER_CONFIGS_DIR, mode)
     sg_config = sync_gateway_config_path_for_mode("sync_gateway_default_functional_tests", mode)
 
     if use_views:


### PR DESCRIPTION
it might affect the non-centos platforms, but that would need to be sorted later

#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- 
-

