### PR TITLE
CM-1119: Debug/custom ports

### DIFF
--- a/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
+++ b/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
@@ -67,7 +67,7 @@
       when:  "'4.5' in couchbase_server_package_name or '4.6' in couchbase_server_package_name"
 
     - name: COUCHBASE SERVER | Configure cluster settings (4.7.X and up) | configure IPv4
-      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli cluster-init -c [{{ couchbase_server_node }}]:{{ couchbase_server_admin_port }} --cluster-username={{ couchbase_server_admin }} --cluster-password={{ couchbase_server_password }} --cluster-port={{couchbase_server_admin_port}} --cluster-ramsize={{ couchbase_server_cluster_ram }}  --services=data,index,query  --cluster-index-ramsize={{ couchbase_server_index_ram }}  --index-storage-setting=default"
+      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli cluster-init -c {{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --cluster-username={{ couchbase_server_admin }} --cluster-password={{ couchbase_server_password }} --cluster-port={{couchbase_server_admin_port}} --cluster-ramsize={{ couchbase_server_cluster_ram }}  --services=data,index,query  --cluster-index-ramsize={{ couchbase_server_index_ram }}  --index-storage-setting=default"
       when:  "not '4.0' in couchbase_server_package_name and not '4.1' in couchbase_server_package_name and not '4.5' in couchbase_server_package_name and not '4.6' in couchbase_server_package_name and not '3.0' in couchbase_server_package_name and not '3.1' in couchbase_server_package_name and not ipv6_enabled"
 
     - name: COUCHBASE SERVER | Configure cluster settings (4.7.X and up) | configure IPv6

--- a/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
+++ b/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
@@ -110,7 +110,7 @@
 
     - set_fact:
         addnode_protocol: ""
-        addnode_port: "{{ couchbase_server_addone_port }}"
+        addnode_port: "{{ couchbase_server_admin_port }}"
       when: couchbase_server_addone_port is defined
 
     - name: COUCHBASE SERVER | Join additional cluster nodes | configure IPv4

--- a/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
+++ b/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
@@ -109,7 +109,7 @@
       when: "( {{ cb_major_version['stdout'] | search('\\b[7]\\b') }} ) or ( '7.1.0' in cb_full_version.stdout )"
 
     - set_fact:
-        addnode_port: "{{ couchbase_server_admin_port }}"
+        addnode_port: "{{ couchbase_server_addone_port }}"
       when: couchbase_server_addone_port is defined
 
     - name: COUCHBASE SERVER | Join additional cluster nodes | configure IPv4

--- a/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
+++ b/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
@@ -109,6 +109,7 @@
       when: "( {{ cb_major_version['stdout'] | search('\\b[7]\\b') }} ) or ( '7.1.0' in cb_full_version.stdout )"
 
     - set_fact:
+        addnode_protocol: http://
         addnode_port: "{{ couchbase_server_addone_port }}"
       when: couchbase_server_addone_port is defined
 

--- a/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
+++ b/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
@@ -96,7 +96,7 @@
 
     - name: COUCHBASE SERVER | Wait for node to be listening on port 8091
       wait_for: port="{{ couchbase_server_admin_port }}" delay=5 timeout=60
-  
+
     - set_fact:
         protocol: ""
         addnode_protocol: ""
@@ -107,6 +107,10 @@
         addnode_port: 18091
         ssl_verify: --no-ssl-verify
       when: "( {{ cb_major_version['stdout'] | search('\\b[7]\\b') }} ) or ( '7.1.0' in cb_full_version.stdout )"
+
+    - set_face:
+        addnode_port: "{{ couchbase_server_addone_port }}"
+      when: couchbase_server_addone_port is defined
 
     - name: COUCHBASE SERVER | Join additional cluster nodes | configure IPv4
       shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli server-add -c {{ addnode_protocol }}{{ couchbase_server_primary_node }}:{{ addnode_port }} -u={{ couchbase_server_admin }} --password={{ couchbase_server_password }} --server-add={{ addnode_protocol }}{{ couchbase_server_node }}:{{ addnode_port }} --server-add-username={{ couchbase_server_admin }} --server-add-password={{ couchbase_server_password }} {{ ssl_verify }}"

--- a/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
+++ b/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
@@ -109,7 +109,6 @@
       when: "( {{ cb_major_version['stdout'] | search('\\b[7]\\b') }} ) or ( '7.1.0' in cb_full_version.stdout )"
 
     - set_fact:
-        addnode_protocol: ""
         addnode_port: "{{ couchbase_server_admin_port }}"
       when: couchbase_server_addone_port is defined
 

--- a/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
+++ b/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
@@ -108,7 +108,7 @@
         ssl_verify: --no-ssl-verify
       when: "( {{ cb_major_version['stdout'] | search('\\b[7]\\b') }} ) or ( '7.1.0' in cb_full_version.stdout )"
 
-    - set_face:
+    - set_fact:
         addnode_port: "{{ couchbase_server_addone_port }}"
       when: couchbase_server_addone_port is defined
 

--- a/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
+++ b/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
@@ -67,7 +67,7 @@
       when:  "'4.5' in couchbase_server_package_name or '4.6' in couchbase_server_package_name"
 
     - name: COUCHBASE SERVER | Configure cluster settings (4.7.X and up) | configure IPv4
-      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli cluster-init -c {{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --cluster-username={{ couchbase_server_admin }} --cluster-password={{ couchbase_server_password }} --cluster-port={{couchbase_server_admin_port}} --cluster-ramsize={{ couchbase_server_cluster_ram }}  --services=data,index,query  --cluster-index-ramsize={{ couchbase_server_index_ram }}  --index-storage-setting=default"
+      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli cluster-init -c {{ couchbase_server_node }} --cluster-username={{ couchbase_server_admin }} --cluster-password={{ couchbase_server_password }} --cluster-port={{couchbase_server_admin_port}} --cluster-ramsize={{ couchbase_server_cluster_ram }}  --services=data,index,query  --cluster-index-ramsize={{ couchbase_server_index_ram }}  --index-storage-setting=default"
       when:  "not '4.0' in couchbase_server_package_name and not '4.1' in couchbase_server_package_name and not '4.5' in couchbase_server_package_name and not '4.6' in couchbase_server_package_name and not '3.0' in couchbase_server_package_name and not '3.1' in couchbase_server_package_name and not ipv6_enabled"
 
     - name: COUCHBASE SERVER | Configure cluster settings (4.7.X and up) | configure IPv6

--- a/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
+++ b/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
@@ -67,7 +67,7 @@
       when:  "'4.5' in couchbase_server_package_name or '4.6' in couchbase_server_package_name"
 
     - name: COUCHBASE SERVER | Configure cluster settings (4.7.X and up) | configure IPv4
-      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli cluster-init -c {{ couchbase_server_node }} --cluster-username={{ couchbase_server_admin }} --cluster-password={{ couchbase_server_password }} --cluster-port={{couchbase_server_admin_port}} --cluster-ramsize={{ couchbase_server_cluster_ram }}  --services=data,index,query  --cluster-index-ramsize={{ couchbase_server_index_ram }}  --index-storage-setting=default"
+      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli cluster-init -c {{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --cluster-username={{ couchbase_server_admin }} --cluster-password={{ couchbase_server_password }} --cluster-port={{couchbase_server_admin_port}} --cluster-ramsize={{ couchbase_server_cluster_ram }}  --services=data,index,query  --cluster-index-ramsize={{ couchbase_server_index_ram }}  --index-storage-setting=default"
       when:  "not '4.0' in couchbase_server_package_name and not '4.1' in couchbase_server_package_name and not '4.5' in couchbase_server_package_name and not '4.6' in couchbase_server_package_name and not '3.0' in couchbase_server_package_name and not '3.1' in couchbase_server_package_name and not ipv6_enabled"
 
     - name: COUCHBASE SERVER | Configure cluster settings (4.7.X and up) | configure IPv6

--- a/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
+++ b/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
@@ -109,7 +109,7 @@
       when: "( {{ cb_major_version['stdout'] | search('\\b[7]\\b') }} ) or ( '7.1.0' in cb_full_version.stdout )"
 
     - set_fact:
-        addnode_protocol: http://
+        addnode_protocol: ""
         addnode_port: "{{ couchbase_server_addone_port }}"
       when: couchbase_server_addone_port is defined
 

--- a/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
+++ b/libraries/provision/ansible/playbooks/configure-couchbase-server.yml
@@ -67,7 +67,7 @@
       when:  "'4.5' in couchbase_server_package_name or '4.6' in couchbase_server_package_name"
 
     - name: COUCHBASE SERVER | Configure cluster settings (4.7.X and up) | configure IPv4
-      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli cluster-init -c {{ couchbase_server_node }}:{{ couchbase_server_admin_port }} --cluster-username={{ couchbase_server_admin }} --cluster-password={{ couchbase_server_password }} --cluster-port={{couchbase_server_admin_port}} --cluster-ramsize={{ couchbase_server_cluster_ram }}  --services=data,index,query  --cluster-index-ramsize={{ couchbase_server_index_ram }}  --index-storage-setting=default"
+      shell: "{{ couchbase_server_home_path }}/bin/couchbase-cli cluster-init -c [{{ couchbase_server_node }}]:{{ couchbase_server_admin_port }} --cluster-username={{ couchbase_server_admin }} --cluster-password={{ couchbase_server_password }} --cluster-port={{couchbase_server_admin_port}} --cluster-ramsize={{ couchbase_server_cluster_ram }}  --services=data,index,query  --cluster-index-ramsize={{ couchbase_server_index_ram }}  --index-storage-setting=default"
       when:  "not '4.0' in couchbase_server_package_name and not '4.1' in couchbase_server_package_name and not '4.5' in couchbase_server_package_name and not '4.6' in couchbase_server_package_name and not '3.0' in couchbase_server_package_name and not '3.1' in couchbase_server_package_name and not ipv6_enabled"
 
     - name: COUCHBASE SERVER | Configure cluster settings (4.7.X and up) | configure IPv6

--- a/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
+++ b/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
@@ -38,7 +38,7 @@ def teardown_clear_custom_port(params_from_base_test_setup):
         command = "cp /opt/couchbase/etc/couchbase/static_config.bak /opt/couchbase/etc/couchbase/static_config \
                    && cp /opt/couchbase/var/lib/couchbase/config/config.dat.bak /opt/couchbase/var/lib/couchbase/config/config.dat"
         remote_executor.execute(command)
-        cb_server.start()
+        cb_server.start(custom_port=True)
     cluster.reset(sg_config_path=sg_conf)
 
 

--- a/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
+++ b/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
@@ -72,7 +72,7 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
     cluster.reset(sg_config_path=sg_conf)
     ansible_runner = AnsibleRunner(cluster_conf)
 
-    custom_port = "9000"
+    custom_port = "8091"
     memcached_ssl_port = "9057"
 
     for server in cluster.servers:

--- a/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
+++ b/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
@@ -73,7 +73,7 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
     ansible_runner = AnsibleRunner(cluster_conf)
 
     custom_port = "9000"
-    memcached_ssl_port = "18091"
+    memcached_ssl_port = "9057"
 
     for server in cluster.servers:
         cb_server = couchbaseserver.CouchbaseServer(server.url)
@@ -107,7 +107,8 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
             "couchbase_server_package_base_url": couchbase_server_url,
             "couchbase_server_package_name": server_version,
             "ipv6_enabled": cluster["environment"]["ipv6_enabled"],
-            "couchbase_server_admin_port": custom_port
+            "couchbase_server_admin_port": custom_port,
+            "couchbase_server_addone_port": memcached_ssl_port
         }
     )
     if status != 0:

--- a/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
+++ b/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
@@ -77,7 +77,6 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
 
     for server in cluster.servers:
         cb_server = couchbaseserver.CouchbaseServer(server.url)
-        time.sleep(1000000000)
         cb_server.stop()
         cbs_target = host_for_url(server.url)
         remote_executor = RemoteExecutor(cbs_target)

--- a/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
+++ b/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
@@ -98,6 +98,7 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
         cluster = json.loads(f.read())
     server_version = cluster["environment"]["server_version"]
     # configuring cluster
+    print("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^GILAD IS HERE")
     status = ansible_runner.run_ansible_playbook(
         "configure-couchbase-server.yml",
         extra_vars={

--- a/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
+++ b/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
@@ -99,6 +99,7 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
     server_version = cluster["environment"]["server_version"]
     # configuring cluster
     print("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^GILAD IS HERE")
+    time.sleep(7000000)
     status = ansible_runner.run_ansible_playbook(
         "configure-couchbase-server.yml",
         extra_vars={

--- a/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
+++ b/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
@@ -72,7 +72,7 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
     cluster.reset(sg_config_path=sg_conf)
     ansible_runner = AnsibleRunner(cluster_conf)
 
-    custom_port = "8091"
+    custom_port = "9000"
     memcached_ssl_port = "9057"
 
     for server in cluster.servers:

--- a/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
+++ b/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
@@ -90,7 +90,7 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
             "&& rm -rf /opt/couchbase/var/lib/couchbase/config/config.dat"
         remote_executor.execute(command)
         cb_server.url = "http://{}:{}".format(host_for_url(server.url), custom_port)
-        cb_server.start(custom_port=True)
+        cb_server.start(custom_port=False)
 
     couchbase_server_url = cluster_topology["couchbase_servers"][0]
     couchbase_server_url = couchbase_server_url.replace("8091", custom_port)

--- a/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
+++ b/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
@@ -73,6 +73,7 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
     ansible_runner = AnsibleRunner(cluster_conf)
 
     custom_port = "9000"
+    custom_ssl_port = "1900"
     memcached_ssl_port = "9057"
 
     for server in cluster.servers:
@@ -85,13 +86,12 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
         remote_executor.execute(command)
         command = "echo {rest_port, " + custom_port + "}. >> /opt/couchbase/etc/couchbase/static_config " \
             "&& echo {memcached_port, 9050}. >> /opt/couchbase/etc/couchbase/static_config " \
-            "&& echo {ssl_rest_port, 1900}. >> /opt/couchbase/etc/couchbase/static_config " \
+            "&& echo {ssl_rest_port, " + custom_ssl_port + "}. >> /opt/couchbase/etc/couchbase/static_config " \
             "&& echo {memcached_ssl_port, " + memcached_ssl_port + "}. >> /opt/couchbase/etc/couchbase/static_config " \
             "&& rm -rf /opt/couchbase/var/lib/couchbase/config/config.dat" \
             "&& rm -rf /opt/couchbase/var/lib/couchbase/config/chronicle/*"
         remote_executor.execute(command)
         cb_server.url = "http://{}:{}".format(host_for_url(server.url), custom_port)
-        print("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ZHOVNA IS HERE")
         cb_server.start(custom_port=True)
 
     couchbase_server_url = cluster_topology["couchbase_servers"][0]
@@ -100,7 +100,6 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
         cluster = json.loads(f.read())
     server_version = cluster["environment"]["server_version"]
     # configuring cluster
-    print("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^GILAD IS HERE")
     status = ansible_runner.run_ansible_playbook(
         "configure-couchbase-server.yml",
         extra_vars={
@@ -108,7 +107,7 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
             "couchbase_server_package_name": server_version,
             "ipv6_enabled": cluster["environment"]["ipv6_enabled"],
             "couchbase_server_admin_port": custom_port,
-            "couchbase_server_addone_port": "1900"
+            "couchbase_server_addone_port": custom_ssl_port
         }
     )
     if status != 0:

--- a/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
+++ b/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
@@ -72,18 +72,19 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
     cluster.reset(sg_config_path=sg_conf)
     ansible_runner = AnsibleRunner(cluster_conf)
 
-    custom_port = "3478"
+    custom_port = "9000"
     memcached_ssl_port = "9057"
 
     for server in cluster.servers:
         cb_server = couchbaseserver.CouchbaseServer(server.url)
+        time.sleep(1000000000)
         cb_server.stop()
         cbs_target = host_for_url(server.url)
         remote_executor = RemoteExecutor(cbs_target)
         command = "cp /opt/couchbase/etc/couchbase/static_config /opt/couchbase/etc/couchbase/static_config.bak" \
             "&& cp /opt/couchbase/var/lib/couchbase/config/config.dat /opt/couchbase/var/lib/couchbase/config/config.dat.bak"
         remote_executor.execute(command)
-        command = "echo {rest_port, 3478}. >> /opt/couchbase/etc/couchbase/static_config " \
+        command = "echo {rest_port, 9000}. >> /opt/couchbase/etc/couchbase/static_config " \
             "&& echo {memcached_port, 9050}. >> /opt/couchbase/etc/couchbase/static_config " \
             "&& echo {ssl_rest_port, 1900}. >> /opt/couchbase/etc/couchbase/static_config " \
             "&& echo {memcached_ssl_port, 9057}. >> /opt/couchbase/etc/couchbase/static_config " \

--- a/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
+++ b/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
@@ -99,7 +99,6 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
     server_version = cluster["environment"]["server_version"]
     # configuring cluster
     print("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^GILAD IS HERE")
-    time.sleep(7000000)
     status = ansible_runner.run_ansible_playbook(
         "configure-couchbase-server.yml",
         extra_vars={

--- a/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
+++ b/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
@@ -88,7 +88,8 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
             "&& echo {memcached_port, 9050}. >> /opt/couchbase/etc/couchbase/static_config " \
             "&& echo {ssl_rest_port, 1900}. >> /opt/couchbase/etc/couchbase/static_config " \
             "&& echo {memcached_ssl_port, 9057}. >> /opt/couchbase/etc/couchbase/static_config " \
-            "&& rm -rf /opt/couchbase/var/lib/couchbase/config/config.dat"
+            "&& rm -rf /opt/couchbase/var/lib/couchbase/config/config.dat" \
+            "&& rm -rf /opt/couchbase/var/lib/couchbase/config/chronicle/*"
         remote_executor.execute(command)
         cb_server.url = "http://{}:{}".format(host_for_url(server.url), custom_port)
         print("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ZHOVNA IS HERE")

--- a/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
+++ b/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
@@ -73,7 +73,7 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
     ansible_runner = AnsibleRunner(cluster_conf)
 
     custom_port = "9000"
-    memcached_ssl_port = "9057"
+    memcached_ssl_port = "18091"
 
     for server in cluster.servers:
         cb_server = couchbaseserver.CouchbaseServer(server.url)
@@ -83,10 +83,10 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
         command = "cp /opt/couchbase/etc/couchbase/static_config /opt/couchbase/etc/couchbase/static_config.bak" \
             "&& cp /opt/couchbase/var/lib/couchbase/config/config.dat /opt/couchbase/var/lib/couchbase/config/config.dat.bak"
         remote_executor.execute(command)
-        command = "echo {rest_port, 9000}. >> /opt/couchbase/etc/couchbase/static_config " \
+        command = "echo {rest_port, " + custom_port + "}. >> /opt/couchbase/etc/couchbase/static_config " \
             "&& echo {memcached_port, 9050}. >> /opt/couchbase/etc/couchbase/static_config " \
             "&& echo {ssl_rest_port, 1900}. >> /opt/couchbase/etc/couchbase/static_config " \
-            "&& echo {memcached_ssl_port, 9057}. >> /opt/couchbase/etc/couchbase/static_config " \
+            "&& echo {memcached_ssl_port, " + memcached_ssl_port + "}. >> /opt/couchbase/etc/couchbase/static_config " \
             "&& rm -rf /opt/couchbase/var/lib/couchbase/config/config.dat" \
             "&& rm -rf /opt/couchbase/var/lib/couchbase/config/chronicle/*"
         remote_executor.execute(command)

--- a/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
+++ b/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
@@ -72,7 +72,7 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
     cluster.reset(sg_config_path=sg_conf)
     ansible_runner = AnsibleRunner(cluster_conf)
 
-    custom_port = "9000"
+    custom_port = "3478"
     memcached_ssl_port = "9057"
 
     for server in cluster.servers:
@@ -83,7 +83,7 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
         command = "cp /opt/couchbase/etc/couchbase/static_config /opt/couchbase/etc/couchbase/static_config.bak" \
             "&& cp /opt/couchbase/var/lib/couchbase/config/config.dat /opt/couchbase/var/lib/couchbase/config/config.dat.bak"
         remote_executor.execute(command)
-        command = "echo {rest_port, 9000}. >> /opt/couchbase/etc/couchbase/static_config " \
+        command = "echo {rest_port, 3478}. >> /opt/couchbase/etc/couchbase/static_config " \
             "&& echo {memcached_port, 9050}. >> /opt/couchbase/etc/couchbase/static_config " \
             "&& echo {ssl_rest_port, 1900}. >> /opt/couchbase/etc/couchbase/static_config " \
             "&& echo {memcached_ssl_port, 9057}. >> /opt/couchbase/etc/couchbase/static_config " \
@@ -91,7 +91,7 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
         remote_executor.execute(command)
         cb_server.url = "http://{}:{}".format(host_for_url(server.url), custom_port)
         print("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ZHOVNA IS HERE")
-        cb_server.start(custom_port=False)
+        cb_server.start(custom_port=True)
 
     couchbase_server_url = cluster_topology["couchbase_servers"][0]
     couchbase_server_url = couchbase_server_url.replace("8091", custom_port)

--- a/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
+++ b/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
@@ -90,6 +90,7 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
             "&& rm -rf /opt/couchbase/var/lib/couchbase/config/config.dat"
         remote_executor.execute(command)
         cb_server.url = "http://{}:{}".format(host_for_url(server.url), custom_port)
+        print("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ZHOVNA IS HERE")
         cb_server.start(custom_port=False)
 
     couchbase_server_url = cluster_topology["couchbase_servers"][0]

--- a/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
+++ b/testsuites/syncgateway/functional/custom_port/test_serversetup_syncgateway.py
@@ -108,7 +108,7 @@ def test_syncgateway_with_customPort_couchbaseServer(params_from_base_test_setup
             "couchbase_server_package_name": server_version,
             "ipv6_enabled": cluster["environment"]["ipv6_enabled"],
             "couchbase_server_admin_port": custom_port,
-            "couchbase_server_addone_port": memcached_ssl_port
+            "couchbase_server_addone_port": "1900"
         }
     )
     if status != 0:


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:
Fix the custom ports tests by:
-  Delete the files in the chronicle folder, per the documentation
- Align the set ports with the configured ports
- Refactor

Tested in Jenkins 

