### PR TITLE
Add a test for audit log rotation

### DIFF
--- a/resources/sync_gateway_configs_cpc/audit_logging_cc.json
+++ b/resources/sync_gateway_configs_cpc/audit_logging_cc.json
@@ -12,10 +12,10 @@
     },
     "logging": { "debug": {"enabled": true},
                  "audit": {"enabled": true,
-                           "rotation": {"max_size": 1,
+                           "rotation": {"max_size": 2,
                                         "max_age": 0,
                                         "localtime": false,
-                                        "rotated_logs_size_limit": 1024
+                                        "rotated_logs_size_limit": 3
                                        }
                           }
                 },

--- a/resources/sync_gateway_configs_cpc/audit_logging_cc.json
+++ b/resources/sync_gateway_configs_cpc/audit_logging_cc.json
@@ -10,7 +10,16 @@
         {{ groupid }}
         "server":"{{ server_scheme }}://{{ couchbase_server_primary_node }}:{{ server_port }}"
     },
-    "logging": {"debug": {"enabled": true}, "audit": {"enabled": true}},
+    "logging": { "debug": {"enabled": true},
+                 "audit": {"enabled": true,
+                           "rotation": {"max_size": 1,
+                                        "max_age": 0,
+                                        "localtime": false,
+                                        "rotated_logs_size_limit": 1024,
+                                        "rotation_interval": 0
+                                       },
+                          },
+                }
     "api":{
         {{ disable_admin_auth }}
         {{ tls }}

--- a/resources/sync_gateway_configs_cpc/audit_logging_cc.json
+++ b/resources/sync_gateway_configs_cpc/audit_logging_cc.json
@@ -16,7 +16,7 @@
                                         "max_age": 0,
                                         "localtime": false,
                                         "rotated_logs_size_limit": 1024,
-                                        "rotation_interval": 0
+                                        "rotation_interval": "0"
                                        }
                           }
                 },

--- a/resources/sync_gateway_configs_cpc/audit_logging_cc.json
+++ b/resources/sync_gateway_configs_cpc/audit_logging_cc.json
@@ -17,9 +17,9 @@
                                         "localtime": false,
                                         "rotated_logs_size_limit": 1024,
                                         "rotation_interval": 0
-                                       },
-                          },
-                }
+                                       }
+                          }
+                },
     "api":{
         {{ disable_admin_auth }}
         {{ tls }}

--- a/resources/sync_gateway_configs_cpc/audit_logging_cc.json
+++ b/resources/sync_gateway_configs_cpc/audit_logging_cc.json
@@ -15,7 +15,7 @@
                            "rotation": {"max_size": 2,
                                         "max_age": 0,
                                         "localtime": false,
-                                        "rotated_logs_size_limit": 3
+                                        "rotated_logs_size_limit": 10
                                        }
                           }
                 },

--- a/resources/sync_gateway_configs_cpc/audit_logging_cc.json
+++ b/resources/sync_gateway_configs_cpc/audit_logging_cc.json
@@ -15,8 +15,7 @@
                            "rotation": {"max_size": 1,
                                         "max_age": 0,
                                         "localtime": false,
-                                        "rotated_logs_size_limit": 1024,
-                                        "rotation_interval": "0"
+                                        "rotated_logs_size_limit": 1024
                                        }
                           }
                 },

--- a/testsuites/syncgateway/functional/tests/test_audit_logging.py
+++ b/testsuites/syncgateway/functional/tests/test_audit_logging.py
@@ -136,6 +136,7 @@ def test_audit_log_rotation(params_from_base_test_setup, audit_logging_fixture):
     _, stdout, _ = remote_executor.execute("ls /home/sync_gateway/logs | grep sg_audit.*.gz")
     assert len(stdout) == 0, "rotated_logs_size_limit was exceeded but the rotated logs were not deleted"
 
+
 def get_audit_log_folder(cluster_config):
     ansible_runner = AnsibleRunner(cluster_config)
 

--- a/testsuites/syncgateway/functional/tests/test_audit_logging.py
+++ b/testsuites/syncgateway/functional/tests/test_audit_logging.py
@@ -122,7 +122,7 @@ def test_audit_log_rotation(params_from_base_test_setup, audit_logging_fixture):
     admin_client.update_audit_config(sg_db, audit_config)
 
     # 2. Triggering event 53280 multiple times to increaes the audit log size to more than 1MB
-    for i in range(0, 4500):
+    for i in range(0, 6500):
         sg_client.get_all_docs(url=sg_url, db=sg_db, auth=(username, password))
     # 3. Looking at the content of the logs directory and expecting it to contain an archive
     _, stdout, _ = remote_executor.execute("ls /home/sync_gateway/logs | grep sg_audit.*.gz")
@@ -131,7 +131,7 @@ def test_audit_log_rotation(params_from_base_test_setup, audit_logging_fixture):
     else:
         assert False, "The archive for the rotation was not found even though it was expected"
 
-    for i in range(0, 20000):
+    for i in range(0, 30000):
         sg_client.get_all_docs(url=sg_url, db=sg_db, auth=(username, password))
     _, stdout, _ = remote_executor.execute("ls /home/sync_gateway/logs | grep sg_audit.*.gz")
     assert len(stdout) == 0, "rotated_logs_size_limit was exceeded but the rotated logs were not deleted"

--- a/testsuites/syncgateway/functional/tests/test_audit_logging.py
+++ b/testsuites/syncgateway/functional/tests/test_audit_logging.py
@@ -63,7 +63,7 @@ def audit_logging_fixture(params_from_base_test_setup):
     yield sg_client, admin_client, sg_url, sg_admin_url
 
     remote_executor = RemoteExecutor(cluster.sync_gateways[0].ip)
-    remote_executor("rm -rf /home/sync_gateway/logs")
+    remote_executor.execute("rm -rf /home/sync_gateway/logs")
 
 
 def test_configure_audit_logging(params_from_base_test_setup, audit_logging_fixture):

--- a/testsuites/syncgateway/functional/tests/test_audit_logging.py
+++ b/testsuites/syncgateway/functional/tests/test_audit_logging.py
@@ -62,6 +62,9 @@ def audit_logging_fixture(params_from_base_test_setup):
             sg_client.create_user(url=sg_admin_url, db=sg_db, name=username, password=password, channels=channels, auth=auth)
     yield sg_client, admin_client, sg_url, sg_admin_url
 
+    remote_executor = RemoteExecutor(cluster.sync_gateways[0].ip)
+    remote_executor("rm -rf /home/sync_gateway/logs")
+
 
 def test_configure_audit_logging(params_from_base_test_setup, audit_logging_fixture):
     '''

--- a/testsuites/syncgateway/functional/tests/test_audit_logging.py
+++ b/testsuites/syncgateway/functional/tests/test_audit_logging.py
@@ -122,7 +122,7 @@ def test_audit_log_rotation(params_from_base_test_setup, audit_logging_fixture):
     admin_client.update_audit_config(sg_db, audit_config)
 
     # 2. Triggering event 53280 multiple times to increaes the audit log size to more than 1MB
-    for i in range(0, 3000):
+    for i in range(0, 4500):
         sg_client.get_all_docs(url=sg_url, db=sg_db, auth=(username, password))
     # 3. Looking at the content of the logs directory and expecting it to contain an archive
     _, stdout, _ = remote_executor.execute("ls /home/sync_gateway/logs | grep sg_audit.*.gz")
@@ -131,6 +131,10 @@ def test_audit_log_rotation(params_from_base_test_setup, audit_logging_fixture):
     else:
         assert False, "The archive for the rotation was not found even though it was expected"
 
+    for i in range(0, 3000):
+        sg_client.get_all_docs(url=sg_url, db=sg_db, auth=(username, password))
+    _, stdout, _ = remote_executor.execute("ls /home/sync_gateway/logs | grep sg_audit.*.gz")
+    assert len(stdout) == 0, "rotated_logs_size_limit was exceeded but the rotated logs were not deleted"
 
 def get_audit_log_folder(cluster_config):
     ansible_runner = AnsibleRunner(cluster_config)

--- a/testsuites/syncgateway/functional/tests/test_audit_logging.py
+++ b/testsuites/syncgateway/functional/tests/test_audit_logging.py
@@ -144,7 +144,7 @@ def test_audit_log_rotation(params_from_base_test_setup, audit_logging_fixture):
     admin_client.update_audit_config(sg_db, audit_config)
 
     # Triggering event 53280: public API User authetication, to increaes the audit log size
-    for i in range(0, 1000):
+    for i in range(0, 3000):
         sg_client.get_all_docs(url=sg_url, db=sg_db, auth=(username, password))
 
 

--- a/testsuites/syncgateway/functional/tests/test_audit_logging.py
+++ b/testsuites/syncgateway/functional/tests/test_audit_logging.py
@@ -16,6 +16,52 @@ from libraries.provision.ansible_runner import AnsibleRunner
 from utilities.scan_logs import scan_for_pattern
 
 
+sg_db = "db"
+username = 'audit-logging-user'
+password = 'password'
+is_audit_logging_set = False
+
+
+@pytest.fixture
+def audit_logging_fixture(params_from_base_test_setup):
+    # get/set the parameters
+    global username
+    global password
+    global sg_db
+    global is_audit_logging_set
+
+    cluster_config = params_from_base_test_setup["cluster_config"]
+    cluster_config = params_from_base_test_setup["cluster_config"]
+    need_sgw_admin_auth = params_from_base_test_setup["need_sgw_admin_auth"]
+    cluster_helper = ClusterKeywords(cluster_config)
+    cluster_hosts = cluster_helper.get_cluster_topology(cluster_config)
+    sg_admin_url = cluster_hosts["sync_gateways"][0]["admin"]
+    cluster = Cluster(config=cluster_config)
+    admin_client = Admin(cluster.sync_gateways[0])
+    sg_url = cluster_hosts["sync_gateways"][0]["public"]
+    sg_client = MobileRestClient()
+    channels = ["audit_logging"]
+    auth = need_sgw_admin_auth and (RBAC_FULL_ADMIN['user'], RBAC_FULL_ADMIN['pwd']) or None
+    db_config = {"bucket": "data-bucket", "num_index_replicas": 0}
+    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
+    xattrs_enabled = params_from_base_test_setup['xattrs_enabled']
+
+    if sync_gateway_version < "3.2.0":
+        pytest.skip('This test cannnot run with sg version below 3.2.0')
+    if xattrs_enabled:
+        pytest.skip('There is no need to run this test with xattrs_enabled')
+    if is_audit_logging_set is False:
+        cluster = Cluster(config=cluster_config)
+        sg_conf = sync_gateway_config_path_for_mode("audit_logging", "cc")
+        cluster.reset(sg_config_path=sg_conf, use_config=True)
+        is_audit_logging_set = True
+        if admin_client.does_db_exist(sg_db) is False:
+            admin_client.create_db(sg_db, db_config)
+        if admin_client.does_user_exist(sg_db, username) is False:
+            sg_client.create_user(url=sg_admin_url, db=sg_db, name=username, password=password, channels=channels, auth=auth)
+    yield sg_client, admin_client, sg_url, sg_admin_url
+
+
 def test_configure_audit_logging(params_from_base_test_setup):
     '''
     @summary:
@@ -83,6 +129,29 @@ def test_configure_audit_logging(params_from_base_test_setup):
             with pytest.raises(Exception):
                 print("*** Checking if even id " + str(id) + " is in the audit log - not expecting it")
                 scan_for_pattern(audit_log_path + "/sg_audit.log", pattern)
+
+def test_audit_log_rotation(params_from_base_test_setup, audit_logging_fixture):
+    '''
+    @summary:
+    1. Enable audit logging by resetting the cluster
+    2. Randomly configure the tested events, to be recorded or not recorded
+    3. Trigger the tested events
+    4. Check that the events are are recorded/not recorded in the audit_log file
+    '''
+    cluster_config = params_from_base_test_setup["cluster_config"]
+    need_sgw_admin_auth = params_from_base_test_setup["need_sgw_admin_auth"]
+    cluster_helper = ClusterKeywords(cluster_config)
+    cluster_hosts = cluster_helper.get_cluster_topology(cluster_config)
+
+
+    sg_client, admin_client, sg_url, sg_admin_url = audit_logging_fixture
+    audit_config = {"enabled": True, "events": {"53280": True}}
+    admin_client.update_audit_config(sg_db, audit_config)
+
+    # Triggering event 53280: public API User authetication, to increaes the audit log size
+    for i in range (0, 1000):
+        sg_client.get_all_docs(url=sg_url, db=sg_db, auth=(username, password))
+
 
 
 def get_audit_log_path(cluster_config, tested_ids):

--- a/testsuites/syncgateway/functional/tests/test_audit_logging.py
+++ b/testsuites/syncgateway/functional/tests/test_audit_logging.py
@@ -131,7 +131,7 @@ def test_audit_log_rotation(params_from_base_test_setup, audit_logging_fixture):
     else:
         assert False, "The archive for the rotation was not found even though it was expected"
 
-    for i in range(0, 3000):
+    for i in range(0, 20000):
         sg_client.get_all_docs(url=sg_url, db=sg_db, auth=(username, password))
     _, stdout, _ = remote_executor.execute("ls /home/sync_gateway/logs | grep sg_audit.*.gz")
     assert len(stdout) == 0, "rotated_logs_size_limit was exceeded but the rotated logs were not deleted"

--- a/testsuites/syncgateway/functional/tests/test_audit_logging.py
+++ b/testsuites/syncgateway/functional/tests/test_audit_logging.py
@@ -72,36 +72,7 @@ def test_configure_audit_logging(params_from_base_test_setup):
     4. Check that the events are are recorded/not recorded in the audit_log file
     '''
     cluster_config = params_from_base_test_setup["cluster_config"]
-    need_sgw_admin_auth = params_from_base_test_setup["need_sgw_admin_auth"]
-    cluster_helper = ClusterKeywords(cluster_config)
-    cluster_hosts = cluster_helper.get_cluster_topology(cluster_config)
-    sg_admin_url = cluster_hosts["sync_gateways"][0]["admin"]
-    cluster = Cluster(config=cluster_config)
-    admin_client = Admin(cluster.sync_gateways[0])
-    sg_url = cluster_hosts["sync_gateways"][0]["public"]
-    sg_db = "db"
-    sg_client = MobileRestClient()
-    username = 'audit-logging-user'
-    password = 'password'
-    channels = ["audit_logging"]
-    auth = need_sgw_admin_auth and (RBAC_FULL_ADMIN['user'], RBAC_FULL_ADMIN['pwd']) or None
-    db_config = {"bucket": "data-bucket", "num_index_replicas": 0}
-    sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
-    xattrs_enabled = params_from_base_test_setup['xattrs_enabled']
-
-    if sync_gateway_version < "3.2.0":
-        pytest.skip('This test cannnot run with sg version below 3.2.0')
-    if xattrs_enabled:
-        pytest.skip('There is no need to run this test with xattrs_enabled')
-
-    # 1. Enable audit logging by resetting the cluster
-    cluster = Cluster(config=cluster_config)
-    sg_conf = sync_gateway_config_path_for_mode("audit_logging", "cc")
-    cluster.reset(sg_config_path=sg_conf, use_config=True)
-    if admin_client.does_db_exist(sg_db) is False:
-        admin_client.create_db(sg_db, db_config)
-    if admin_client.does_user_exist(sg_db, username) is False:
-        sg_client.create_user(url=sg_admin_url, db=sg_db, name=username, password=password, channels=channels, auth=auth)
+    sg_client, admin_client, sg_url, sg_admin_url = audit_logging_fixture
 
     # 2. Randomly configure the tested events, to be recorded or not recorded.
     tested_ids = {"53281": bool(random.randint(0, 1)), "53280": bool(random.randint(0, 1))}
@@ -116,7 +87,6 @@ def test_configure_audit_logging(params_from_base_test_setup):
         pass
     # Triggering event 53280: public API User authetication
     sg_client.get_all_docs(url=sg_url, db=sg_db, auth=(username, password))
-
     # End of triggered events
 
     # 4. Check that the events are are recorded/not recorded in the audit_log file
@@ -135,24 +105,25 @@ def test_configure_audit_logging(params_from_base_test_setup):
 def test_audit_log_rotation(params_from_base_test_setup, audit_logging_fixture):
     '''
     @summary:
-    1. Enable audit logging by resetting the cluster
-    2. Randomly configure the tested events, to be recorded or not recorded
-    3. Trigger the tested events
-    4. Check that the events are are recorded/not recorded in the audit_log file
+    1. Enable event 53280 - public API authetication
+    2. Triggering event 53280 multiple times to increaes the audit log size to more than 1MB
+    3. Looking at the content of the logs directory and expecting it to contain an archive
     '''
     sg_client, admin_client, sg_url, sg_admin_url = audit_logging_fixture
     cluster_config = params_from_base_test_setup["cluster_config"]
     cluster = Cluster(config=cluster_config)
     remote_executor = RemoteExecutor(cluster.sync_gateways[0].ip)
 
+    # 1. Enable event 53280 - public API authetication
     audit_config = {"enabled": True, "events": {"53280": True}}
     admin_client.update_audit_config(sg_db, audit_config)
 
-    # Triggering event 53280: public API User authetication, to increaes the audit log size to more than 1MB
+    # 2. Triggering event 53280 multiple times to increaes the audit log size to more than 1MB
     for i in range(0, 3000):
         sg_client.get_all_docs(url=sg_url, db=sg_db, auth=(username, password))
+    # 3. Looking at the content of the logs directory and expecting it to contain an archive
     _, stdout, _ = remote_executor.execute("ls /home/sync_gateway/logs | grep sg_audit.*.gz")
-    print("*******************************************" + str(stdout))
+    assert ".log.gz" in stdout, "The archive for the rotation was not found even though it was expected"
 
 
 def get_audit_log_folder(cluster_config):

--- a/testsuites/syncgateway/functional/tests/test_audit_logging.py
+++ b/testsuites/syncgateway/functional/tests/test_audit_logging.py
@@ -63,7 +63,7 @@ def audit_logging_fixture(params_from_base_test_setup):
     yield sg_client, admin_client, sg_url, sg_admin_url
 
 
-def test_configure_audit_logging(params_from_base_test_setup):
+def test_configure_audit_logging(params_from_base_test_setup, audit_logging_fixture):
     '''
     @summary:
     1. Enable audit logging by resetting the cluster

--- a/testsuites/syncgateway/functional/tests/test_audit_logging.py
+++ b/testsuites/syncgateway/functional/tests/test_audit_logging.py
@@ -131,11 +131,6 @@ def test_audit_log_rotation(params_from_base_test_setup, audit_logging_fixture):
     else:
         assert False, "The archive for the rotation was not found even though it was expected"
 
-    for i in range(0, 30000):
-        sg_client.get_all_docs(url=sg_url, db=sg_db, auth=(username, password))
-    _, stdout, _ = remote_executor.execute("ls /home/sync_gateway/logs | grep sg_audit.*.gz")
-    assert len(stdout) == 0, "rotated_logs_size_limit was exceeded but the rotated logs were not deleted"
-
 
 def get_audit_log_folder(cluster_config):
     ansible_runner = AnsibleRunner(cluster_config)

--- a/testsuites/syncgateway/functional/tests/test_audit_logging.py
+++ b/testsuites/syncgateway/functional/tests/test_audit_logging.py
@@ -123,7 +123,7 @@ def test_audit_log_rotation(params_from_base_test_setup, audit_logging_fixture):
         sg_client.get_all_docs(url=sg_url, db=sg_db, auth=(username, password))
     # 3. Looking at the content of the logs directory and expecting it to contain an archive
     _, stdout, _ = remote_executor.execute("ls /home/sync_gateway/logs | grep sg_audit.*.gz")
-    assert ".log.gz" in stdout, "The archive for the rotation was not found even though it was expected"
+    assert ".log.gz" in stdout[0], "The archive for the rotation was not found even though it was expected"
 
 
 def get_audit_log_folder(cluster_config):

--- a/testsuites/syncgateway/functional/tests/test_audit_logging.py
+++ b/testsuites/syncgateway/functional/tests/test_audit_logging.py
@@ -130,6 +130,7 @@ def test_configure_audit_logging(params_from_base_test_setup):
                 print("*** Checking if even id " + str(id) + " is in the audit log - not expecting it")
                 scan_for_pattern(audit_log_path + "/sg_audit.log", pattern)
 
+
 def test_audit_log_rotation(params_from_base_test_setup, audit_logging_fixture):
     '''
     @summary:
@@ -138,20 +139,13 @@ def test_audit_log_rotation(params_from_base_test_setup, audit_logging_fixture):
     3. Trigger the tested events
     4. Check that the events are are recorded/not recorded in the audit_log file
     '''
-    cluster_config = params_from_base_test_setup["cluster_config"]
-    need_sgw_admin_auth = params_from_base_test_setup["need_sgw_admin_auth"]
-    cluster_helper = ClusterKeywords(cluster_config)
-    cluster_hosts = cluster_helper.get_cluster_topology(cluster_config)
-
-
     sg_client, admin_client, sg_url, sg_admin_url = audit_logging_fixture
     audit_config = {"enabled": True, "events": {"53280": True}}
     admin_client.update_audit_config(sg_db, audit_config)
 
     # Triggering event 53280: public API User authetication, to increaes the audit log size
-    for i in range (0, 1000):
+    for i in range(0, 1000):
         sg_client.get_all_docs(url=sg_url, db=sg_db, auth=(username, password))
-
 
 
 def get_audit_log_path(cluster_config, tested_ids):

--- a/testsuites/syncgateway/functional/tests/test_audit_logging.py
+++ b/testsuites/syncgateway/functional/tests/test_audit_logging.py
@@ -63,7 +63,7 @@ def audit_logging_fixture(params_from_base_test_setup):
     yield sg_client, admin_client, sg_url, sg_admin_url
 
     remote_executor = RemoteExecutor(cluster.sync_gateways[0].ip)
-    remote_executor.execute("rm -rf /home/sync_gateway/logs")
+    remote_executor.execute("rm -rf /home/sync_gateway/logs/audit_log*")
 
 
 def test_configure_audit_logging(params_from_base_test_setup, audit_logging_fixture):
@@ -126,7 +126,10 @@ def test_audit_log_rotation(params_from_base_test_setup, audit_logging_fixture):
         sg_client.get_all_docs(url=sg_url, db=sg_db, auth=(username, password))
     # 3. Looking at the content of the logs directory and expecting it to contain an archive
     _, stdout, _ = remote_executor.execute("ls /home/sync_gateway/logs | grep sg_audit.*.gz")
-    assert ".log.gz" in stdout[0], "The archive for the rotation was not found even though it was expected"
+    if len(stdout) > 0:
+        assert ".log.gz" in stdout[0], "The archive for the rotation was not found even though it was expected"
+    else:
+        assert False, "The archive for the rotation was not found even though it was expected"
 
 
 def get_audit_log_folder(cluster_config):


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Add a test for log rotation.
- Refactor the previous test.

Tested in Jenkins by running the 2 tests together
