### PR TITLE
Skip all the test parameters because they all fail

### DIFF
--- a/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/test_replication_multiple_sgs.py
+++ b/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/test_replication_multiple_sgs.py
@@ -13,6 +13,7 @@ from keywords.constants import CLUSTER_CONFIGS_DIR
 from keywords.constants import RBAC_FULL_ADMIN
 
 
+@pytest.mark.skip(reason="Under investigation: https://issues.couchbase.com/browse/CM-1183")
 @pytest.mark.listener
 @pytest.mark.replication
 @pytest.mark.parametrize("sg_conf_name, num_of_docs", [

--- a/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/test_sgreplicate_cbl.py
+++ b/testsuites/CBLTester/topology_specific_tests/multiple_sync_gateways/test_sgreplicate_cbl.py
@@ -122,6 +122,7 @@ def setup_syncGateways_with_cbl(params_from_base_test_setup, setup_customized_te
     return db, num_of_docs, sg_db1, sg_db2, name1, name2, password1, password2, channels1, channels2, replicator, replicator_authenticator1, replicator_authenticator2, sg1_blip_url, sg2_blip_url, sg1, sg2, repl1, c_cluster, cbl_db1, cbl_db2, session1
 
 
+@pytest.mark.skip(reason="investigated in:  https://issues.couchbase.com/browse/CM-1110")
 @pytest.mark.topospecific
 @pytest.mark.syncgateway
 @pytest.mark.sgreplicate
@@ -129,9 +130,9 @@ def setup_syncGateways_with_cbl(params_from_base_test_setup, setup_customized_te
     (True, "push", False),
     (False, "pull", False),
     (False, "pushAndPull", False),
-    # (True, "push", True),  https://issues.couchbase.com/browse/CM-1110
-    # (False, "pull", True),  https://issues.couchbase.com/browse/CM-1110
-    # pytest.param(True, "pushAndPull", True, marks=pytest.mark.sanity),  https://issues.couchbase.com/browse/CM-1110
+    (True, "push", True),
+    (False, "pull", True),
+    pytest.param(True, "pushAndPull", True, marks=pytest.mark.sanity),
 ])
 def test_sg_replicate_push_pull_replication(params_from_base_test_setup, setup_customized_teardown_test, continuous, direction, attachments):
     '''


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- 
-

