### PR TITLE
Fix/dot net cleanup

### DIFF
--- a/libraries/provision/ansible/playbooks/stop-testserver-windows.yml
+++ b/libraries/provision/ansible/playbooks/stop-testserver-windows.yml
@@ -7,7 +7,7 @@
     - debug: msg="Stoping the Testserver "
     - debug: msg="Copying logs at - {{ log_full_path }}"
     - name: Stop TestServer
-      shell: nssm stop TestServer
+      win_shell: nssm stop TestServer
 
       # win_nssm:
       #  name: TestServer

--- a/libraries/provision/ansible/playbooks/stop-testserver-windows.yml
+++ b/libraries/provision/ansible/playbooks/stop-testserver-windows.yml
@@ -8,6 +8,7 @@
     - debug: msg="Copying logs at - {{ log_full_path }}"
     - name: Stop TestServer
       win_command: nssm stop TestServer
+      ignore_errors: true
 
       # win_nssm:
       #  name: TestServer

--- a/libraries/provision/ansible/playbooks/stop-testserver-windows.yml
+++ b/libraries/provision/ansible/playbooks/stop-testserver-windows.yml
@@ -10,6 +10,7 @@
       win_command: nssm stop TestServer
       ignore_errors: true
 
+      # The Ansible generic way to stop the server, using win_nssm, can fail and cause all the tests to fail.
       # win_nssm:
       #  name: TestServer
       #  application: C:\PROGRA~1\dotnet\dotnet.exe

--- a/libraries/provision/ansible/playbooks/stop-testserver-windows.yml
+++ b/libraries/provision/ansible/playbooks/stop-testserver-windows.yml
@@ -7,7 +7,9 @@
     - debug: msg="Stoping the Testserver "
     - debug: msg="Copying logs at - {{ log_full_path }}"
     - name: Stop TestServer
-      win_nssm:
-        name: TestServer
-        application: C:\PROGRA~1\dotnet\dotnet.exe
-        state: stopped
+      shell: nssm stop TestServer
+
+      # win_nssm:
+      #  name: TestServer
+      #  application: C:\PROGRA~1\dotnet\dotnet.exe
+      #  state: stopped

--- a/libraries/provision/ansible/playbooks/stop-testserver-windows.yml
+++ b/libraries/provision/ansible/playbooks/stop-testserver-windows.yml
@@ -7,7 +7,7 @@
     - debug: msg="Stoping the Testserver "
     - debug: msg="Copying logs at - {{ log_full_path }}"
     - name: Stop TestServer
-      win_shell: nssm stop TestServer
+      win_command: nssm stop TestServer
 
       # win_nssm:
       #  name: TestServer


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Stop the .NET server directly, rather than using the Ansible command. The Ansible command sometimes fails, causing the entire tests suite to fail as well. It's not clear why the command is failing, but it could be because the Ansible version is old.
-

