### PR TITLE
Skip failing cbl tests

### DIFF
--- a/testsuites/CBLTester/CBL_Functional_tests/SuiteSetup_FunctionalTests/test_query.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/SuiteSetup_FunctionalTests/test_query.py
@@ -1586,6 +1586,7 @@ def test_query_arthimetic(params_from_base_suite_setup):
     qy.query_arthimetic(cbl_db)
 
 
+@pytest.mark.skip(reason="Under investiation:https://issues.couchbase.com/browse/CM-1170")
 def test_live_query_response_delay_time(params_from_base_suite_setup):
     """
     note: this test case is for android/java only

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_cbl_log_redaction.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_cbl_log_redaction.py
@@ -20,6 +20,8 @@ from keywords.constants import RBAC_FULL_ADMIN
     ("auto password"),
     pytest.param("validpassword", marks=pytest.mark.ce_sanity),
 ])
+@pytest.mark.skipif(pytest.config.getoption("--liteserv-platform").startswith("android"),
+                    reason="Under investiation:https://issues.couchbase.com/browse/CM-1174")
 def test_mask_password_in_logs(params_from_base_test_setup, password):
     """
         @summary:
@@ -81,6 +83,8 @@ def test_mask_password_in_logs(params_from_base_test_setup, password):
     "auto password",
     "invalidpassword",
 ])
+@pytest.mark.skipif(pytest.config.getoption("--liteserv-platform").startswith("android"),
+                    reason="Under investiation:https://issues.couchbase.com/browse/CM-1173")
 def test_verify_invalid_mask_password_in_logs(params_from_base_test_setup, invalid_password):
     """
         @summary:

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_no_conflicts_cbl.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_no_conflicts_cbl.py
@@ -199,6 +199,8 @@ def test_no_conflicts_enabled_with_revs_limit(params_from_base_test_setup, sg_co
 @pytest.mark.conflicts
 @pytest.mark.noconflicts
 @pytest.mark.replication
+@pytest.mark.skipif(pytest.config.getoption("--liteserv-platform").startswith("java"),
+                    reason="Under investiation:https://issues.couchbase.com/browse/CM-1169")
 @pytest.mark.parametrize("sg_conf_name, num_of_docs, revs_limit", [
     ('sync_gateway_revs_conflict_configurable', 10, 25),
     ('sync_gateway_revs_conflict_configurable', 100, 35),
@@ -838,7 +840,7 @@ def test_multiple_cbls_updates_concurrently_with_push(params_from_base_test_setu
 @pytest.mark.replication
 @pytest.mark.parametrize("sg_conf_name, num_of_docs, number_of_updates", [
     ('listener_tests/listener_tests_no_conflicts', 10, 2),
-    ('listener_tests/listener_tests_no_conflicts', 100, 5),
+    # ('listener_tests/listener_tests_no_conflicts', 100, 5), tracked in: https://issues.couchbase.com/browse/CM-1168
     ('listener_tests/listener_tests_no_conflicts', 1000, 10)
 ])
 def test_multiple_cbls_updates_concurrently_with_pull(params_from_base_test_setup, setup_customized_teardown_test, sg_conf_name, num_of_docs, number_of_updates):

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
@@ -612,7 +612,7 @@ def test_replication_configuration_with_headers(params_from_base_test_setup):
 @pytest.mark.noconflicts
 @pytest.mark.parametrize("num_of_docs, x509_cert_auth", [
     (10, False),
-    (100, True),
+    # (100, True), tracked in https://issues.couchbase.com/browse/CM-1172
     (1000, False)
 ])
 def test_CBL_tombstone_doc(params_from_base_test_setup, num_of_docs, x509_cert_auth):
@@ -2746,6 +2746,8 @@ def test_replication_withMultipleBuckets(params_from_base_test_setup, setup_cust
 
 @pytest.mark.listener
 @pytest.mark.replication
+@pytest.mark.skipif(pytest.config.getoption("--liteserv-platform").startswith("java"),
+                    reason="Under investiation:https://issues.couchbase.com/browse/CM-1171")
 def test_replication_1withMultipleBuckets_deleteOneBucket(params_from_base_test_setup, setup_customized_teardown_test):
     """
         @summary:

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
@@ -134,12 +134,10 @@ def test_replication_configuration_valid_values(params_from_base_test_setup, num
     replicator.stop(repl)
 
 
-@pytest.mark.skipif(pytest.config.getoption("--liteserv-platform").startswith("net-"),
-                    reason="Under investigation:https://issues.couchbase.com/browse/CM-1163")
 @pytest.mark.listener
 @pytest.mark.replication
 @pytest.mark.parametrize("authenticator_type, attachments_generator", [
-    ('session', attachment.generate_2_png_10_10),
+    # ('session', attachment.generate_2_png_10_10), https://issues.couchbase.com/browse/CM-1163
     ('basic', None)
 ])
 def test_replication_configuration_with_pull_replication(params_from_base_test_setup, authenticator_type, attachments_generator):
@@ -220,12 +218,10 @@ def test_replication_configuration_with_pull_replication(params_from_base_test_s
                 assert verify_stat_on_prometheus("sgw_replication_pull_attachment_pull_count"), expvars["syncgateway"]["per_db"][sg_db]["cbl_replication_pull"]["attachment_pull_count"]
 
 
-@pytest.mark.skipif(pytest.config.getoption("--liteserv-platform").startswith("net-"),
-                    reason="Under investigation:https://issues.couchbase.com/browse/CM-1163")
 @pytest.mark.listener
 @pytest.mark.replication
 @pytest.mark.parametrize("authenticator_type, attachments_generator", [
-    ('session', attachment.generate_2_png_10_10),
+    # ('session', attachment.generate_2_png_10_10), https://issues.couchbase.com/browse/CM-1163
     ('basic', None)
 ])
 def test_replication_configuration_with_push_replication(params_from_base_test_setup, authenticator_type, attachments_generator):

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
@@ -47,6 +47,7 @@ def setup_teardown_test(params_from_base_test_setup):
 @pytest.mark.parametrize("num_of_docs, continuous, x509_cert_auth", [
     pytest.param(10, True, True, marks=pytest.mark.sanity)
 ])
+@pytest.mark.skip(reason="Under investiation:https://issues.couchbase.com/browse/CM-1176")
 def test_replication_configuration_valid_values(params_from_base_test_setup, num_of_docs, continuous, x509_cert_auth):
     """
         @summary:
@@ -2742,8 +2743,7 @@ def test_replication_withMultipleBuckets(params_from_base_test_setup, setup_cust
 
 @pytest.mark.listener
 @pytest.mark.replication
-@pytest.mark.skipif(pytest.config.getoption("--liteserv-platform").startswith("java"),
-                    reason="Under investiation:https://issues.couchbase.com/browse/CM-1171")
+@pytest.mark.skip(reason="Under investiation:https://issues.couchbase.com/browse/CM-1171")
 def test_replication_1withMultipleBuckets_deleteOneBucket(params_from_base_test_setup, setup_customized_teardown_test):
     """
         @summary:

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication.py
@@ -1167,6 +1167,7 @@ def CBL_offline_test(params_from_base_test_setup, sg_conf_name, num_of_docs):
 @pytest.mark.syncgateway
 @pytest.mark.replication
 @pytest.mark.backgroundapp
+@pytest.mark.skip(reason="Under investigation:https://issues.couchbase.com/browse/CM-1166")
 @pytest.mark.parametrize("num_docs, need_attachments, replication_after_backgroundApp", [
     (1000, True, False),
     (1000, False, False),

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication_eventing.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_replication_eventing.py
@@ -510,7 +510,7 @@ def test_replication_delete_event(params_from_base_test_setup, num_of_docs):
         assert sg_doc["id"] not in doc_ids, "channel access removal didn't purge the docs from cbl db"
 
 
-@pytest.mark.skipif(pytest.config.getoption("--liteserv-platform").startswith("net-"),
+@pytest.mark.skipif(pytest.config.getoption("--liteserv-platform").startswith("net-") or pytest.config.getoption("--liteserv-platform").startswith("android"),
                     reason="Under investigation:https://issues.couchbase.com/browse/CM-1163")
 @pytest.mark.listener
 @pytest.mark.replication

--- a/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_xattrs_grants_with_cbl.py
+++ b/testsuites/CBLTester/CBL_Functional_tests/TestSetup_FunctionalTests/test_xattrs_grants_with_cbl.py
@@ -15,8 +15,8 @@ from keywords.constants import RBAC_FULL_ADMIN
 @pytest.mark.channels
 @pytest.mark.syncgateway
 @pytest.mark.parametrize("x509_cert_auth", [
-    pytest.param(False, marks=pytest.mark.ce_sanity),
-    pytest.param(True, marks=pytest.mark.sanity)
+    pytest.param(False, marks=pytest.mark.ce_sanity)
+    # pytest.param(True, marks=pytest.mark.sanity) investigated in https://issues.couchbase.com/browse/CM-1177
 ])
 def test_xattrs_grant_automatic_imports(params_from_base_test_setup, x509_cert_auth):
     """

--- a/testsuites/CBLTester/topology_specific_tests/sync_gateway_proxy_enabled/test_replication.py
+++ b/testsuites/CBLTester/topology_specific_tests/sync_gateway_proxy_enabled/test_replication.py
@@ -30,6 +30,8 @@ def setup_teardown_test(params_from_base_test_setup):
 
 
 @pytest.mark.replication
+@pytest.mark.skipif(pytest.config.getoption("--liteserv-platform").startswith("android"),
+                    reason="Under investiation:https://issues.couchbase.com/browse/CM-1167")
 def test_replication_heartbeat(params_from_base_test_setup):
     """
         @summary:


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Skipping more known CBL failures 
-

