### PR TITLE
Workaround a problem with the file list not treated as a list

### DIFF
--- a/libraries/provision/ansible/playbooks/tasks/sg-pull-sgcollect-zip.yml
+++ b/libraries/provision/ansible/playbooks/tasks/sg-pull-sgcollect-zip.yml
@@ -7,5 +7,11 @@
 
   - name: SYNC COLLECT FETCH | sg collect fetching redacted zip file from {{ sg_logs_dir }}
     become: yes
-    fetch: src={{ sg_logs_dir }}/{{ item }} dest=/tmp/sg_redaction_logs/{{ inventory_hostname }}/ fail_on_missing=yes flat=yes validate_checksum=no
-    with_items: "{{ files_to_copy.stdout_lines }}"
+    fetch: src={{ sg_logs_dir }}/{{ files_to_copy.stdout_lines[0] | replace('[', '') | replace(']', '') | replace("'", '') }} dest=/tmp/sg_redaction_logs/{{ inventory_hostname }}/ fail_on_missing=yes flat=yes validate_checksum=no
+
+ # A workaround because of a problem with a loop - it doesn't treat files_to_copy.stdout_lines as a list
+ # but rather as a string. We therefore access the items directly.
+  - name: SYNC COLLECT FETCH | sg collect fetching the second zip file{{ sg_logs_dir }}
+    become: yes
+    fetch: src={{ sg_logs_dir }}/{{ files_to_copy.stdout_lines[1] | replace('[', '') | replace(']', '') | replace("'", '') }} dest=/tmp/sg_redaction_logs/{{ inventory_hostname }}/ fail_on_missing=yes flat=yes validate_checksum=no
+    when:  "{{ files_to_copy.stdout_lines | length == 2 }}"


### PR DESCRIPTION
#### Fixes #.

- [ ] Ran `flake8`
- [ ] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Replace the loop with a direct access to the list indexes by checking the length of the variable an accessing each individual index. It's not a good solution, but I haven't been able to find a solution with a loop that doesn't hit that problem of the loop either: (1) not identifying the list as a list (2) joining all indexes to one list.


