### PR TITLE
Downgrade the setuptools to 68

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -48,4 +48,4 @@ export ANSIBLE_CONFIG=$currentdir/ansible.cfg
 pip install --upgrade pip==20.1.1
 pip install couchbase==3.2.7
 pip install importlib-metadata==4.3.0
-pip install setuptools==70.3.0
+pip install setuptools==68.0.0


### PR DESCRIPTION
#### Fixes #.

- [x] Ran `flake8`
- [x] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- Some slave have an older Python version which doesn't support version 70.
-  Tested with the jobs that originally failed. well as the jobs because of which the setuptools dependency was added in the first place.
