### PR TITLE
Test RBAC for stats endpoints

### DIFF
--- a/libraries/testkit/cluster.py
+++ b/libraries/testkit/cluster.py
@@ -403,7 +403,7 @@ class Cluster:
             self.servers[0].create_buckets(bucket_names=bucket_name_set, cluster_config=self._cluster_config, ipv6=self.ipv6)
             log_info(">>> Waiting for Server: {} to be in a healthy state".format(self.servers[0].url))
             self.servers[0].wait_for_ready_state()
-        self.servers[0]._create_internal_rbac_user_by_roles('*', common_bucket_user, "mobile_sync_gateway")
+        self.servers[0]._create_internal_rbac_user_by_roles(common_bucket_user, "mobile_sync_gateway", bucketname="*")
         log_info(">>> Starting sync_gateway with configuration using setup_server_and_sgw: {}".format(cpc_config_path_full))
 
         # Extracing sgw config from sgw config file

--- a/pytest.ini
+++ b/pytest.ini
@@ -54,3 +54,4 @@ markers =
     views:          test that covers view i.e non GSI scenarios
     oscertify:     test that covers for os certification
     basicsgw:      test that covers all basic functionality on SGW
+    adminauth:     test that may require admin auth enabled for full functionality

--- a/testsuites/syncgateway/functional/tests/test_cbs_collections.py
+++ b/testsuites/syncgateway/functional/tests/test_cbs_collections.py
@@ -506,6 +506,7 @@ def test_import_filters(scopes_collections_tests_fixture):
 
 @pytest.mark.syncgateway
 @pytest.mark.collections
+@pytest.mark.adminauth
 def test_collection_stats(scopes_collections_tests_fixture):
     """
     1. Verify that global stats and scopes/collection stats can be procured via RBAC users

--- a/testsuites/syncgateway/functional/tests/test_cbs_collections.py
+++ b/testsuites/syncgateway/functional/tests/test_cbs_collections.py
@@ -537,7 +537,7 @@ def test_collection_stats(scopes_collections_tests_fixture):
     auths = [rbac_auth_sgw_dev_ops, rbac_auth_stats_reader, admin_auth]
     for auth in auths:
         stats = sg_client.get_expvars(sg_admin_url, auth)
-        verify_stats_retrieval(stats, auth)
+        verify_stats_retrieval(stats, auth, db, scope, collection)
 
     # 2. Add two new collections on CB server, rename SGW collection to map to it, adding new collection and enable import + sync functions
     second_collection = "second_collection" + random_suffix
@@ -631,7 +631,7 @@ def get_collection_stats(db, scope, collection, stats):
         return str(k)
 
 
-def verify_stats_retrieval(stats, auth):
+def verify_stats_retrieval(stats, auth, db, scope, collection):
     """
     Helper function for test_collection_stats
     Verify stats can be procured as RBAC roles sgw_dev_ops, external_stats_reader and full admin


### PR DESCRIPTION
- [ ] Ran `flake8`
- [ ] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:
Test that sync_gateway_dev_ops and external_stats_reader RBAC roles on CBServer can access _expvar endpoint on SGW admin port
