### PR TITLE
Fix/isgr scp with magma

### DIFF
--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -370,6 +370,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     errors = c.verify_alive(mode)
 
     # if the test failed pull logs
+    print("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" + request.node)
     if collect_logs or ("rep_call" in request.node and request.node.rep_call.failed) or len(errors) != 0:
         logging_helper = Logging()
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -370,7 +370,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     errors = c.verify_alive(mode)
 
     # if the test failed pull logs
-    print("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" + str(request.node))
-    if collect_logs or ("rep_call" in request.node and request.node.rep_call.failed) or len(errors) != 0:
+    print("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" + str(request.node()))
+    if collect_logs or ("rep_call" in request.node and request.node().rep_call.failed) or len(errors) != 0:
         logging_helper = Logging()
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -369,8 +369,12 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     c = cluster.Cluster(cluster_config)
     errors = c.verify_alive(mode)
 
+    try:
+        failures = request.node.rep_call.failed
+    except Exception:
+        failures = False
+
     # if the test failed pull logs
-    print("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" + str(request.node()))
-    if collect_logs or ("rep_call" in request.node and request.node().rep_call.failed) or len(errors) != 0:
+    if collect_logs or failures or len(errors) != 0:
         logging_helper = Logging()
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -370,6 +370,6 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     errors = c.verify_alive(mode)
 
     # if the test failed pull logs
-    if collect_logs or request.node.rep_call.failed or len(errors) != 0:
+    if collect_logs or ("rep_call" in request.node and request.node.rep_call.failed) or len(errors) != 0:
         logging_helper = Logging()
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/conftest.py
@@ -370,7 +370,7 @@ def params_from_base_test_setup(request, params_from_base_suite_setup):
     errors = c.verify_alive(mode)
 
     # if the test failed pull logs
-    print("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" + request.node)
+    print("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" + str(request.node))
     if collect_logs or ("rep_call" in request.node and request.node.rep_call.failed) or len(errors) != 0:
         logging_helper = Logging()
         logging_helper.fetch_and_analyze_logs(cluster_config=cluster_config, test_name=test_name)

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
@@ -59,8 +59,9 @@ def scopes_collections_tests_fixture(params_from_base_test_setup):
 
         pre_test_db_exists = pre_test_user_exists = sg_client = None
         cluster_config = params_from_base_test_setup["cluster_config"]
+        print("*****************************************************" + str(is_magma_enabled(cluster_config)))
         if is_magma_enabled(cluster_config):
-            pytest.skip("There is no need to test ISGR and scopes and collections. If that changes, the buckets quota needs to increase")
+            pytest.skip("It is not necessary to test ISGR with scopes and collections and MAGMA")
         cluster_helper = ClusterKeywords(cluster_config)
         topology = cluster_helper.get_cluster_topology(cluster_config)
         cbs_url = topology["couchbase_servers"][0]

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
@@ -8,6 +8,7 @@ from keywords.ClusterKeywords import ClusterKeywords
 from libraries.testkit.cluster import Cluster
 from libraries.testkit.admin import Admin
 from keywords import couchbaseserver
+from utilities.cluster_config_utils import is_magma_enabled
 
 # test file shared variables
 bucket = "data-bucket"
@@ -58,6 +59,8 @@ def scopes_collections_tests_fixture(params_from_base_test_setup):
 
         pre_test_db_exists = pre_test_user_exists = sg_client = None
         cluster_config = params_from_base_test_setup["cluster_config"]
+        if is_magma_enabled(cluster_config):
+            pytest.skip("There is no need to test ISGR and scopes and collections. If that changes, the buckets quota needs to increase")
         cluster_helper = ClusterKeywords(cluster_config)
         topology = cluster_helper.get_cluster_topology(cluster_config)
         cbs_url = topology["couchbase_servers"][0]

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
@@ -47,6 +47,7 @@ def scopes_collections_tests_fixture(params_from_base_test_setup):
 
     cluster_config = params_from_base_test_setup["cluster_config"]
     if is_magma_enabled(cluster_config):
+        print("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^HERE")
         pytest.skip("It is not necessary to test ISGR with scopes and collections and MAGMA")
     try:  # To be able to teardon in case of a setup error
         random_suffix = str(uuid.uuid4())[:8]

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
@@ -45,6 +45,9 @@ def scopes_collections_tests_fixture(params_from_base_test_setup):
     global sg3_admin_url
     global random_suffix
 
+    cluster_config = params_from_base_test_setup["cluster_config"]
+    if is_magma_enabled(cluster_config):
+        pytest.skip("It is not necessary to test ISGR with scopes and collections and MAGMA")
     try:  # To be able to teardon in case of a setup error
         random_suffix = str(uuid.uuid4())[:8]
         scope_prefix = "scope_"
@@ -52,10 +55,6 @@ def scopes_collections_tests_fixture(params_from_base_test_setup):
         scope = scope_prefix + random_suffix
         collection = collection_prefix + random_suffix
         collection2 = collection_prefix + "2_" + random_suffix
-        cluster_config = params_from_base_test_setup["cluster_config"]
-        print("*****************************************************" + str(is_magma_enabled(cluster_config)))
-        if is_magma_enabled(cluster_config):
-            pytest.skip("It is not necessary to test ISGR with scopes and collections and MAGMA")
         cbs_cluster = Cluster(config=cluster_config)
         client_auth = HTTPBasicAuth(sg_username, sg_password)
         channels = ["A"]

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
@@ -59,7 +59,7 @@ def scopes_collections_tests_fixture(params_from_base_test_setup):
 
         pre_test_db_exists = pre_test_user_exists = sg_client = None
         cluster_config = params_from_base_test_setup["cluster_config"]
-        print("*****************************************************" + str(is_magma_enabled(cluster_config)))
+        print("*****************************************************" + str(is_magma_enabled(cbs_cluster)))
         if is_magma_enabled(cluster_config):
             pytest.skip("It is not necessary to test ISGR with scopes and collections and MAGMA")
         cluster_helper = ClusterKeywords(cluster_config)

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
@@ -55,6 +55,7 @@ def scopes_collections_tests_fixture(params_from_base_test_setup):
         scope = scope_prefix + random_suffix
         collection = collection_prefix + random_suffix
         collection2 = collection_prefix + "2_" + random_suffix
+        cluster_config = params_from_base_test_setup["cluster_config"]
         cbs_cluster = Cluster(config=cluster_config)
         client_auth = HTTPBasicAuth(sg_username, sg_password)
         channels = ["A"]

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
@@ -47,7 +47,6 @@ def scopes_collections_tests_fixture(params_from_base_test_setup):
 
     cluster_config = params_from_base_test_setup["cluster_config"]
     if is_magma_enabled(cluster_config):
-        print("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^HERE")
         pytest.skip("It is not necessary to test ISGR with scopes and collections and MAGMA")
     try:  # To be able to teardon in case of a setup error
         random_suffix = str(uuid.uuid4())[:8]

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
@@ -53,15 +53,14 @@ def scopes_collections_tests_fixture(params_from_base_test_setup):
         collection = collection_prefix + random_suffix
         collection2 = collection_prefix + "2_" + random_suffix
         cluster_config = params_from_base_test_setup["cluster_config"]
+        print("*****************************************************" + str(is_magma_enabled(cluster_config)))
+        if is_magma_enabled(cluster_config):
+            pytest.skip("It is not necessary to test ISGR with scopes and collections and MAGMA")
         cbs_cluster = Cluster(config=cluster_config)
         client_auth = HTTPBasicAuth(sg_username, sg_password)
         channels = ["A"]
 
         pre_test_db_exists = pre_test_user_exists = sg_client = None
-        cluster_config = params_from_base_test_setup["cluster_config"]
-        print("*****************************************************" + str(is_magma_enabled(cbs_cluster)))
-        if is_magma_enabled(cbs_cluster):
-            pytest.skip("It is not necessary to test ISGR with scopes and collections and MAGMA")
         cluster_helper = ClusterKeywords(cluster_config)
         topology = cluster_helper.get_cluster_topology(cluster_config)
         cbs_url = topology["couchbase_servers"][0]

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
@@ -60,7 +60,7 @@ def scopes_collections_tests_fixture(params_from_base_test_setup):
         pre_test_db_exists = pre_test_user_exists = sg_client = None
         cluster_config = params_from_base_test_setup["cluster_config"]
         print("*****************************************************" + str(is_magma_enabled(cbs_cluster)))
-        if is_magma_enabled(cluster_config):
+        if is_magma_enabled(cbs_cluster):
             pytest.skip("It is not necessary to test ISGR with scopes and collections and MAGMA")
         cluster_helper = ClusterKeywords(cluster_config)
         topology = cluster_helper.get_cluster_topology(cluster_config)


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Skip the ISGR tests for MAGMA. Magma buckets require higher quota, and the ISGR scopes and collections aren't really adding value with a MAGMA bucket (ISGR with MAGMA is already tested). 
- Fix a problem with the logs collection that was failing in certain situations when rep_call was missing.
- Remove a duplicated line (cluster_config = params_from_base_test_setup["cluster_config"])

