### PR TITLE
Update server package to use linux_amd64 instead of debian10_amd64

### DIFF
--- a/keywords/couchbaseserver.py
+++ b/keywords/couchbaseserver.py
@@ -922,7 +922,7 @@ class CouchbaseServer:
             elif version.startswith("3.1"):
                 return "couchbase-server-{}_{}_x86_64_{}-{}-rel.deb".format(edition, cbs_platform, version, build_number)
             else:
-                return "couchbase-server-{}_{}-{}-{}10_amd64.deb".format(edition, version, build_number, cbs_platform)
+                return "couchbase-server-{}_{}-{}-linux_amd64.deb".format(edition, version, build_number)
         elif "centos" in cbs_platform:
             if version.startswith("3.1.6"):
                 return "couchbase-server-{}-{}-{}.x86_64.rpm".format(edition, version, cbs_platform)


### PR DESCRIPTION
#### Fixes #.

- [ ] Ran `flake8`
- [ ] Ran `run_repo_tests.sh`

#### Changes proposed in this pull request:

- 
-

