### PR TITLE
Add max_retries for cases that 10 retries are not enough

### DIFF
--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -786,7 +786,7 @@ class CouchbaseServer:
         self._wait_for_rebalance_complete()
         return True
 
-    def recover(self, server_to_recover):
+    def recover(self, server_to_recover, max_retries=10):
 
         if not isinstance(server_to_recover, CouchbaseServer):
             raise TypeError("'server_to_add' must be a 'CouchbaseServer'")
@@ -798,7 +798,6 @@ class CouchbaseServer:
         }
         # Override session headers for this one off request
         count = 0
-        max_retries = 10
         while count < max_retries:
             try:
                 resp = self._session.post(
@@ -811,6 +810,7 @@ class CouchbaseServer:
             if resp.status_code == 200:
                 break
             count += 1
+            log_info("Retrying setting recovery type...")
             time.sleep(1)
         log_r(resp)
         resp.raise_for_status()

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/test_multiple_servers.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/test_multiple_servers.py
@@ -376,4 +376,4 @@ def test_server_goes_down_rebuild_channels(params_from_base_test_setup):
     # Test succeeded without timeout, bring server back into topology
     flakey_server.start()
     main_server.recover(flakey_server)
-    main_server.rebalance_in(coucbase_servers, flakey_server)
+    main_server.rebalance_in(coucbase_servers, flakey_server, max_retries=30)

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/test_multiple_servers.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_servers/test_multiple_servers.py
@@ -375,5 +375,5 @@ def test_server_goes_down_rebuild_channels(params_from_base_test_setup):
 
     # Test succeeded without timeout, bring server back into topology
     flakey_server.start()
-    main_server.recover(flakey_server)
-    main_server.rebalance_in(coucbase_servers, flakey_server, max_retries=30)
+    main_server.recover(flakey_server, max_retries=30)
+    main_server.rebalance_in(coucbase_servers, flakey_server)

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
@@ -48,9 +48,6 @@ def scopes_collections_tests_fixture(params_from_base_test_setup):
     cluster_config = params_from_base_test_setup["cluster_config"]
     if is_magma_enabled(cluster_config):
         pytest.skip("It is not necessary to test ISGR with scopes and collections and MAGMA")
-    if params_from_base_test_setup["sync_gateway_version"] < "3.1.0":
-        pytest.skip('This test cannot run with Sync Gateway version below 3.1.0')
-
     try:  # To be able to teardon in case of a setup error
         random_suffix = str(uuid.uuid4())[:8]
         scope_prefix = "scope_"
@@ -153,10 +150,15 @@ def test_scopes_and_collections_replication(scopes_collections_tests_fixture, pa
     sg2 = sgs["sg2"]
     admin_client_1 = Admin(sg1["sg_obj"])
     admin_client_2 = Admin(sg2["sg_obj"])
+    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
     num_of_docs = 3
     pull_replication_prefix = "should_be_in_sg2_after_pull"
     push_replication_prefix = "should_be_in_sg2_after_push"
     sg_client, scope, collection, collection2 = scopes_collections_tests_fixture
+
+    if sync_gateway_version < "3.1.0":
+        pytest.skip('This test cannot run with Sync Gateway version below 3.1.0')
+
     sg_client = MobileRestClient()
 
     # 1. Create users, user sessions
@@ -252,8 +254,13 @@ def test_replication_implicit_mapping_filtered_collection(scopes_collections_tes
     sg2 = sgs["sg2"]
     admin_client_1 = Admin(sg1["sg_obj"])
     admin_client_2 = Admin(sg2["sg_obj"])
+    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
 
     sg_client, scope, collection, collection2 = scopes_collections_tests_fixture
+
+    # check sync gateway version
+    if sync_gateway_version < "3.1.0":
+        pytest.skip('This test cannot run with Sync Gateway version below 3.0')
 
     # create users, user sessions
     password = "password"
@@ -316,8 +323,13 @@ def test_multiple_replicators_multiple_scopes(scopes_collections_tests_fixture, 
     admin_client_1 = Admin(sg1["sg_obj"])
     admin_client_2 = Admin(sg2["sg_obj"])
     admin_client_3 = Admin(sg3["sg_obj"])
+    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
 
     sg_client, scope, collection, collection2 = scopes_collections_tests_fixture
+
+    # check sync gateway version
+    if sync_gateway_version < "3.1.0":
+        pytest.skip('This test cannot run with Sync Gateway version below 3.0')
 
     # create users, user sessions
     password = "password"
@@ -627,8 +639,13 @@ def test_missing_collection_error(scopes_collections_tests_fixture, params_from_
     sg2 = sgs["sg2"]
     admin_client_1 = Admin(sg1["sg_obj"])
     admin_client_2 = Admin(sg2["sg_obj"])
+    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
 
     sg_client, scope, collection, collection2 = scopes_collections_tests_fixture
+
+    # check sync gateway version
+    if sync_gateway_version < "3.1.0":
+        pytest.skip('This test cannot run with Sync Gateway version below 3.0')
 
     # create users, user sessions
     password = "password"

--- a/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
+++ b/testsuites/syncgateway/functional/topology_specific_tests/multiple_sync_gateways/test_scopes_and_collections.py
@@ -48,6 +48,9 @@ def scopes_collections_tests_fixture(params_from_base_test_setup):
     cluster_config = params_from_base_test_setup["cluster_config"]
     if is_magma_enabled(cluster_config):
         pytest.skip("It is not necessary to test ISGR with scopes and collections and MAGMA")
+    if params_from_base_test_setup["sync_gateway_version"] < "3.1.0":
+        pytest.skip('This test cannot run with Sync Gateway version below 3.1.0')
+
     try:  # To be able to teardon in case of a setup error
         random_suffix = str(uuid.uuid4())[:8]
         scope_prefix = "scope_"
@@ -150,15 +153,10 @@ def test_scopes_and_collections_replication(scopes_collections_tests_fixture, pa
     sg2 = sgs["sg2"]
     admin_client_1 = Admin(sg1["sg_obj"])
     admin_client_2 = Admin(sg2["sg_obj"])
-    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
     num_of_docs = 3
     pull_replication_prefix = "should_be_in_sg2_after_pull"
     push_replication_prefix = "should_be_in_sg2_after_push"
     sg_client, scope, collection, collection2 = scopes_collections_tests_fixture
-
-    if sync_gateway_version < "3.1.0":
-        pytest.skip('This test cannot run with Sync Gateway version below 3.1.0')
-
     sg_client = MobileRestClient()
 
     # 1. Create users, user sessions
@@ -254,13 +252,8 @@ def test_replication_implicit_mapping_filtered_collection(scopes_collections_tes
     sg2 = sgs["sg2"]
     admin_client_1 = Admin(sg1["sg_obj"])
     admin_client_2 = Admin(sg2["sg_obj"])
-    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
 
     sg_client, scope, collection, collection2 = scopes_collections_tests_fixture
-
-    # check sync gateway version
-    if sync_gateway_version < "3.1.0":
-        pytest.skip('This test cannot run with Sync Gateway version below 3.0')
 
     # create users, user sessions
     password = "password"
@@ -323,13 +316,8 @@ def test_multiple_replicators_multiple_scopes(scopes_collections_tests_fixture, 
     admin_client_1 = Admin(sg1["sg_obj"])
     admin_client_2 = Admin(sg2["sg_obj"])
     admin_client_3 = Admin(sg3["sg_obj"])
-    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
 
     sg_client, scope, collection, collection2 = scopes_collections_tests_fixture
-
-    # check sync gateway version
-    if sync_gateway_version < "3.1.0":
-        pytest.skip('This test cannot run with Sync Gateway version below 3.0')
 
     # create users, user sessions
     password = "password"
@@ -639,13 +627,8 @@ def test_missing_collection_error(scopes_collections_tests_fixture, params_from_
     sg2 = sgs["sg2"]
     admin_client_1 = Admin(sg1["sg_obj"])
     admin_client_2 = Admin(sg2["sg_obj"])
-    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
 
     sg_client, scope, collection, collection2 = scopes_collections_tests_fixture
-
-    # check sync gateway version
-    if sync_gateway_version < "3.1.0":
-        pytest.skip('This test cannot run with Sync Gateway version below 3.0')
 
     # create users, user sessions
     password = "password"


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Increase the recovery timeout for test_server_goes_down_rebuild_channels
-

