### PR TITLE
Replace the sample loading with an API call, rather than cmd tools

### DIFF
--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -1061,7 +1061,7 @@ class CouchbaseServer:
     def load_sample_bucket(self, sample_bucket):
         """ Loads a given sample bucket """
         log_info("Enabling sample bucket {}".format(sample_bucket))
-        self.remote_executor.must_execute('sudo /opt/couchbase/bin/cbdocloader -c localhost:8091 -u Administrator -p password -b {} -m 200 -d /opt/couchbase/samples/{}.zip'.format(sample_bucket, sample_bucket))
+        self.remote_executor.must_execute('/opt/couchbase/bin/cbdocloader -c localhost:8091 -u Administrator -p password -b {} -m 200 -d /opt/couchbase/samples/{}.zip'.format(sample_bucket, sample_bucket))
 
     def get_bucket_connection(self, cbs_url, bucket_name, ssl_enabled, cluster):
         cbs_ip = host_for_url(cbs_url)

--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -1061,7 +1061,7 @@ class CouchbaseServer:
     def load_sample_bucket(self, sample_bucket):
         """ Loads a given sample bucket """
 
-        resp = self._session.post("curl -X POST -u Administrator:password {}/sampleBuckets/install".format(self.url), data='[\"{}\"]'.format(sample_bucket))
+        resp = self._session.post("{}/sampleBuckets/install".format(self.url), data='[\"{}\"]'.format(sample_bucket))
         log_r(resp)
         resp.raise_for_status()
         # log_info("Enabling sample bucket {}".format(sample_bucket))

--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -1061,7 +1061,7 @@ class CouchbaseServer:
     def load_sample_bucket(self, sample_bucket):
         """ Loads a given sample bucket """
 
-        resp = self._session.post("curl -X POST -u Administrator:password {}/sampleBuckets/install".format(self.url), date='[\"{}\"]'.format(sample_bucket))
+        resp = self._session.post("curl -X POST -u Administrator:password {}/sampleBuckets/install".format(self.url), data='[\"{}\"]'.format(sample_bucket))
         log_r(resp)
         resp.raise_for_status()
         # log_info("Enabling sample bucket {}".format(sample_bucket))

--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -1061,7 +1061,7 @@ class CouchbaseServer:
     def load_sample_bucket(self, sample_bucket):
         """ Loads a given sample bucket """
 
-        resp = self._session.post("curl -X POST -u Administrator:password {}/sampleBuckets/install -d '[\"{}\"]".format(self.url, sample_bucket))
+        resp = self._session.post("curl -X POST -u Administrator:password {}/sampleBuckets/install".format(self.url), date='[\"{}\"]'.format(sample_bucket))
         log_r(resp)
         resp.raise_for_status()
         # log_info("Enabling sample bucket {}".format(sample_bucket))

--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -1060,9 +1060,15 @@ class CouchbaseServer:
 
     def load_sample_bucket(self, sample_bucket):
         """ Loads a given sample bucket """
-        log_info("Enabling sample bucket {}".format(sample_bucket))
+
+        resp = self._session.post("curl -X POST -u Administrator:password \
+        http://{}:8091/sampleBuckets/install \
+        -d '[\"{}\"]".format( self.url, sample_bucket))
+        log_r(resp)
+        resp.raise_for_status()
+        # log_info("Enabling sample bucket {}".format(sample_bucket))
         # self.remote_executor.must_execute('/opt/couchbase/bin/cbdocloader -c localhost:8091 -u Administrator -p password -b {} -m 200 -d /opt/couchbase/samples/{}.zip'.format(sample_bucket, sample_bucket))
-        self.remote_executor.must_execute('ls')
+        # self.remote_executor.must_execute('ls')
 
 
     def get_bucket_connection(self, cbs_url, bucket_name, ssl_enabled, cluster):

--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -1062,8 +1062,8 @@ class CouchbaseServer:
         """ Loads a given sample bucket """
 
         resp = self._session.post("curl -X POST -u Administrator:password \
-        http://{}:8091/sampleBuckets/install \
-        -d '[\"{}\"]".format( self.url, sample_bucket))
+        {}/sampleBuckets/install \
+        -d '[\"{}\"]".format(self.url, sample_bucket))
         log_r(resp)
         resp.raise_for_status()
         # log_info("Enabling sample bucket {}".format(sample_bucket))

--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -1064,9 +1064,6 @@ class CouchbaseServer:
         resp = self._session.post("{}/sampleBuckets/install".format(self.url), data='[\"{}\"]'.format(sample_bucket))
         log_r(resp)
         resp.raise_for_status()
-        # log_info("Enabling sample bucket {}".format(sample_bucket))
-        # self.remote_executor.must_execute('/opt/couchbase/bin/cbdocloader -c localhost:8091 -u Administrator -p password -b {} -m 200 -d /opt/couchbase/samples/{}.zip'.format(sample_bucket, sample_bucket))
-        # self.remote_executor.must_execute('ls')
 
     def get_bucket_connection(self, cbs_url, bucket_name, ssl_enabled, cluster):
         cbs_ip = host_for_url(cbs_url)

--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -1061,9 +1061,7 @@ class CouchbaseServer:
     def load_sample_bucket(self, sample_bucket):
         """ Loads a given sample bucket """
 
-        resp = self._session.post("curl -X POST -u Administrator:password \
-        {}/sampleBuckets/install \
-        -d '[\"{}\"]".format(self.url, sample_bucket))
+        resp = self._session.post("curl -X POST -u Administrator:password {}/sampleBuckets/install -d '[\"{}\"]".format(self.url, sample_bucket))
         log_r(resp)
         resp.raise_for_status()
         # log_info("Enabling sample bucket {}".format(sample_bucket))

--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -1068,7 +1068,6 @@ class CouchbaseServer:
         # self.remote_executor.must_execute('/opt/couchbase/bin/cbdocloader -c localhost:8091 -u Administrator -p password -b {} -m 200 -d /opt/couchbase/samples/{}.zip'.format(sample_bucket, sample_bucket))
         # self.remote_executor.must_execute('ls')
 
-
     def get_bucket_connection(self, cbs_url, bucket_name, ssl_enabled, cluster):
         cbs_ip = host_for_url(cbs_url)
         if ssl_enabled and cluster.ipv6:

--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -1061,7 +1061,9 @@ class CouchbaseServer:
     def load_sample_bucket(self, sample_bucket):
         """ Loads a given sample bucket """
         log_info("Enabling sample bucket {}".format(sample_bucket))
-        self.remote_executor.must_execute('/opt/couchbase/bin/cbdocloader -c localhost:8091 -u Administrator -p password -b {} -m 200 -d /opt/couchbase/samples/{}.zip'.format(sample_bucket, sample_bucket))
+        # self.remote_executor.must_execute('/opt/couchbase/bin/cbdocloader -c localhost:8091 -u Administrator -p password -b {} -m 200 -d /opt/couchbase/samples/{}.zip'.format(sample_bucket, sample_bucket))
+        self.remote_executor.must_execute('ls')
+
 
     def get_bucket_connection(self, cbs_url, bucket_name, ssl_enabled, cluster):
         cbs_ip = host_for_url(cbs_url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ mccabe==0.6.1
 netifaces==0.10.4
 olefile==0.44
 packaging==16.8
-paramiko==3.4.0
+paramiko==2.5.0
 Pillow==9.2.0
 py==1.5.1
 pyasn1==0.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ mccabe==0.6.1
 netifaces==0.10.4
 olefile==0.44
 packaging==16.8
-paramiko==2.5.0
+paramiko==2.7.0
 Pillow==9.2.0
 py==1.5.1
 pyasn1==0.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ mccabe==0.6.1
 netifaces==0.10.4
 olefile==0.44
 packaging==16.8
-paramiko==2.7.0
+paramiko==3.4.0
 Pillow==9.2.0
 py==1.5.1
 pyasn1==0.2.3


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Using API rather than cmd tools to set the sample bucket.
- Tested on job that have previously failed

