### PR TITLE
Increase the timeout for the isgr in the test case

### DIFF
--- a/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/test_sgreplicate_cbl.py
+++ b/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/test_sgreplicate_cbl.py
@@ -2187,7 +2187,7 @@ def test_sg_replicate_custom_conflict_resolve(params_from_base_test_setup, setup
     sg1.restart(config=temp_sg_config, cluster_config=cluster_config)
     # 6. start push_pull replication with one shot with custom conflict resovler
     sg1.admin.wait_until_sgw_replication_done(sg_db1, repl_id, read_flag=True, write_flag=True)
-    time.sleep(30)  # To avoid inconsistent failure when replication did not complete
+    time.sleep(60)  # To avoid inconsistent failure when replication did not complete
     # 7. if  local_wins : docs updated on sg1 gets replicated to sg2
     # if  remote_wins : docs updated on sg2 gets replicated to sg1
     # Verify docs created in cbl2

--- a/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/test_sgreplicate_cbl.py
+++ b/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/test_sgreplicate_cbl.py
@@ -2156,7 +2156,7 @@ def test_sg_replicate_custom_conflict_resolve(params_from_base_test_setup, setup
         remote_password=password,
         continuous=True
     )
-    sg1.admin.wait_until_sgw_replication_done(db=sg_db1, repl_id=repl_id_1, write_flag=True, max_times=35)
+    sg1.admin.wait_until_sgw_replication_done(db=sg_db1, repl_id=repl_id_1, write_flag=True)
     replicator.configure_and_replicate(
         source_db=cbl_db2, replicator_authenticator=replicator_authenticator2, target_url=sg2_blip_url
     )


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

-  The test is timing out because of the low timeout. I've changed it to the default, it seems to pass now.
-

