### PR TITLE
Adjust fixture teardown ordering to fix timeout error during teardown

### DIFF
--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
@@ -93,12 +93,6 @@ def scopes_collections_tests_fixture(params_from_base_test_setup):
     except Exception as e:
         raise e
     finally:
-        cb_server.delete_scope_if_exists(bucket, scope)
-        cb_server.delete_bucket(bucket)
-        cb_server.delete_bucket(bucket2)
-        if pre_test_is_bucket_exist:
-            cb_server.create_bucket(cluster_config, bucket)
-
         for key in sgs:
             admin_client = Admin(sgs[key]["sg_obj"])
             # Cleanup everything that was created
@@ -107,6 +101,12 @@ def scopes_collections_tests_fixture(params_from_base_test_setup):
             if (pre_test_db_exists is not None) and (pre_test_db_exists is False):
                 if admin_client.does_db_exist(sgs[key]["db"]) is True:
                     admin_client.delete_db(sgs[key]["db"])
+
+        cb_server.delete_scope_if_exists(bucket, scope)
+        cb_server.delete_scope_if_exists(bucket2, scope)
+        cb_server.delete_buckets()
+        if pre_test_is_bucket_exist:
+            cb_server.create_bucket(cluster_config, bucket)
 
 
 @pytest.mark.syncgateway


### PR DESCRIPTION
- [ ] Ran `flake8`
- [ ] Ran `run_repo_tests.sh`


