### PR TITLE
Adjust the configure audit test and refactor the tests

### DIFF
--- a/testsuites/syncgateway/functional/tests/test_audit_logging.py
+++ b/testsuites/syncgateway/functional/tests/test_audit_logging.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import time
 import pytest
-import random
+import uuid
 
 from keywords.ClusterKeywords import ClusterKeywords
 from keywords.remoteexecutor import RemoteExecutor
@@ -16,11 +16,16 @@ from keywords.exceptions import CollectionError
 from libraries.provision.ansible_runner import AnsibleRunner
 from utilities.scan_logs import scan_for_pattern
 
+EXPECTED_IN_LOGS = True
+NOT_EXPECTED_IN_THE_LOGS = False
 
 sg_db = "db"
 username = 'audit-logging-user'
 password = 'password'
 is_audit_logging_set = False
+channels = ["audit_logging"]
+auth = None
+random_suffix = str(uuid.uuid4())[:8]
 
 
 @pytest.fixture
@@ -30,6 +35,8 @@ def audit_logging_fixture(params_from_base_test_setup):
     global password
     global sg_db
     global is_audit_logging_set
+    global channels
+    global auth
 
     cluster_config = params_from_base_test_setup["cluster_config"]
     cluster_config = params_from_base_test_setup["cluster_config"]
@@ -41,7 +48,6 @@ def audit_logging_fixture(params_from_base_test_setup):
     admin_client = Admin(cluster.sync_gateways[0])
     sg_url = cluster_hosts["sync_gateways"][0]["public"]
     sg_client = MobileRestClient()
-    channels = ["audit_logging"]
     auth = need_sgw_admin_auth and (RBAC_FULL_ADMIN['user'], RBAC_FULL_ADMIN['pwd']) or None
     db_config = {"bucket": "data-bucket", "num_index_replicas": 0}
     sync_gateway_version = params_from_base_test_setup["sync_gateway_version"]
@@ -66,51 +72,58 @@ def audit_logging_fixture(params_from_base_test_setup):
     remote_executor.execute("rm -rf /home/sync_gateway/logs/audit_log*")
 
 
-def test_configure_audit_logging(params_from_base_test_setup, audit_logging_fixture):
+def test_default_audit_settings(params_from_base_test_setup, audit_logging_fixture):
     '''
     @summary:
-    1. Enable audit logging by resetting the cluster
-    2. Randomly configure the tested events, to be recorded or not recorded
-    3. Trigger the tested events
-    4. Check that the events are are recorded/not recorded in the audit_log file
+    This test checks a selected number of events and checks that they are logged.
+    The events values cannot be changed
+    1. Trigger the tested events
+    2. Check that the events are are recorded/not recorded in the audit_log file
     '''
     cluster_config = params_from_base_test_setup["cluster_config"]
     sg_client, admin_client, sg_url, sg_admin_url = audit_logging_fixture
+    event_user = "user" + random_suffix
+    event_role = "role" + random_suffix
+    tested_ids = {"53281": EXPECTED_IN_LOGS,  # public API User authetication failed
+                  "53280": EXPECTED_IN_LOGS,  # public API User authetication
+                  "54100": EXPECTED_IN_LOGS,  # Create user
+                  "54101": EXPECTED_IN_LOGS,  # Read user
+                  "54102": EXPECTED_IN_LOGS,  # Update user
+                  "54103": EXPECTED_IN_LOGS,  # Delete user
+                  "54110": EXPECTED_IN_LOGS,  # Create role
+                  "54111": EXPECTED_IN_LOGS,  # Read role
+                  "54112": EXPECTED_IN_LOGS  # Update role
+                  }
 
-    # 2. Randomly configure the tested events, to be recorded or not recorded.
-    tested_ids = {"53281": bool(random.randint(0, 1)), "53280": bool(random.randint(0, 1))}
-    audit_config = {"enabled": True, "events": tested_ids}
-    admin_client.replace_audit_config(sg_db, audit_config)
+    # 1. Trigger the tested events
+    trigger_event_53281(sg_client=sg_client, sg_url=sg_url)
+    trigger_event_53280(sg_client=sg_client, sg_url=sg_url, auth=(username, password))
+    trigger_event_54100(sg_client=sg_client, sg_admin_url=sg_admin_url, user=event_user)
+    trigger_event_54101(sg_client=sg_client, sg_admin_url=sg_admin_url, user=event_user)
+    trigger_event_54102(sg_client=sg_client, sg_admin_url=sg_admin_url, user=event_user)
+    trigger_event_54103(sg_client=sg_client, sg_admin_url=sg_admin_url, user=event_user)
+    trigger_event_54110(sg_client=sg_client, sg_admin_url=sg_admin_url, role=event_role)
+    trigger_event_54111(sg_client=sg_client, sg_admin_url=sg_admin_url, role=event_role)
+    trigger_event_54112(sg_client=sg_client, sg_admin_url=sg_admin_url, role=event_role)
 
-    # 3. Trigger the tested events
-    # Triggering event 53281: public API User authetication failed
-    try:
-        sg_client.get_all_docs(url=sg_url, db=sg_db, auth=("fake_user", "fake_password"))
-    except (Exception):
-        pass
-    # Triggering event 53280: public API User authetication
-    sg_client.get_all_docs(url=sg_url, db=sg_db, auth=(username, password))
-    # End of triggered events
-
-    # 4. Check that the events are are recorded/not recorded in the audit_log file
+    # 2. Check that the events are are recorded/not recorded in the audit_log file
     audit_log_folder = get_audit_log_folder(cluster_config)
     for id in tested_ids.keys():
         pattern = ["\"id\":" + id]
-        if tested_ids[id] is True:  # we are expecting the id in the log
+        if tested_ids[id] is EXPECTED_IN_LOGS:  # we are expecting the id in the log
             print("*** Expecting event " + str(id) + " to be in the logs")
             scan_for_pattern(audit_log_folder + "/sg_audit.log", pattern)
         else:  # we are NOT expecting the id in the log
             with pytest.raises(Exception):
-                print("*** Checking if even id " + str(id) + " is in the audit log - not expecting it")
+                print("*** Checking if event id " + str(id) + " is in the audit log - not expecting it")
                 scan_for_pattern(audit_log_folder + "/sg_audit.log", pattern)
 
 
 def test_audit_log_rotation(params_from_base_test_setup, audit_logging_fixture):
     '''
     @summary:
-    1. Enable event 53280 - public API authetication
-    2. Triggering event 53280 multiple times to increaes the audit log size to more than 1MB
-    3. Looking at the content of the logs directory and expecting it to contain an archive
+    1. Triggering event 53280 multiple times to increaes the audit log size to more than 1MB
+    2. Looking at the content of the logs directory and expecting it to contain an archive
     '''
     sg_client, admin_client, sg_url, sg_admin_url = audit_logging_fixture
     cluster_config = params_from_base_test_setup["cluster_config"]
@@ -118,13 +131,13 @@ def test_audit_log_rotation(params_from_base_test_setup, audit_logging_fixture):
     remote_executor = RemoteExecutor(cluster.sync_gateways[0].ip)
 
     # 1. Enable event 53280 - public API authetication
-    audit_config = {"enabled": True, "events": {"53280": True}}
-    admin_client.update_audit_config(sg_db, audit_config)
+    # audit_config = {"enabled": True, "events": {"53280": True}}
+    # admin_client.update_audit_config(sg_db, audit_config)
 
-    # 2. Triggering event 53280 multiple times to increaes the audit log size to more than 1MB
+    # 1. Triggering event 53280 multiple times to increaes the audit log size to more than 1MB
     for i in range(0, 6500):
-        sg_client.get_all_docs(url=sg_url, db=sg_db, auth=(username, password))
-    # 3. Looking at the content of the logs directory and expecting it to contain an archive
+        trigger_event_53280(sg_client=sg_client, sg_url=sg_url, auth=(username, password))
+    # 2. Looking at the content of the logs directory and expecting it to contain an archive
     _, stdout, _ = remote_executor.execute("ls /home/sync_gateway/logs | grep sg_audit.*.gz")
     if len(stdout) > 0:
         assert ".log.gz" in stdout[0], "The archive for the rotation was not found even though it was expected"
@@ -147,3 +160,46 @@ def get_audit_log_folder(cluster_config):
         temp_log_path = "/tmp/{}-{}-sglogs".format("audit-logging", date_time)
         shutil.copytree("/tmp/sg_logs", temp_log_path)
         return "{}/sg1".format(temp_log_path)
+
+
+def trigger_event_53281(sg_client, sg_url):
+    try:
+        sg_client.get_all_docs(url=sg_url, db=sg_db, auth=("fake_user", "fake_password"))
+    except (Exception):
+        pass
+
+
+def trigger_event_53280(sg_client, sg_url, auth):
+    sg_client.get_all_docs(url=sg_url, db=sg_db, auth=auth)
+
+
+def trigger_event_54100(sg_client, sg_admin_url, user):
+    sg_client.create_user(url=sg_admin_url, db=sg_db, name=user, password=password, channels=channels, auth=auth)
+
+
+def trigger_event_54101(sg_client, sg_admin_url, user):
+    sg_client.get_user(url=sg_admin_url, db=sg_db, name=user, auth=auth)
+
+
+def trigger_event_54102(sg_client, sg_admin_url, user):
+    sg_client.update_user(url=sg_admin_url, db=sg_db, name=user, password="password1", auth=auth)
+
+
+def trigger_event_54103(sg_client, sg_admin_url, user):
+    sg_client.delete_user(url=sg_admin_url, db=sg_db, name=user, auth=auth)
+
+
+def trigger_event_54110(sg_client, sg_admin_url, role):
+    sg_client.create_role(url=sg_admin_url, db=sg_db, name=role)
+
+
+def trigger_event_54111(sg_client, sg_admin_url, role):
+    sg_client.get_role(url=sg_admin_url, db=sg_db, name=role)
+
+
+def trigger_event_54112(sg_client, sg_admin_url, role):
+    sg_client.update_role(url=sg_admin_url, db=sg_db, name=role)
+
+
+def trigger_event_53282(sg_client, sg_admin_url):
+    sg_client.create_session(url=sg_admin_url, db=sg_db, name=username, auth=auth)

--- a/testsuites/syncgateway/functional/tests/test_audit_logging.py
+++ b/testsuites/syncgateway/functional/tests/test_audit_logging.py
@@ -130,10 +130,6 @@ def test_audit_log_rotation(params_from_base_test_setup, audit_logging_fixture):
     cluster = Cluster(config=cluster_config)
     remote_executor = RemoteExecutor(cluster.sync_gateways[0].ip)
 
-    # 1. Enable event 53280 - public API authetication
-    # audit_config = {"enabled": True, "events": {"53280": True}}
-    # admin_client.update_audit_config(sg_db, audit_config)
-
     # 1. Triggering event 53280 multiple times to increaes the audit log size to more than 1MB
     for i in range(0, 6500):
         trigger_event_53280(sg_client=sg_client, sg_url=sg_url, auth=(username, password))


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Adjust the configure test because it was updating events that are not allowed to be configured in the most recent 3.2.0 build
- Refactor the tests, for readability
- Tested in Jenkins

